### PR TITLE
Publication form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -111,7 +111,7 @@ gem 'bundler', '>= 1.8.4'
 source 'https://rails-assets.org' do
   gem 'rails-assets-bootstrap-multiselect', '~> 0.9.13'
   gem 'rails-assets-bootstrap-tagsinput', '~> 0.8.0'
-  gem 'rails-assets-typeahead.js', '~> 0.10.4'
+  gem 'rails-assets-typeahead.js', '~> 0.10.5'
 end
 
 group :assets do

--- a/Gemfile
+++ b/Gemfile
@@ -135,6 +135,8 @@ group :development do
   gem 'guard-rubycritic', require: false
   gem 'rails_best_practices'
   gem 'quiet_assets'
+  gem 'ruby-debug-ide', '>= 0.6.1.beta2', require: false
+  gem 'debase', '>= 0.2.2.beta8', require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -243,6 +243,9 @@ GEM
     database_cleaner (1.4.1)
     datacite_doi_ify (1.1.0)
       rest-client (~> 1.7)
+    debase (0.2.2.beta8)
+      debase-ruby_core_source
+    debase-ruby_core_source (0.9.2)
     delayed_job (4.0.6)
       activesupport (>= 3.0, < 5.0)
     delayed_job_active_record (4.0.3)
@@ -615,6 +618,8 @@ GEM
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.4)
+    ruby-debug-ide (0.6.1.beta2)
+      rake (>= 0.8.1)
     ruby-prof (0.15.8)
     ruby-progressbar (1.7.5)
     ruby_parser (3.6.6)
@@ -800,6 +805,7 @@ DEPENDENCIES
   daemons
   database_cleaner
   datacite_doi_ify (~> 1.1.0)
+  debase (>= 0.2.2.beta8)
   delayed_job_active_record
   docsplit
   doi_query_tool!
@@ -863,6 +869,7 @@ DEPENDENCIES
   ro-bundle
   rspec-rails
   rubocop
+  ruby-debug-ide (>= 0.6.1.beta2)
   ruby-prof
   rubycritic
   rubyzip (~> 1.1.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -849,7 +849,7 @@ DEPENDENCIES
   rails (= 3.2.22)
   rails-assets-bootstrap-multiselect (~> 0.9.13)!
   rails-assets-bootstrap-tagsinput (~> 0.8.0)!
-  rails-assets-typeahead.js (~> 0.10.4)!
+  rails-assets-typeahead.js (~> 0.10.5)!
   rails_autolink
   rails_best_practices
   rdf-virtuoso (>= 0.1.6)

--- a/app/assets/javascripts/publication.js
+++ b/app/assets/javascripts/publication.js
@@ -39,7 +39,7 @@ function removePublication(index) {
 function updatePublications() {
     publication_text='<ul class="related_asset_list">';
     
-    for (var i=0;i<publication_array.length;i++) {        
+    for (var i=0;i<publication_array.length;i++) {
         publication=publication_array[i];
         title=publication[0];
         id=publication[1];

--- a/app/assets/javascripts/scales/scales_selection.js
+++ b/app/assets/javascripts/scales/scales_selection.js
@@ -14,7 +14,7 @@ function addSelectedToFancy2(multiselect, value) {
         param: $('choose_parameter_for_scale_id').value,
         unit: $('choose_unit_for_scale_id').value
 
-    }
+    };
     if (!scale_and_params_selected(value)) {
         $(multiselect).setValue($F(multiselect).concat(value.scale_id));
         updateScaleAndParamsList(value);
@@ -50,9 +50,9 @@ function updateFancyMultiselect2(multiselect) {
     multiselect = $(multiselect);
     var display_area = $(multiselect.id + '_display_area');
 
-    var selected_options = multiselect.childElements().select(function(c){return c.selected});
+    var selected_options = multiselect.childElements().select(function(c){return c.selected;});
     if(selected_options.length > 0) {
-        display_area.innerHTML = '<ul class="related_asset_list"></ul>'
+        display_area.innerHTML = '<ul class="related_asset_list"></ul>';
         var list = display_area.select('ul')[0];
         selected_options.each(function(opt){
             insertFancyListItem2(multiselect, list, opt);
@@ -81,7 +81,7 @@ function insertFancyListItem2(multiselect, displaylist, option) {
 function fetchJsonForScale(scale_id) {
 
     var result=new Array();
-    var options = $('scale_ids_and_params').childElements().select(function(c){return c.selected});
+    var options = $('scale_ids_and_params').childElements().select(function(c){return c.selected;});
     options.each(function(opt) {
 
         var json = JSON.parse(opt.value);
@@ -98,7 +98,7 @@ function removeFromFancy2(multiselect, value,param) {
     console.log(value);
     console.log(param);
     $('scale_ids_and_params').select("option:selected").each(function(opt){
-        var item=JSON.parse(opt.value)
+        var item=JSON.parse(opt.value);
 
         if (item.scale_id == value && item.param==param) {
             console.log(opt.value);

--- a/app/assets/javascripts/templates/typeahead/publication_author.hbs
+++ b/app/assets/javascripts/templates/typeahead/publication_author.hbs
@@ -1,0 +1,5 @@
+<span class="text">{{first_name}} {{last_name}}</span> 
+<span class="badge">{{count}}</span>
+{{#if person_id}} 
+<span class="glyphicon glyphicon-user"></span>
+{{/if}}

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -47,7 +47,7 @@ class PublicationsController < ApplicationController
   def create
     publication_params = params[:publication].dup
 
-    @subaction = params[:subaction]
+    @subaction = params[:subaction] || 'Register'
 
     # publication authors need to be added separately
     publication_params.delete(:publication_authors)
@@ -59,7 +59,7 @@ class PublicationsController < ApplicationController
     @publication.doi = doi
     @publication.pubmed_id = pubmed_id
 
-    if params[:subaction] == 'Register'
+    if @subaction == 'Register'
       result = get_data(@publication, @publication.pubmed_id, @publication.doi)
       assay_ids = params[:assay_ids] || []
 
@@ -92,7 +92,7 @@ class PublicationsController < ApplicationController
       end
     end # Register publication from doi or pubmedid
 
-    if params[:subaction] == 'Create'
+    if @subaction == 'Create'
       assay_ids = params[:assay_ids] || []
       # create publication authors
       plain_authors = params[:publication][:publication_authors]

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -36,8 +36,6 @@ class Publication < ActiveRecord::Base
   validate :check_uniqueness_of_identifier_within_project, :unless => "Seek::Config.is_virtualliver"
   validate :check_uniqueness_of_title_within_project, :unless => "Seek::Config.is_virtualliver"
 
-  validate :check_identifier_present
-
   after_update :update_creators_from_publication_authors
 
   # http://bioruby.org/rdoc/Bio/Reference.html#method-i-format
@@ -242,21 +240,6 @@ class Publication < ActiveRecord::Base
                           :authors => publication_authors.map {|e| e.person ? [e.person.last_name, e.person.first_name].join(', ') : [e.last_name, e.first_name].join(', ')},
                           :year => published_date.year}.with_indifferent_access)
     end
-  end
-
-  def check_identifier_present
-    if doi.blank? && pubmed_id.blank?
-      self.errors[:base] << "Please specify either a PubMed ID or DOI"
-      return false
-    end
-
-    if !doi.blank? && !pubmed_id.blank?
-      self.errors[:base] << "Can't have both a PubMed ID and a DOI"
-      return false
-    end
-
-    true
-
   end
 
   def check_uniqueness_of_identifier_within_project

--- a/app/models/publication_author.rb
+++ b/app/models/publication_author.rb
@@ -11,4 +11,20 @@ class PublicationAuthor < ActiveRecord::Base
     "#{first_name} #{last_name}"
   end
 
+  # @param full_name e.g. "Joe J. Shmoe"
+  # @return [first_name, last_name] eg . ["Joe J.", "Shmoe"]
+  def self.split_full_name full_name
+    full_name_split = full_name.split(" ")
+    first_name = ""
+    last_name = ""
+
+    if full_name_split.length == 1
+      last_name = full_name_split[0]
+    elsif full_name_split.length > 1
+      last_name = full_name_split.pop
+      first_name = full_name_split.join " "
+    end
+    return first_name, last_name
+  end
+
 end

--- a/app/views/publications/_publication_preview.html.erb
+++ b/app/views/publications/_publication_preview.html.erb
@@ -20,5 +20,5 @@
     <%= f.hidden_field :doi %>
     <%= f.select :project_ids, Project.all.collect(&:id), {}, :selected=> @publication.project_ids, :multiple=>true, :style=>"display:none;", :class => 'project_ids' %>
 
-    <%= f.submit 'Register', :onclick => "updateProjectIds();", :class => 'btn btn-primary' %>
+    <%= f.submit 'Register', :name => "subaction", :value => 'Register', :onclick => "updateProjectIds();", :class => 'btn btn-primary' %>
 <% end %>

--- a/app/views/publications/new.html.erb
+++ b/app/views/publications/new.html.erb
@@ -85,12 +85,21 @@
   </div>
   </div>
   <div class="form-group">
-  <%= label_tag :publication_authors, 'Authors', :class => 'control-label col-sm-2' %>
-  <div class="col-sm-10">
+    <%= label_tag :publication_authors, 'Authors', :class => 'control-label col-sm-2' %>
+    <div class="col-sm-9">
       <%= publication_form.collection_select :publication_authors, @publication.publication_authors, :full_name, :full_name, {:selected => @publication.publication_authors.map(&:id)}, :class => 'form-control', :multiple => 'multiple' %>
-      <%#= publication_form.collection_select :publication_authors, [], :id, :full_name, {}, :class => 'form-control', :multiple => 'multiple' %>
-      <%#= publication_form.text_field :publication_authors, :class => 'form-control' %>
     </div>
+    <div class="col-sm-1">
+      <button type="button" class="btn btn-sm" data-toggle="popover" data-html="true" data-content="
+        <span class='tag label label-primary'>Author linked to User</span><br>
+        <span class='tag label label-success'>User</span><br>
+        <span class='tag label label-warning'>Known Author</span><br>
+        <span class='tag label label-danger'>New Author</span>
+      ">
+        Explain
+      </button>
+    </div>
+
   </div>
   <div class="form-group">
   <%= label_tag :abstract, nil, :class => 'control-label col-sm-2' %>  
@@ -165,30 +174,76 @@ jQuery(document).ready(function() {
     activate_tab.trigger('click');
   }
   
+  // activate popovers
+  jQuery('[data-toggle="popover"]').popover();
+  
   jQuery('div[id="Create"] select[id="publication_project_ids"]').multiselect({
     enableCaseInsensitiveFiltering: true
   });
+  
+  var bloodhound_authors = new Bloodhound({
+    datumTokenizer: Bloodhound.tokenizers.obj.whitespace(['first_name','last_name']),
+    queryTokenizer: Bloodhound.tokenizers.whitespace,
+    remote: {
+      url: '<%= query_authors_typeahead_publications_path :format => :json, :full_name => 'FULL_NAME_QUERY' %>',
+      wildcard: 'FULL_NAME_QUERY'
+    },
+    limit: 10
+  });
+  bloodhound_authors.initialize();
+
+  var bloodhound_users = new Bloodhound({
+    datumTokenizer: Bloodhound.tokenizers.obj.whitespace('name'),
+    queryTokenizer: Bloodhound.tokenizers.whitespace,
+    remote: {
+      url: '<%= typeahead_people_path :format => :json, :query => 'FULL_NAME_QUERY' %>',
+      wildcard: 'FULL_NAME_QUERY'
+    },
+    limit: 10
+  });
+  bloodhound_authors.initialize();
+  bloodhound_users.initialize();
+  
   jQuery('#publication_publication_authors').tagsinput({
     tagClass: function(item){
+      // person/user and not an author
+      if( item.name) return 'label label-success';
       // this author does not exist yet
-      if( !item.id) return 'label label-warning';
+      if( item.count == 0) return 'label label-danger';
       // this author is associated with a know person
-      if( item.person_id) return 'label label-success';
+      if( item.person_id) return 'label label-primary';
       // this is an author that is already associated with a publication
-      return 'label label-primary';
+      return 'label label-warning';
     },
     freeInput: false,
     allowDuplicates: true,
-    // itemText: function(item) { return "<span class=\"text\">" + item.first_name + " " + item.last_name + "</span> <span class=\"badge\">" + item.count + "</span>" + (item.person_id ? " <span class=\"glyphicon glyphicon-user\"></span>" : ""); },
-    itemText: function(item) { return typeof item === "string" ? item : item.first_name + " " + item.last_name; },
-    itemValue: function(item) { return typeof item === "string" ? item : item.first_name + " " + item.last_name; },
-    // itemValue: function(item) { return item; },
-    itemTitle: function(item) { return typeof item === "string" ? item : item.first_name + " " + item.last_name + ": #publications " + item.count + ", seek_person? " + (item.person_id ? "yes" : "no"); },
-    typeahead: {
-      source: function(query) {
-        return jQuery.get( "<%= query_authors_typeahead_publications_path :format => :json %>", { "full_name": query}, null, "json");
-      }
-    }
+    itemText: function(item) { return item.name ? item.name : item.first_name + " " + item.last_name; },
+    itemValue: function(item) { return item.name ? item.name : item.first_name + " " + item.last_name; },
+    itemTitle: function(item) { return item.name ? item.name : ( item.first_name + " " + item.last_name + ": #publications " + item.count + ", seek_person? " + (item.person_id ? "yes" : "no")); },
+    typeaheadjs: [{
+        highlight: true,
+        minLength: 1
+      },
+      [
+        {
+          name: "authors",
+          displayKey: function(item){ return item.first_name + " " + item.last_name;},
+          source: bloodhound_authors.ttAdapter(),
+          templates: {
+            header: 'Authors',
+            suggestion: HandlebarsTemplates['typeahead/publication_author']
+          }
+        },{
+          name: "users",
+          displayKey: function(item){ return item.name;},
+          source: bloodhound_users.ttAdapter(),
+          templates: {
+            header: 'Users',
+            suggestion: HandlebarsTemplates['typeahead/hint']
+          }
+        }
+      ]
+    ]
   });
 
   // add all options of the multiselect
@@ -292,15 +347,15 @@ jQuery(document).ready(function() {
   });
 });
 
-// function updateProjectIds(){
-  // var form = $('new_publication');
-  // //need to query by classname, as there are now two elements with the same id publication_project_ids
-  // //this is the inactive element
-  // var inactive_project_select = form.getElementsByClassName('project_ids')[0];
-  // //this is the active element, that the selected value gets changed through UI
-  // var active_project_select = $('publication_project_ids');
-  // //need to update inactive element from active element
-  // inactive_project_select.setValue(active_project_select.getValue());
-// }
+function updateProjectIds(){
+  var form = $('new_publication');
+  //need to query by classname, as there are now two elements with the same id publication_project_ids
+  //this is the inactive element
+  var inactive_project_select = form.getElementsByClassName('project_ids')[0];
+  //this is the active element, that the selected value gets changed through UI
+  var active_project_select = $('div[id="Register"] select[id="publication_project_ids"]');
+  //need to update inactive element from active element
+  inactive_project_select.setValue(active_project_select.getValue());
+}
 
 </script>

--- a/app/views/publications/new.html.erb
+++ b/app/views/publications/new.html.erb
@@ -1,16 +1,26 @@
 <h1>Register Publication</h1>
 
+<div>
 <%= error_messages_for('publication', :message => nil) %>
 
-<%= form_tag_with_callbacks(fetch_preview_publications_path,
+<!-- Nav tabs -->
+<% subaction = @subaction || 'Register' # default tab is the old Register %>
+<ul class="nav nav-tabs" role="tablist" id="new_publication_tabs" data-subaction="<%= subaction %>">
+  <li role="presentation"><a href="#Register" aria-controls="Register" role="tab" data-toggle="tab">From Identifier</a></li>
+  <li role="presentation"><a href="#Create" aria-controls="Create" role="tab" data-toggle="tab">Enter manually</a></li>
+</ul>
+
+<!-- Tab panes -->
+<div class="tab-content">
+  <div role="tabpanel" class="tab-pane" id="Register">
+    <%= form_tag_with_callbacks(fetch_preview_publications_path,
                             {:remote=>true,
                              :id=>"fetch_publication",
                              :success => "Element.show('publication_preview_container'); Element.hide('publication_error'); new Effect.Highlight('publication_preview_container', { duration: 1.0 });",
                              :failure => "Element.show('publication_error'); Element.hide('publication_preview_container');new Effect.Highlight('publication_error', { duration: 1.0, startcolor: '#FF5555' });",
                              :loading => "Element.hide('publication_preview_container');Element.show('spinner');$('fetch_button').disabled=true;",
-                             :complete => "Element.hide('spinner');$('fetch_button').disabled=false;"}) do %>
-    <p>
-      Choose whether to search by PubMed ID or DOI using the dropdown menu below, then enter the document identifier into the text box and click "Fetch".<br/>
+                             :complete => "Element.hide('spinner');$('fetch_button').disabled=false;"}) do %>    <p>
+      Choose whether to search by PubMed ID or DOI using the dropdown menu below, then enter the document identifier into the text box and click "Fetch".<br>
       If SEEK successfully retrieves your publication, click "Register" to process to the next step.
     </p>
     <div id="publication_error" class="error_div alert alert-danger" style="display:none"></div>
@@ -36,19 +46,261 @@
 
     <%= submit_tag 'Fetch',:id=>"fetch_button", :class => 'btn btn-default' %>
     <%= image_tag "ajax-loader.gif", :id => 'spinner', :style => 'display:none;' -%>
-<% end %>
+    <% end %>
 
-<div id="publication_preview_container" style="display:none;"></div>
+    <div id="publication_preview_container" style="display:none;"></div>
+</div>
+
+<div role="tabpanel" class="tab-pane" id="Create">
+<%= form_for @publication, :html => { :class => 'form-horizontal' } do |publication_form| %>
+  <%= publication_form.hidden_field :parent_name %>
+  <div class="form-group">
+  <%= label_tag :project_ids, 'Projects', :class => 'control-label col-sm-2' %>
+  <div class="col-sm-10">
+      <%= publication_form.collection_select :project_ids, User.current_user.person.projects, :id, :title, {}, :class => 'form-control', :multiple => 'multiple' %>
+    </div>
+  </div>
+  <div class="form-group">
+    <%= label_tag :pubmed_id, "Pubmed ID", :class => 'control-label col-sm-2' %>
+    <div class="col-sm-6">
+      <%= publication_form.text_field :pubmed_id, :class => 'form-control' %>
+    </div>
+    <div class=" col-sm-4">
+      <button id="retrieve_from_pubmed" class="btn btn-default">PUBMED</button>
+    </div>
+  </div>
+  <div class="form-group">
+    <%= label_tag :doi, "DOI", :class => 'control-label col-sm-2' %>
+    <div class="col-sm-6">
+      <%= publication_form.text_field :doi, :class => 'form-control' %>
+    </div>
+    <div class=" col-sm-4">
+      <button id="retrieve_from_crossref" class="btn btn-default">Crossref</button>
+    </div>
+  </div>
+  <div class="form-group">
+  <%= label_tag :title, 'Title', :class => 'control-label col-sm-2' %>  
+  <div class="col-sm-10">
+    <%= publication_form.text_area :title, :class => 'form-control', :rows => 2, :cols => 100 %>
+  </div>
+  </div>
+  <div class="form-group">
+  <%= label_tag :publication_authors, 'Authors', :class => 'control-label col-sm-2' %>
+  <div class="col-sm-10">
+      <%= publication_form.collection_select :publication_authors, @publication.publication_authors, :full_name, :full_name, {:selected => @publication.publication_authors.map(&:id)}, :class => 'form-control', :multiple => 'multiple' %>
+      <%#= publication_form.collection_select :publication_authors, [], :id, :full_name, {}, :class => 'form-control', :multiple => 'multiple' %>
+      <%#= publication_form.text_field :publication_authors, :class => 'form-control' %>
+    </div>
+  </div>
+  <div class="form-group">
+  <%= label_tag :abstract, nil, :class => 'control-label col-sm-2' %>  
+  <div class="col-sm-10">
+      <%= publication_form.text_area :abstract, :class => 'form-control', :rows => 5, :cols => 100 %>
+    </div>
+  </div>
+  <div class="form-group">
+  <%= label_tag :journal, nil, :class => 'control-label col-sm-2' %>
+  <div class="col-sm-10">
+      <%= publication_form.text_field :journal, :class => 'form-control' %>
+    </div>
+  </div>
+  <div class="form-group">
+  <%= label_tag :citation, nil, :class => 'control-label col-sm-2' %>
+  <div class="col-sm-10">
+      <%= publication_form.text_field :citation, :class => 'form-control' %>
+    </div>
+  </div>
+  <div class="form-group">
+  <%= label_tag :published_date, nil, :class => 'control-label col-sm-2' %>  
+  <div class="col-sm-10">
+      <%= publication_form.date_select :published_date, :class => 'form-control' %>
+    </div>
+  </div>
+  <div class="form-group">
+    <div class="col-sm-2 col-sm-offset-2">
+      <%= publication_form.submit 'Create', :name => "subaction", :value => 'Create', :class => 'btn btn-primary' %>
+    </div>
+  </div>
+
+<% end %>
+  
+</div>
+
+</div><!--end Tab panes -->
+
+</div>
 
 <script type="text/javascript">
-    function updateProjectIds(){
-        var form = $('new_publication');
-        //need to query by classname, as there are now two elements with the same id publication_project_ids
-        //this is the inactive element
-        var inactive_project_select = form.getElementsByClassName('project_ids')[0];
-        //this is the active element, that the selected value gets changed through UI
-        var active_project_select = $('publication_project_ids');
-        //need to update inactive element from active element
-        inactive_project_select.setValue(active_project_select.getValue());
+function addAuthorsToPublication( authorlist, selector_tagsinput) {
+  var tagsinput_elem = jQuery(selector_tagsinput);
+  if( tagsinput_elem.length == 0) {
+    return;
+  }
+
+  tagsinput_elem.tagsinput('removeAll');
+
+  if( authorlist.length == 0) {
+    return;
+  }
+
+  jQuery.ajax({
+    url: "<%= query_authors_publications_path :format => :json %>",
+    datatype: 'json',
+    contentType: "application/json",
+    data: { "authors": authorlist },
+    success: function(authors){
+      authors.forEach( function(item,index){
+        tagsinput_elem.tagsinput('add', item);
+      });
     }
+  });
+}
+
+jQuery(document).ready(function() {
+  // activate tab of current subaction, but only if no hash is set
+  if( !window.location.hash) {
+    var newpublications_tabs = jQuery('#new_publication_tabs');
+    var activate_tab_hash = newpublications_tabs.data('subaction');
+    var activate_tab = newpublications_tabs.find('a[href="#' + activate_tab_hash + '"]');
+    activate_tab.trigger('click');
+  }
+  
+  jQuery('div[id="Create"] select[id="publication_project_ids"]').multiselect({
+    enableCaseInsensitiveFiltering: true
+  });
+  jQuery('#publication_publication_authors').tagsinput({
+    tagClass: function(item){
+      // this author does not exist yet
+      if( !item.id) return 'label label-warning';
+      // this author is associated with a know person
+      if( item.person_id) return 'label label-success';
+      // this is an author that is already associated with a publication
+      return 'label label-primary';
+    },
+    freeInput: false,
+    allowDuplicates: true,
+    // itemText: function(item) { return "<span class=\"text\">" + item.first_name + " " + item.last_name + "</span> <span class=\"badge\">" + item.count + "</span>" + (item.person_id ? " <span class=\"glyphicon glyphicon-user\"></span>" : ""); },
+    itemText: function(item) { return typeof item === "string" ? item : item.first_name + " " + item.last_name; },
+    itemValue: function(item) { return typeof item === "string" ? item : item.first_name + " " + item.last_name; },
+    // itemValue: function(item) { return item; },
+    itemTitle: function(item) { return typeof item === "string" ? item : item.first_name + " " + item.last_name + ": #publications " + item.count + ", seek_person? " + (item.person_id ? "yes" : "no"); },
+    typeahead: {
+      source: function(query) {
+        return jQuery.get( "<%= query_authors_typeahead_publications_path :format => :json %>", { "full_name": query}, null, "json");
+      }
+    }
+  });
+
+  // add all options of the multiselect
+  jQuery('#publication_publication_authors option').each(function(index,element){
+    jQuery('#publication_publication_authors').tagsinput('add', jQuery(element).val());
+  });
+
+  jQuery('#retrieve_from_crossref').on('click', function(e){
+    e.preventDefault(); // prevent the default form submit action
+
+    var doi = jQuery('#publication_doi').val();
+    doi = doi.replace(/^http:\/\/dx\.doi\.org/, '');
+
+    jQuery.ajax({
+      url: 'http://data.crossref.org/' + doi,
+      accepts: { 'citeproc': "application/vnd.citationstyles.csl+json" },
+      dataType: 'json',
+      success: function(data, textStatus, jqXHR) {
+        jQuery('#publication_doi').parents('.form-group').removeClass('has-error');
+        jQuery('#publication_doi').parents('.form-group').addClass('has-success');
+        jQuery('#crossref_id').val(data.DOI);
+        jQuery('#publication_title').val(data.title);
+        jQuery('#publication_journal').val(data.publisher);
+        jQuery('#publication_published_date_1i').val(data["published-online"]["date-parts"][0][0]);
+        jQuery('#publication_published_date_2i').val(data["published-online"]["date-parts"][0][1]);
+        jQuery('#publication_published_date_3i').val(data["published-online"]["date-parts"][0][2]);
+        var authorlist = [];
+        data.author.forEach(function(item,index){
+          authorlist.push({"first_name": item.given, "last_name": item.family});
+        });
+        addAuthorsToPublication( authorlist, '#publication_publication_authors');
+      },
+      // http://www.crosscite.org/cn/
+      statusCode: {
+        // 200: function() { console.log("DOI: " + doi + " The request was OK.");},
+        204: function() { console.log("DOI: " + doi + " The request was OK but there was no metadata available.");},
+        404: function() { console.log("DOI: " + doi + " The DOI requested doesn't exist.");},
+        406: function() { console.log("DOI: " + doi + " Can't serve any requested content type.");}
+      },
+      error: function() {
+        jQuery('#publication_doi').parents('.form-group').removeClass('has-success');
+        jQuery('#publication_doi').parents('.form-group').addClass('has-error');
+      }
+    });
+  });
+  jQuery('#retrieve_from_pubmed').on('click', function(e){
+    e.preventDefault(); // prevent the default form submit action
+    var pubmedid = jQuery('#publication_pubmed_id').val();
+    jQuery.ajax({
+      url: 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi',
+      data: {
+        'db': 'pubmed',
+        'id': pubmedid,
+        'retmode': 'xml',
+        'retmax': 1
+      },
+      dataType: 'xml',
+      success: function(data, textStatus, jqXHR) {
+        jQuery('#publication_pubmed_id').parents('.form-group').removeClass('has-error');
+        jQuery('#publication_pubmed_id').parents('.form-group').addClass('has-success');
+        var doc = jQuery(data);
+        var doi_elem = jQuery(data).find('PubmedArticleSet > PubmedArticle > PubmedData > ArticleIdList > ArticleId[IdType="doi"]');
+        if( doi_elem.length != 0) {
+          jQuery('#publication_doi').val(doi_elem.html());
+        }
+        
+        var medline_citation = jQuery(data).find('PubmedArticleSet > PubmedArticle > MedlineCitation');
+        
+        var title_elem = medline_citation.find('Article > ArticleTitle');
+        if( title_elem.length != 0) {
+          jQuery('#publication_title').val(title_elem.html());
+        }
+        var abstract_elem = medline_citation.find('Article > Abstract > AbstractText');
+        if( abstract_elem.length != 0) {
+          jQuery('#publication_abstract').val(abstract_elem.html());
+        }
+        var journal_elem = medline_citation.find('Article > Journal > Title');
+        if( journal_elem.length != 0) {
+          jQuery('#publication_journal').val(journal_elem.html());
+        }
+        var datecreated_elem = medline_citation.find('DateCreated');
+        if( datecreated_elem.length != 0) {
+          jQuery('#publication_published_date_1i').val(parseInt(datecreated_elem.find('Year').html()));
+          jQuery('#publication_published_date_2i').val(parseInt(datecreated_elem.find('Month').html()));
+          jQuery('#publication_published_date_3i').val(parseInt(datecreated_elem.find('Day').html()));
+        }
+        
+        var authorlist = [];
+        var author_list_elem = medline_citation.find('Article > AuthorList > Author').each( function(index, element){
+          var firstname = jQuery(element).find('ForeName').html();
+          var lastname = jQuery(element).find('LastName').html();
+          authorlist.push({"first_name": firstname, "last_name": lastname});
+        });
+        addAuthorsToPublication(authorlist,"#publication_publication_authors");
+      },
+      error: function() {
+        jQuery('#publication_pubmed_id').parents('.form-group').removeClass('has-success');
+        jQuery('#publication_pubmed_id').parents('.form-group').addClass('has-error');
+      }
+    });
+  });
+});
+
+// function updateProjectIds(){
+  // var form = $('new_publication');
+  // //need to query by classname, as there are now two elements with the same id publication_project_ids
+  // //this is the inactive element
+  // var inactive_project_select = form.getElementsByClassName('project_ids')[0];
+  // //this is the active element, that the selected value gets changed through UI
+  // var active_project_select = $('publication_project_ids');
+  // //need to update inactive element from active element
+  // inactive_project_select.setValue(active_project_select.getValue());
+// }
+
 </script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -561,6 +561,8 @@ SEEK::Application.routes.draw do
     collection do
       get :typeahead
       get :preview
+      get :query_authors
+      get :query_authors_typeahead
       post :fetch_preview
       post :items_for_result
       post :resource_in_tab

--- a/test/unit/publication_test.rb
+++ b/test/unit/publication_test.rb
@@ -194,7 +194,7 @@ class PublicationTest < ActiveSupport::TestCase
     assert asset.valid?
 
     asset=Publication.new :title=>"fred",:projects=>[project]
-    assert !asset.valid?
+    assert asset.valid?
 
     asset=Publication.new :projects=>[project],:doi=>"111"
     assert !asset.valid?
@@ -204,11 +204,11 @@ class PublicationTest < ActiveSupport::TestCase
       assert asset.valid?
     end
 
-    #cant have both a pubmed and doi
+    #can have both a pubmed and doi
     asset = Publication.new :title=>"bob",:doi=>"777",:projects=>[project]
     assert asset.valid?
     asset.pubmed_id="999"
-    assert !asset.valid?
+    assert asset.valid?
     asset.doi=nil
     assert asset.valid?
   end


### PR DESCRIPTION
added an alternative way to add a publication through an actual form
-in that form, doi and.or pubmedid can be entered and the form can be filled client-side
-authors are added in a tag-input field with some coloring depending on if seek has seen that author or even that user before
in the publication_controller:
-create function has a subaction:
  -'Register' is using the old way
  -'Create' is using the new form
-two action that assist in typeahead.js querying with bloodhound

Publication has changed:
-doi or pubmedid are not required any more and both can be given

typeahead.js upgrade from 0.10.4 -> 0.10.5