### PR TITLE
Publication form calendar_date_select, https://dx.doi.org, add author on validation error

### DIFF
--- a/app/assets/javascripts/templates/typeahead/publication_author.hbs
+++ b/app/assets/javascripts/templates/typeahead/publication_author.hbs
@@ -1,5 +1,5 @@
-<span class="text">{{first_name}} {{last_name}}</span> 
+<span class="text">{{first_name}} {{last_name}}</span>
 <span class="badge">{{count}}</span>
-{{#if person_id}} 
+{{#if person_id}}
 <span class="glyphicon glyphicon-user"></span>
 {{/if}}

--- a/app/assets/stylesheets/new_styles.css.scss
+++ b/app/assets/stylesheets/new_styles.css.scss
@@ -282,7 +282,7 @@ div.hidden_list_item {
 .date-select img.calendar_date_select_popup_icon {
   position: absolute;
   bottom: 8px;
-  left: 8px;
+  padding-left: 8px;
 }
 
 a.select_assay_class {

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -283,7 +283,7 @@ class PublicationsController < ApplicationController
           user = users_db[0]
           authors << { :name => user.name }
         else # just add the queried name as author
-          authors << { :person_id => nil, :first_name => author_q['first_name'], :last_name => author_q['last_name'], :count => 0 }
+          authors << { :person_id => nil, :first_name => params[:first_name], :last_name => params[:last_name], :count => 0 }
         end
       end
     }

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -323,11 +323,6 @@ class PublicationsController < ApplicationController
     authors.delete_if { |author| author[:first_name].empty? && author[:last_name].empty? }
     author = PublicationAuthor.where({ :first_name => first_name, :last_name => last_name}).limit(1)
 
-    # add the queried author if he does not exist
-    if author.empty?
-      authors << { :person_id => nil, :first_name => first_name, :last_name => last_name, :count => 0 }
-    end
-
     respond_to do |format|
       format.json { render :json => authors }
       format.xml  { render :xml  => authors }

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -254,7 +254,13 @@ class PublicationsController < ApplicationController
 
     authors = []
     authors_q.each { |author_i, author_q|
-      params = { :first_name => author_q['first_name'], :last_name => author_q['last_name'] }
+      params = { }
+      if author_q.key?('full_name')
+        first_name, last_name = PublicationAuthor::split_full_name author_q['full_name']
+        params = { :first_name => first_name, :last_name => last_name }
+      else
+        params = { :first_name => author_q['first_name'], :last_name => author_q['last_name'] }
+      end
 
       authors_db = PublicationAuthor.where(params)
                                     .select([:person_id, :first_name, :last_name])

--- a/app/views/publications/new.html.erb
+++ b/app/views/publications/new.html.erb
@@ -247,6 +247,7 @@ jQuery(document).ready(function() {
             return sync([{name: q, count: 0}]);
           },
           templates: {
+            header: 'New Author',
             suggestion: HandlebarsTemplates['typeahead/hint']
           }
         },

--- a/app/views/publications/new.html.erb
+++ b/app/views/publications/new.html.erb
@@ -119,10 +119,10 @@
       <%= publication_form.text_field :citation, :class => 'form-control' %>
     </div>
   </div>
-  <div class="form-group">
+  <div class="form-group date-select">
   <%= label_tag :published_date, nil, :class => 'control-label col-sm-2' %>  
   <div class="col-sm-10">
-      <%= publication_form.date_select :published_date, :class => 'form-control' %>
+      <%= publication_form.calendar_date_select :published_date, :class => 'form-control' %>
     </div>
   </div>
   <div class="form-group">
@@ -271,7 +271,7 @@ jQuery(document).ready(function() {
     doi = doi.replace(/^http:\/\/dx\.doi\.org/, '');
 
     jQuery.ajax({
-      url: 'http://data.crossref.org/' + doi,
+      url: 'https://dx.doi.org/' + doi,
       accepts: { 'citeproc': "application/vnd.citationstyles.csl+json" },
       dataType: 'json',
       success: function(data, textStatus, jqXHR) {
@@ -280,9 +280,16 @@ jQuery(document).ready(function() {
         jQuery('#crossref_id').val(data.DOI);
         jQuery('#publication_title').val(data.title);
         jQuery('#publication_journal').val(data.publisher);
-        jQuery('#publication_published_date_1i').val(data["published-online"]["date-parts"][0][0]);
-        jQuery('#publication_published_date_2i').val(data["published-online"]["date-parts"][0][1]);
-        jQuery('#publication_published_date_3i').val(data["published-online"]["date-parts"][0][2]);
+
+        var date_published = {
+          year: data["published-online"]["date-parts"][0][0],
+          month: data["published-online"]["date-parts"][0][1]-1,
+          day: data["published-online"]["date-parts"][0][2]
+        };
+        var cds = new CalendarDateSelect( jQuery('#publication_published_date')[0], {time: "mixed"});
+        cds.updateSelectedDate(date_published,false);
+        cds.close();
+
         var authorlist = [];
         data.author.forEach(function(item,index){
           authorlist.push({"first_name": item.given, "last_name": item.family});
@@ -339,9 +346,14 @@ jQuery(document).ready(function() {
         }
         var datecreated_elem = medline_citation.find('DateCreated');
         if( datecreated_elem.length != 0) {
-          jQuery('#publication_published_date_1i').val(parseInt(datecreated_elem.find('Year').html()));
-          jQuery('#publication_published_date_2i').val(parseInt(datecreated_elem.find('Month').html()));
-          jQuery('#publication_published_date_3i').val(parseInt(datecreated_elem.find('Day').html()));
+          var date_published = {
+            year: datecreated_elem.find('Year').html(),
+            month: datecreated_elem.find('Month').html()-1,
+            day: datecreated_elem.find('Day').html()
+          };
+          var cds = new CalendarDateSelect( jQuery('#publication_published_date')[0], {time: "mixed"});
+          cds.updateSelectedDate(date_published,false);
+          cds.close();
         }
         
         var authorlist = [];

--- a/app/views/publications/new.html.erb
+++ b/app/views/publications/new.html.erb
@@ -165,6 +165,21 @@ function addAuthorsToPublication( authorlist, selector_tagsinput) {
   });
 }
 
+function addAuthorsFromSelect() {
+  // convert all options of the multiselect to an authorlist
+  var authorlist = jQuery('#publication_publication_authors option').map( function(index,element){
+   return { full_name: jQuery(element).val()};
+  }).get();
+  
+  addAuthorsToPublication( authorlist, '#publication_publication_authors');
+  return;
+  
+  // jQuery('#publication_publication_authors option').each(function(index,element){
+    // console.log('value:' + jQuery(element).val());
+    // jQuery('#publication_publication_authors').tagsinput('add', jQuery(element).val());
+  // });
+}
+
 jQuery(document).ready(function() {
   // activate tab of current subaction, but only if no hash is set
   if( !window.location.hash) {
@@ -247,9 +262,7 @@ jQuery(document).ready(function() {
   });
 
   // add all options of the multiselect
-  jQuery('#publication_publication_authors option').each(function(index,element){
-    jQuery('#publication_publication_authors').tagsinput('add', jQuery(element).val());
-  });
+  addAuthorsFromSelect();
 
   jQuery('#retrieve_from_crossref').on('click', function(e){
     e.preventDefault(); // prevent the default form submit action
@@ -274,7 +287,7 @@ jQuery(document).ready(function() {
         data.author.forEach(function(item,index){
           authorlist.push({"first_name": item.given, "last_name": item.family});
         });
-        addAuthorsToPublication( authorlist, '#publication_publication_authors');
+        addAuthorsToPublication(authorlist,'#publication_publication_authors');
       },
       // http://www.crosscite.org/cn/
       statusCode: {
@@ -337,7 +350,7 @@ jQuery(document).ready(function() {
           var lastname = jQuery(element).find('LastName').html();
           authorlist.push({"first_name": firstname, "last_name": lastname});
         });
-        addAuthorsToPublication(authorlist,"#publication_publication_authors");
+        addAuthorsToPublication(authorlist,'#publication_publication_authors');
       },
       error: function() {
         jQuery('#publication_pubmed_id').parents('.form-group').removeClass('has-success');

--- a/app/views/publications/new.html.erb
+++ b/app/views/publications/new.html.erb
@@ -222,7 +222,7 @@ jQuery(document).ready(function() {
   jQuery('#publication_publication_authors').tagsinput({
     tagClass: function(item){
       // person/user and not an author
-      if( item.name) return 'label label-success';
+      if( item.name && typeof(item.count) == "undefined") return 'label label-success';
       // this author does not exist yet
       if( item.count == 0) return 'label label-danger';
       // this author is associated with a know person
@@ -241,11 +241,21 @@ jQuery(document).ready(function() {
       },
       [
         {
+          name: "typed",
+          displayKey: function(item){ return item.name;},
+          source: function(q, sync) {
+            return sync([{name: q, count: 0}]);
+          },
+          templates: {
+            suggestion: HandlebarsTemplates['typeahead/hint']
+          }
+        },
+        {
           name: "authors",
           displayKey: function(item){ return item.first_name + " " + item.last_name;},
           source: bloodhound_authors.ttAdapter(),
           templates: {
-            header: 'Authors',
+            header: 'Known Authors',
             suggestion: HandlebarsTemplates['typeahead/publication_author']
           }
         },{
@@ -253,7 +263,7 @@ jQuery(document).ready(function() {
           displayKey: function(item){ return item.name;},
           source: bloodhound_users.ttAdapter(),
           templates: {
-            header: 'Users',
+            header: 'People',
             suggestion: HandlebarsTemplates['typeahead/hint']
           }
         }


### PR DESCRIPTION
the publication date uses the calendar_date_select form helper 
filling the manual publication form using doi, https://dx.doi.org is used instead of http://data.crossref.org (no https available)
the tags-input for authors was not adding the tags for already entered authors correctly - the add expected an object with first_name and last_name but just got the full_name as a single string