### PR TITLE
Default permissions config

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -198,6 +198,7 @@ class AdminsController < ApplicationController
     Seek::Config.recaptcha_enabled = string_to_boolean params[:recaptcha_enabled]
     Seek::Config.recaptcha_private_key = params[:recaptcha_private_key]
     Seek::Config.recaptcha_public_key = params[:recaptcha_public_key]
+    Seek::Config.default_consortium_access_type = params[:default_consortium_access_type]
     update_flag = (pubmed_email == '' || pubmed_email_valid) && (crossref_email == '' || (crossref_email_valid)) && (only_integer tag_threshold, 'tag threshold') && (only_positive_integer max_visible_tags, 'maximum visible tags')
     update_redirect_to update_flag, 'others'
   end

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -198,7 +198,9 @@ class AdminsController < ApplicationController
     Seek::Config.recaptcha_enabled = string_to_boolean params[:recaptcha_enabled]
     Seek::Config.recaptcha_private_key = params[:recaptcha_private_key]
     Seek::Config.recaptcha_public_key = params[:recaptcha_public_key]
+    Seek::Config.default_associated_projects_access_type = params[:default_associated_projects_access_type]
     Seek::Config.default_consortium_access_type = params[:default_consortium_access_type]
+    Seek::Config.default_all_visitors_access_type = params[:default_all_visitors_access_type]
     update_flag = (pubmed_email == '' || pubmed_email_valid) && (crossref_email == '' || (crossref_email_valid)) && (only_integer tag_threshold, 'tag threshold') && (only_positive_integer max_visible_tags, 'maximum visible tags')
     update_redirect_to update_flag, 'others'
   end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -92,6 +92,14 @@ module AdminHelper
     end
   end
 
+  def admin_dropdown_setting(name, option_tags, title, description = nil, options = {})
+    admin_setting_block(title, description) do
+      #   select_tag "people", "<option>David</option>".html_safe
+      #   # => <select id="people" name="people"><option>David</option></select>
+      select_tag(name, option_tags, options)
+    end
+  end
+
   private
 
   def admin_setting_block(title, description)

--- a/app/helpers/policy_helper.rb
+++ b/app/helpers/policy_helper.rb
@@ -2,11 +2,14 @@ module PolicyHelper
   
   def policy_selection_options policies = nil, resource = nil, access_type = nil
     policies ||= [Policy::NO_ACCESS,Policy::VISIBLE,Policy::ACCESSIBLE,Policy::EDITING,Policy::MANAGING]
-    #TODO handle access_type = ACCESSIBLE, and !resource.is_downloadable?
-    #TODO  Seek::Config.default :default_projects_access_type = @resource.is_asset? ? Policy::ACCESSIBLE : Policy::EDITING
-    # In that case set access_type to VISIBLE
-    #  if !access_type.try(:)
-    policies.delete(Policy::ACCESSIBLE) unless resource.try(:is_downloadable?)
+    unless resource.try(:is_downloadable?)
+      policies.delete(Policy::ACCESSIBLE)
+      if access_type == Policy::ACCESSIBLE
+        #handle access_type = ACCESSIBLE, and !resource.is_downloadable?
+        # In that case set access_type to VISIBLE
+        access_type = Policy::VISIBLE
+      end
+    end
     options=""
     policies.each do |policy|
       options << "<option value='#{policy}' #{"selected='selected'" if access_type == policy}>#{Policy.get_access_type_wording(policy, resource.try(:is_downloadable?))} </option>"

--- a/app/helpers/policy_helper.rb
+++ b/app/helpers/policy_helper.rb
@@ -2,6 +2,10 @@ module PolicyHelper
   
   def policy_selection_options policies = nil, resource = nil, access_type = nil
     policies ||= [Policy::NO_ACCESS,Policy::VISIBLE,Policy::ACCESSIBLE,Policy::EDITING,Policy::MANAGING]
+    #TODO handle access_type = ACCESSIBLE, and !resource.is_downloadable?
+    #TODO  Seek::Config.default :default_projects_access_type = @resource.is_asset? ? Policy::ACCESSIBLE : Policy::EDITING
+    # In that case set access_type to VISIBLE
+    #  if !access_type.try(:)
     policies.delete(Policy::ACCESSIBLE) unless resource.try(:is_downloadable?)
     options=""
     policies.each do |policy|

--- a/app/views/admins/others.html.erb
+++ b/app/views/admins/others.html.erb
@@ -28,6 +28,11 @@
                                'Captcha enabled', 'Enable to show a captcha on forms susceptible to spam',
                                :onchange=>toggle_appear_javascript('captcha_key_settings')) %>
 
+    <%= access_type_options = [Policy::NO_ACCESS, Policy::VISIBLE, Policy::EDITING]
+        option_tags = policy_selection_options(access_type_options, nil, Seek::Config.default_consortium_access_type)
+        admin_dropdown_setting(:default_consortium_access_type, option_tags, 'Consortium default',
+                               description = 'Default permissions option for all registered users', options = {}) %>
+
     <div id="captcha_key_settings" class="additional_settings" style="<%= show_or_hide_block(Seek::Config.recaptcha_enabled) %>">
       <p>
         You can request a private and public key for Recaptcha by visiting

--- a/app/views/admins/others.html.erb
+++ b/app/views/admins/others.html.erb
@@ -28,8 +28,9 @@
                                'Captcha enabled', 'Enable to show a captcha on forms susceptible to spam',
                                :onchange=>toggle_appear_javascript('captcha_key_settings')) %>
 
-    <%= access_type_options = [Policy::NO_ACCESS, Policy::VISIBLE, Policy::EDITING]
-        option_tags = policy_selection_options(access_type_options, nil, Seek::Config.default_consortium_access_type)
+    <%= access_type_options = [Policy::NO_ACCESS, Policy::VISIBLE, Policy::ACCESSIBLE, Policy::EDITING]
+        # Passing in a data file so that is_downloadable is true, and the ACCESSIBLE option will be kept.
+        option_tags = policy_selection_options(access_type_options, DataFile.new, Seek::Config.default_consortium_access_type)
         admin_dropdown_setting(:default_consortium_access_type, option_tags, 'Consortium default',
                                description = 'Default permissions option for all registered users', options = {}) %>
 

--- a/app/views/admins/others.html.erb
+++ b/app/views/admins/others.html.erb
@@ -24,27 +24,27 @@
     <%= admin_text_setting(:sabiork_ws_base_url, Seek::Config.sabiork_ws_base_url,
                            'SabioRK WS base URL', 'This base URL for sabiork webservices REST API') %>
 
-    <%= admin_checkbox_setting(:recaptcha_enabled, 1, Seek::Config.recaptcha_enabled,
-                               'Captcha enabled', 'Enable to show a captcha on forms susceptible to spam',
-                               :onchange=>toggle_appear_javascript('captcha_key_settings')) %>
-
     <%= access_type_options = [Policy::VISIBLE, Policy::ACCESSIBLE, Policy::EDITING, Policy::MANAGING]
         # Passing in a data file so that is_downloadable is true, and the ACCESSIBLE option will be kept.
         option_tags = policy_selection_options(access_type_options, DataFile.new, Seek::Config.default_associated_projects_access_type)
-        admin_dropdown_setting(:default_associated_projects_access_type, option_tags, 'Associated projects default',
+        admin_dropdown_setting(:default_associated_projects_access_type, option_tags, 'Settings For Default Permissions',
                                description = 'Default permissions option for members of associated projects', options = {}) %>
 
     <%= access_type_options = [Policy::NO_ACCESS, Policy::VISIBLE, Policy::ACCESSIBLE, Policy::EDITING]
         # Passing in a data file so that is_downloadable is true, and the ACCESSIBLE option will be kept.
         option_tags = policy_selection_options(access_type_options, DataFile.new, Seek::Config.default_consortium_access_type)
-        admin_dropdown_setting(:default_consortium_access_type, option_tags, 'Consortium default',
+        admin_dropdown_setting(:default_consortium_access_type, option_tags, nil,
                                description = 'Default permissions option for all registered users', options = {}) %>
 
     <%= access_type_options = [Policy::VISIBLE, Policy::ACCESSIBLE]
         # Passing in a data file so that is_downloadable is true, and the ACCESSIBLE option will be kept.
         option_tags = policy_selection_options(access_type_options, DataFile.new, Seek::Config.default_all_visitors_access_type)
-        admin_dropdown_setting(:default_all_visitors_access_type, option_tags, 'All visitors default',
+        admin_dropdown_setting(:default_all_visitors_access_type, option_tags, nil,
                                description = 'Default permissions option for all visitors', options = {}) %>
+
+    <%= admin_checkbox_setting(:recaptcha_enabled, 1, Seek::Config.recaptcha_enabled,
+                               'Captcha enabled', 'Enable to show a captcha on forms susceptible to spam',
+                               :onchange=>toggle_appear_javascript('captcha_key_settings')) %>
 
     <div id="captcha_key_settings" class="additional_settings" style="<%= show_or_hide_block(Seek::Config.recaptcha_enabled) %>">
       <p>

--- a/app/views/admins/others.html.erb
+++ b/app/views/admins/others.html.erb
@@ -28,11 +28,23 @@
                                'Captcha enabled', 'Enable to show a captcha on forms susceptible to spam',
                                :onchange=>toggle_appear_javascript('captcha_key_settings')) %>
 
+    <%= access_type_options = [Policy::VISIBLE, Policy::ACCESSIBLE, Policy::EDITING, Policy::MANAGING]
+        # Passing in a data file so that is_downloadable is true, and the ACCESSIBLE option will be kept.
+        option_tags = policy_selection_options(access_type_options, DataFile.new, Seek::Config.default_associated_projects_access_type)
+        admin_dropdown_setting(:default_associated_projects_access_type, option_tags, 'Associated projects default',
+                               description = 'Default permissions option for members of associated projects', options = {}) %>
+
     <%= access_type_options = [Policy::NO_ACCESS, Policy::VISIBLE, Policy::ACCESSIBLE, Policy::EDITING]
         # Passing in a data file so that is_downloadable is true, and the ACCESSIBLE option will be kept.
         option_tags = policy_selection_options(access_type_options, DataFile.new, Seek::Config.default_consortium_access_type)
         admin_dropdown_setting(:default_consortium_access_type, option_tags, 'Consortium default',
                                description = 'Default permissions option for all registered users', options = {}) %>
+
+    <%= access_type_options = [Policy::VISIBLE, Policy::ACCESSIBLE]
+        # Passing in a data file so that is_downloadable is true, and the ACCESSIBLE option will be kept.
+        option_tags = policy_selection_options(access_type_options, DataFile.new, Seek::Config.default_all_visitors_access_type)
+        admin_dropdown_setting(:default_all_visitors_access_type, option_tags, 'All visitors default',
+                               description = 'Default permissions option for all visitors', options = {}) %>
 
     <div id="captcha_key_settings" class="additional_settings" style="<%= show_or_hide_block(Seek::Config.recaptcha_enabled) %>">
       <p>

--- a/app/views/assets/_sharing_form.html.erb
+++ b/app/views/assets/_sharing_form.html.erb
@@ -4,7 +4,7 @@
    disable_advanced_view ||= nil
    show_advanced_permissions = !@resource.respond_to?(:has_advanced_permissions?) || @resource.has_advanced_permissions?
    default_projects_access_type = @resource.is_asset? ? Policy::ACCESSIBLE : Policy::EDITING
-   default_consortium_access_type = Policy::VISIBLE
+   default_consortium_access_type = Seek::Config.default_consortium_access_type
    can_publish = @resource.respond_to?(:can_publish?) ? @resource.can_publish? : true
 %>
 <%# initialization: required to keep javascript independent of the access type codes, to allow the use the constants instead -%>
@@ -99,8 +99,12 @@
              </select>
              <br/>
             <span style="margin-left:10em;">... and all other registered users:</span>
-             <%= render :partial => "assets/sharing_form_access_type_dropdown", :locals => { :access_type_selector_for_scope => Policy::ALL_USERS,
-               :sharing_scope => Policy::ALL_USERS, :access_type => (@resource.respond_to?(:policy) && @resource.policy.try(:sharing_scope)==Policy::ALL_USERS ? @access_mode : default_consortium_access_type), :access_type_options=>[Policy::NO_ACCESS,Policy::VISIBLE,Policy::ACCESSIBLE,Policy::EDITING] } -%>
+          <%=
+              render :partial => "assets/sharing_form_access_type_dropdown",
+                     :locals => {:access_type_selector_for_scope => Policy::ALL_USERS,
+                                 :sharing_scope => Policy::ALL_USERS,
+                                 :access_type => (@resource.respond_to?(:policy) && @resource.policy.try(:sharing_scope)==Policy::ALL_USERS ? @access_mode : default_consortium_access_type),
+                                 :access_type_options => [Policy::NO_ACCESS, Policy::VISIBLE, Policy::ACCESSIBLE, Policy::EDITING]} -%>
              <%= additional_advanced_permissions_included @resource, Policy::ALL_USERS -%>
         </p>
 
@@ -111,8 +115,11 @@
                    value="<%= Policy::EVERYONE -%>"/>
             - All visitors (including anonymous visitors with no login):
           </label>
-           <%= render :partial => "assets/sharing_form_access_type_dropdown", :locals => { :access_type_selector_for_scope => Policy::EVERYONE,
-            :sharing_scope => @sharing_mode, :access_type => @access_mode, :default_access_type=>Policy::ACCESSIBLE } -%>
+          <%= render :partial => "assets/sharing_form_access_type_dropdown",
+                     :locals => {:access_type_selector_for_scope => Policy::EVERYONE,
+                                 :sharing_scope => @sharing_mode,
+                                 :access_type => @access_mode,
+                                 :default_access_type => Policy::ACCESSIBLE} -%>
            <%= additional_advanced_permissions_included @resource, Policy::EVERYONE -%>
           <br/>
         </p>

--- a/app/views/assets/_sharing_form.html.erb
+++ b/app/views/assets/_sharing_form.html.erb
@@ -3,8 +3,9 @@
    set_parameters_for_sharing_form object
    disable_advanced_view ||= nil
    show_advanced_permissions = !@resource.respond_to?(:has_advanced_permissions?) || @resource.has_advanced_permissions?
-   default_projects_access_type = @resource.is_asset? ? Policy::ACCESSIBLE : Policy::EDITING
+   default_projects_access_type = Seek::Config.default_associated_projects_access_type
    default_consortium_access_type = Seek::Config.default_consortium_access_type
+   default_all_visitors_access_type = Seek::Config.default_all_visitors_access_type
    can_publish = @resource.respond_to?(:can_publish?) ? @resource.can_publish? : true
 %>
 <%# initialization: required to keep javascript independent of the access type codes, to allow the use the constants instead -%>
@@ -119,7 +120,7 @@
                      :locals => {:access_type_selector_for_scope => Policy::EVERYONE,
                                  :sharing_scope => @sharing_mode,
                                  :access_type => @access_mode,
-                                 :default_access_type => Policy::ACCESSIBLE} -%>
+                                 :default_access_type => default_all_visitors_access_type} -%>
            <%= additional_advanced_permissions_included @resource, Policy::EVERYONE -%>
           <br/>
         </p>

--- a/config/initializers/seek_configuration.rb-biovel
+++ b/config/initializers/seek_configuration.rb-biovel
@@ -127,7 +127,9 @@ SEEK::Application.configure do
   Seek::Config.default :seek_video_link, "http://www.youtube.com/user/elinawetschHITS?feature=mhee#p/u"
 
   # Set default permissions
+  Seek::Config.default :default_associated_projects_access_type, Policy::ACCESSIBLE
   Seek::Config.default :default_consortium_access_type, Policy::VISIBLE
+  Seek::Config.default :default_all_visitors_access_type, Policy::ACCESSIBLE
 
   Seek::Config.fixed :css_prepended,''
   Seek::Config.fixed :css_appended,'biovel_application'

--- a/config/initializers/seek_configuration.rb-biovel
+++ b/config/initializers/seek_configuration.rb-biovel
@@ -125,7 +125,10 @@ SEEK::Application.configure do
   Seek::Config.default :recaptcha_enabled, true
 
   Seek::Config.default :seek_video_link, "http://www.youtube.com/user/elinawetschHITS?feature=mhee#p/u"
-  
+
+  # Set default permissions
+  Seek::Config.default :default_consortium_access_type, Policy::VISIBLE
+
   Seek::Config.fixed :css_prepended,''
   Seek::Config.fixed :css_appended,'biovel_application'
   Seek::Config.fixed :javascript_prepended,''

--- a/config/initializers/seek_configuration.rb-openseek
+++ b/config/initializers/seek_configuration.rb-openseek
@@ -152,7 +152,9 @@ SEEK::Application.configure do
   Seek::Config.default :seek_video_link, "http://www.youtube.com/user/elinawetschHITS?feature=mhee#p/u"
 
   # Set default permissions
+  Seek::Config.default :default_associated_projects_access_type, Policy::ACCESSIBLE
   Seek::Config.default :default_consortium_access_type, Policy::VISIBLE
+  Seek::Config.default :default_all_visitors_access_type, Policy::ACCESSIBLE
 
   Seek::Config.fixed :css_prepended,''
   Seek::Config.fixed :css_appended,''

--- a/config/initializers/seek_configuration.rb-openseek
+++ b/config/initializers/seek_configuration.rb-openseek
@@ -151,9 +151,11 @@ SEEK::Application.configure do
   #MERGENOTE - remove this from config and replace with alternative partial
   Seek::Config.default :seek_video_link, "http://www.youtube.com/user/elinawetschHITS?feature=mhee#p/u"
 
+  # Set default permissions
+  Seek::Config.default :default_consortium_access_type, Policy::VISIBLE
+
   Seek::Config.fixed :css_prepended,''
   Seek::Config.fixed :css_appended,''
   Seek::Config.fixed :main_layout,'application'
-
 end
 

--- a/config/initializers/seek_configuration.rb-vln
+++ b/config/initializers/seek_configuration.rb-vln
@@ -139,7 +139,9 @@ SEEK::Application.configure do
   Seek::Config.default :seek_video_link, "http://www.youtube.com/user/elinawetschHITS?feature=mhee#p/u"
 
   # Set default permissions
+  Seek::Config.default :default_associated_projects_access_type, Policy::ACCESSIBLE
   Seek::Config.default :default_consortium_access_type, Policy::VISIBLE
+  Seek::Config.default :default_all_visitors_access_type, Policy::ACCESSIBLE
 
   Seek::Config.fixed :css_prepended,''
   Seek::Config.fixed :css_appended,''

--- a/config/initializers/seek_configuration.rb-vln
+++ b/config/initializers/seek_configuration.rb-vln
@@ -138,6 +138,9 @@ SEEK::Application.configure do
 
   Seek::Config.default :seek_video_link, "http://www.youtube.com/user/elinawetschHITS?feature=mhee#p/u"
 
+  # Set default permissions
+  Seek::Config.default :default_consortium_access_type, Policy::VISIBLE
+
   Seek::Config.fixed :css_prepended,''
   Seek::Config.fixed :css_appended,''
   Seek::Config.fixed :main_layout,'application'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -359,7 +359,7 @@ ActiveRecord::Schema.define(:version => 20150728133757) do
   add_index "data_files_projects", ["project_id"], :name => "index_data_files_projects_on_project_id"
 
   create_table "db_files", :force => true do |t|
-    t.binary "data"
+    t.binary "data", :limit => 2147483647
   end
 
   create_table "delayed_jobs", :force => true do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -359,7 +359,7 @@ ActiveRecord::Schema.define(:version => 20150728133757) do
   add_index "data_files_projects", ["project_id"], :name => "index_data_files_projects_on_project_id"
 
   create_table "db_files", :force => true do |t|
-    t.binary "data", :limit => 2147483647
+    t.binary "data"
   end
 
   create_table "delayed_jobs", :force => true do |t|

--- a/lib/seek/config.rb
+++ b/lib/seek/config.rb
@@ -355,6 +355,7 @@ module Seek
 
 
     # Settings that require a conversion to integer
+    # These are defined here instead of in config_setting_attributes.yml
     setting :tag_threshold, convert: 'to_i'
     setting :limit_latest, convert: 'to_i'
     setting :max_visible_tags, convert: 'to_i'
@@ -363,6 +364,7 @@ module Seek
     setting :community_news_number_of_entries, convert: 'to_i'
     setting :home_feeds_cache_timeout, convert: 'to_i'
     setting :time_lock_doi_for, convert: 'to_ig'
+    setting :default_consortium_access_type, convert: 'to_i'
 
     read_setting_attributes.each do |sym|
       setting sym

--- a/lib/seek/config.rb
+++ b/lib/seek/config.rb
@@ -364,7 +364,10 @@ module Seek
     setting :community_news_number_of_entries, convert: 'to_i'
     setting :home_feeds_cache_timeout, convert: 'to_i'
     setting :time_lock_doi_for, convert: 'to_ig'
+    setting :default_associated_projects_access_type, convert: 'to_i'
     setting :default_consortium_access_type, convert: 'to_i'
+    setting :default_all_visitors_access_type, convert: 'to_i'
+    setting :default_project_members_access_type, convert: 'to_i'
 
     read_setting_attributes.each do |sym|
       setting sym

--- a/lib/seek/config_setting_attributes.yml
+++ b/lib/seek/config_setting_attributes.yml
@@ -1,5 +1,8 @@
-#keys that create the Seek::Config settigs.
+#keys that create the Seek::Config settings.
 #e.g. Seek::Config.home_description
+
+# N.B. Settings that require a conversion to integer should NOT be set here.
+# They should be set in config.rb, in the Config class.
 home_description:
 home_feeds_cache_timeout:
 events_enabled:

--- a/test/functional/admins_controller_test.rb
+++ b/test/functional/admins_controller_test.rb
@@ -97,6 +97,14 @@ class AdminsControllerTest < ActionController::TestCase
     assert_equal 9,Seek::Config.max_visible_tags
   end
 
+  test 'update default consortium permissions' do
+    login_as(:quentin)
+    Seek::Config.default_consortium_access_type=0
+    assert_equal 0, Seek::Config.default_consortium_access_type
+    post :update_others, :default_consortium_access_type => '2'
+    assert_equal 2, Seek::Config.default_consortium_access_type
+  end
+
   test 'invalid email address' do
     login_as(:quentin)
     post :update_others, :pubmed_api_email => 'quentin', :crossref_api_email => 'quentin@example.com', :tag_threshold => '1', :max_visible_tags => '20'

--- a/test/functional/admins_controller_test.rb
+++ b/test/functional/admins_controller_test.rb
@@ -97,12 +97,28 @@ class AdminsControllerTest < ActionController::TestCase
     assert_equal 9,Seek::Config.max_visible_tags
   end
 
+  test 'update default default_associated_projects_access_type permissions' do
+    login_as(:quentin)
+    Seek::Config.default_associated_projects_access_type=0
+    assert_equal 0, Seek::Config.default_associated_projects_access_type
+    post :update_others, :default_associated_projects_access_type => '2'
+    assert_equal 2, Seek::Config.default_associated_projects_access_type
+  end
+
   test 'update default consortium permissions' do
     login_as(:quentin)
     Seek::Config.default_consortium_access_type=0
     assert_equal 0, Seek::Config.default_consortium_access_type
     post :update_others, :default_consortium_access_type => '2'
     assert_equal 2, Seek::Config.default_consortium_access_type
+  end
+
+  test 'update default default_all_visitors_access_type permissions' do
+    login_as(:quentin)
+    Seek::Config.default_all_visitors_access_type=0
+    assert_equal 0, Seek::Config.default_all_visitors_access_type
+    post :update_others, :default_all_visitors_access_type => '2'
+    assert_equal 2, Seek::Config.default_all_visitors_access_type
   end
 
   test 'invalid email address' do

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -143,6 +143,16 @@ class ConfigTest < ActiveSupport::TestCase
     assert_equal 5, Seek::Config.tag_threshold
   end
 
+  test 'tag as integer' do
+    Seek::Config.tag_threshold = 6
+    assert_equal 6, Seek::Config.tag_threshold
+  end
+
+  test 'changing default_consortium_access_type integer conversion' do
+    Seek::Config.default_consortium_access_type = '0'
+    assert_equal 0, Seek::Config.default_consortium_access_type
+  end
+
   test 'smtp_settings authentication' do
     assert_equal :plain, Seek::Config.smtp_settings('authentication')
   end
@@ -287,6 +297,16 @@ end
   test 'convert setting from database' do
     Settings.limit_latest = '6'
     assert_equal 6, Seek::Config.limit_latest
+  end
+
+  test 'default consortium access permission is visible' do
+    assert_equal Policy::VISIBLE, Seek::Config.default_consortium_access_type
+  end
+
+  test 'changing default_consortium_access_type' do
+    Seek::Config.default_consortium_access_type = Policy::NO_ACCESS
+    assert_equal Policy::NO_ACCESS, Seek::Config.default_consortium_access_type
+    assert_equal Policy::NO_ACCESS.class, Seek::Config.default_consortium_access_type.class
   end
 
   test 'invalid setting accessor' do

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -148,9 +148,19 @@ class ConfigTest < ActiveSupport::TestCase
     assert_equal 6, Seek::Config.tag_threshold
   end
 
+  test 'changing default_associated_projects_access_type integer conversion' do
+    Seek::Config.default_associated_projects_access_type = '0'
+    assert_equal 0, Seek::Config.default_associated_projects_access_type
+  end
+
   test 'changing default_consortium_access_type integer conversion' do
     Seek::Config.default_consortium_access_type = '0'
     assert_equal 0, Seek::Config.default_consortium_access_type
+  end
+
+  test 'changing default_all_visitors_access_type integer conversion' do
+    Seek::Config.default_all_visitors_access_type = '0'
+    assert_equal 0, Seek::Config.default_all_visitors_access_type
   end
 
   test 'smtp_settings authentication' do
@@ -299,8 +309,16 @@ end
     assert_equal 6, Seek::Config.limit_latest
   end
 
+  test 'default associated projects access permission is accessible' do
+    assert_equal Policy::ACCESSIBLE, Seek::Config.default_associated_projects_access_type
+  end
+
   test 'default consortium access permission is visible' do
     assert_equal Policy::VISIBLE, Seek::Config.default_consortium_access_type
+  end
+
+  test 'default all visitors access permission is accessible' do
+    assert_equal Policy::ACCESSIBLE, Seek::Config.default_all_visitors_access_type
   end
 
   test 'changing default_consortium_access_type' do

--- a/test/unit/helpers/policy_helper_test.rb
+++ b/test/unit/helpers/policy_helper_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+
+class PolicyHelperTest < ActionView::TestCase
+
+  test "policy selection options accessible removed if not downloadable" do
+    policies = [Policy::NO_ACCESS, Policy::VISIBLE, Policy::ACCESSIBLE, Policy::EDITING]
+    resource = nil # not downloadable
+    selected_access_type = Policy::NO_ACCESS
+    actual_options = policy_selection_options policies, resource, selected_access_type
+
+    expected_options = "<option value='0' selected='selected'>No access </option><option value='1' >View summary </option><option value='3' >View and edit summary </option>"
+
+    assert_equal expected_options, actual_options
+  end
+
+  #  handle access_type = ACCESSIBLE, and !resource.is_downloadable?
+  #  Seek::Config.default :default_projects_access_type = @resource.is_asset? ? Policy::ACCESSIBLE : Policy::VISIBLE
+  test "policy selection options handles access type accessible selected but item not downloadable" do
+    policies = [Policy::NO_ACCESS, Policy::VISIBLE, Policy::ACCESSIBLE, Policy::EDITING]
+    resource = nil # not downloadable
+    selected_access_type = Policy::ACCESSIBLE
+    actual_options = policy_selection_options policies, resource, selected_access_type
+
+    expected_options = "<option value='0' >No access </option><option value='1' selected='selected'>View summary </option><option value='3' >View and edit summary </option>"
+
+    assert_equal expected_options, actual_options, "default selected access type should change from accessible
+to visible if item is not downloadable and the accessible option is removed."
+  end
+
+  test "policy selection options keeps access type accessible selected when item is downloadable" do
+    policies = [Policy::NO_ACCESS, Policy::VISIBLE, Policy::ACCESSIBLE, Policy::EDITING]
+    resource = DataFile.new # is downloadable
+    selected_access_type = Policy::ACCESSIBLE
+    actual_options = policy_selection_options policies, resource, selected_access_type
+
+    expected_options = "<option value='0' >No access </option><option value='1' >View summary only </option><option value='2' selected='selected'>View summary and get contents </option><option value='3' >View and edit summary and contents </option>"
+
+    assert_equal expected_options, actual_options, "default selected access type should change from accessible
+to visible if item is not downloadable and the accessible option is removed."
+  end
+
+end


### PR DESCRIPTION
Added settings for the default sharing permissions at the bottom of the 'Additional Settings' config page. Also changed the permissions pages to use these settings as their default.