### PR TITLE
Docker readme quickstart create volumes

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -7,6 +7,12 @@
 
 ## Quick start
 
+Create docker volumes:
+
+    docker volume create --name=seek-filestore
+    docker volume create --name=seek-mysql-db
+    docker volume create --name=seek-solr-data
+
 Load the database schema and seed data:
 
     docker-compose run seek bundle exec rake db:setup


### PR DESCRIPTION
Trying the docker quickstart documented in docker/README.md
It is necessary to create the volumes in advance

> docker-compose version 1.8.0, build f3628c7
> Docker version 1.12.1, build 23cf638

I am not sure if there is a command line flag to docker-compose for the automatic creation of external volumes - which could be documented alternatively.