### PR TITLE
use bootstrap text-center class and fix ruby warnings

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -178,7 +178,7 @@ class AdminsController < ApplicationController
     Seek::Config.set_default_page 'presentations', params[:presentations]
     Seek::Config.set_default_page 'events', params[:events]
     Seek::Config.limit_latest = params[:limit_latest] if only_positive_integer params[:limit_latest], 'latest limit'
-    update_redirect_to (only_positive_integer params[:limit_latest], 'latest limit'), 'pagination'
+    update_redirect_to only_positive_integer(params[:limit_latest], 'latest limit'), 'pagination'
   end
 
   def update_others
@@ -272,7 +272,7 @@ class AdminsController < ApplicationController
         attribute_name = a.attribute.name
         a.destroy unless replacement_tags.include?(@tag)
         replacement_tags.each do |tag|
-          if annotatable.annotations_with_attribute_and_by_source(attribute_name, source).select { |a| a.value == tag }.blank?
+          if annotatable.annotations_with_attribute_and_by_source(attribute_name, source).select { |an| an.value == tag }.blank?
             new_annotation = Annotation.new attribute_name: attribute_name, value: tag, annotatable: annotatable, source: source
             new_annotation.save!
           end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -542,7 +542,6 @@ class ApplicationController < ActionController::Base
     payload[:user_agent] = request.user_agent
   end
 
-
   def log_extra_exception_data
       request.env["exception_notifier.exception_data"] = {
           :current_logged_in_user=>current_user
@@ -554,6 +553,4 @@ class ApplicationController < ActionController::Base
   end
 
 end
-
-
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -122,7 +122,7 @@ class ApplicationController < ActionController::Base
     elsif resource_type == "Person" && Seek::Config.is_virtualliver && current_user.nil?
       authorized_resources = []
     else
-      authorized_resources = resources.select &:can_view?
+      authorized_resources = resources.select(&:can_view?)
     end
 
     render :update do |page|

--- a/app/controllers/assays_controller.rb
+++ b/app/controllers/assays_controller.rb
@@ -75,7 +75,7 @@ class AssaysController < ApplicationController
 
     @assay.assay_class=AssayClass.for_type(@assay_class) unless @assay_class.nil?
 
-    investigations = Investigation.all.select &:can_view?
+    investigations = Investigation.all.select(&:can_view?)
     studies=[]
     investigations.each do |i|
       studies << i.studies.select(&:can_view?)

--- a/app/controllers/data_files_controller.rb
+++ b/app/controllers/data_files_controller.rb
@@ -289,9 +289,9 @@ class DataFilesController < ApplicationController
     #FIXME: should use the correct version
     @matching_model_items = @data_file.matching_models
     #filter authorization
-    ids = @matching_model_items.collect &:primary_key
+    ids = @matching_model_items.collect(&:primary_key)
     models = Model.find_all_by_id(ids)
-    authorised_ids = Model.authorize_asset_collection(models,"view").collect &:id
+    authorised_ids = Model.authorize_asset_collection(models,"view").collect(&:id)
     @matching_model_items = @matching_model_items.select{|mdf| authorised_ids.include?(mdf.primary_key.to_i)}
 
     flash.now[:notice]="#{@matching_model_items.count} #{t('model').pluralize}  were found that may be relevant to this #{t('data_file')} "

--- a/app/controllers/favourite_groups_controller.rb
+++ b/app/controllers/favourite_groups_controller.rb
@@ -130,7 +130,7 @@ class FavouriteGroupsController < ApplicationController
       format.json {
         unless already_exists
           render :json => {:status => 200, :group_class_name => @f_group.class.name, :group_name => @f_group.name, :group_id => @f_group.id, :favourite_groups => users_favourite_groups }
-        else already_exists
+        else #already_exists
           render :json => {:status => 422, :error_message => "You already have a #{t('favourite_group')} with such name.\nPlease change it and try again." }
         end
       }

--- a/app/controllers/model_images_controller.rb
+++ b/app/controllers/model_images_controller.rb
@@ -68,7 +68,7 @@ class ModelImagesController < ApplicationController
 
   def filter_size size
     max_size=1500
-    matches = size.match /([0-9]+)x([0-9]+).*/
+    matches = size.match(/([0-9]+)x([0-9]+).*/)
     if matches
       width = matches[1].to_i
       height = matches[2].to_i
@@ -76,7 +76,7 @@ class ModelImagesController < ApplicationController
       height = max_size if height>max_size
       return "#{width}x#{height}"
     else
-      matches = size.match /([0-9]+)/
+      matches = size.match(/([0-9]+)/)
       if matches
         width=matches[1].to_i
         width = max_size if width>max_size

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -220,9 +220,9 @@ class ModelsController < ApplicationController
     @matching_data_items = @model.matching_data_files
 
     #filter authorization
-    ids = @matching_data_items.collect &:primary_key
+    ids = @matching_data_items.collect(&:primary_key)
     data_files = DataFile.find_all_by_id(ids)
-    authorised_ids = DataFile.authorize_asset_collection(data_files, "view").collect &:id
+    authorised_ids = DataFile.authorize_asset_collection(data_files, "view").collect(&:id)
     @matching_data_items = @matching_data_items.select { |mdf| authorised_ids.include?(mdf.primary_key.to_i) }
 
     flash.now[:notice]="#{@matching_data_items.count} #{t('data_file').pluralize} found that may be relevant to this #{t('model')}"

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -1,6 +1,5 @@
 #encoding: utf-8
 class PublicationsController < ApplicationController
-  
   include Seek::IndexPager
   include Seek::AssetsCommon
   include Seek::BioExtension

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -51,7 +51,7 @@ class StudiesController < ApplicationController
         flash.now[:error] = "You do not have permission to associate the new #{t('study')} with the #{t('investigation')} '#{investigation.title}'."
       end
     end
-    investigations = Investigation.all.select &:can_view?
+    investigations = Investigation.all.select(&:can_view?)
     respond_to do |format|
       if investigations.blank?
        flash.now[:notice] = "No #{t('investigation')} available, you have to create a new one before creating your Study!"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -92,9 +92,9 @@ module ApplicationHelper
   end
 
   def authorized_list all_items, attribute, sort=true, max_length=75, count_hidden_items=false
-    items = all_items.select &:can_view?
+    items = all_items.select(&:can_view?)
     if Seek::Config.is_virtualliver
-      title_only_items = (all_items - items).select &:title_is_public?
+      title_only_items = (all_items - items).select(&:title_is_public?)
     else
       title_only_items = []
     end

--- a/app/helpers/assets_helper.rb
+++ b/app/helpers/assets_helper.rb
@@ -119,7 +119,7 @@ module AssetsHelper
   # assets are sorted by title except if they are projects and scales (because of hierarchies)
   def authorised_assets(asset_class, projects = nil, action = 'view')
     assets = asset_class.all_authorized_for action, User.current_user, projects
-    assets = assets.sort_by &:title if !assets.blank? && !%w(Project Scale).include?(assets.first.class.name)
+    assets = assets.sort_by(&:title) if !assets.blank? && !%w(Project Scale).include?(assets.first.class.name)
     assets
   end
 

--- a/app/helpers/related_items_helper.rb
+++ b/app/helpers/related_items_helper.rb
@@ -19,7 +19,7 @@ module RelatedItemsHelper
   def update_resource_items_for_authorization(resource_item)
     total_count = resource_item[:items].size
     total = resource_item[:items]
-    resource_item[:items] = resource_item[:items].select &:can_view?
+    resource_item[:items] = resource_item[:items].select(&:can_view?)
     resource_item[:hidden_items] = total - resource_item[:items]
     resource_item[:hidden_count] = total_count - resource_item[:items].size
   end

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -104,7 +104,7 @@ class Publication < ActiveRecord::Base
 
 
   def self.sort publications
-    publications.sort_by &:published_date
+    publications.sort_by(&:published_date)
   end
 
   def contributor_credited?

--- a/app/sweepers/common_sweepers.rb
+++ b/app/sweepers/common_sweepers.rb
@@ -21,8 +21,8 @@ module CommonSweepers
   end
 
   def expire_header_and_footer
-    expire_fragment /header/
-    expire_fragment "footer"
+    expire_fragment(/header/)
+    expire_fragment("footer")
   end
 
   def expire_download_activity

--- a/app/views/admins/_workflow_stats.html.erb
+++ b/app/views/admins/_workflow_stats.html.erb
@@ -35,7 +35,7 @@
   </thead>
   <% stats.sort_by {|s| -s[:unique_users] }.each do |wf_stats| %>
       <tr>
-        <td style="text-align: left"><%= link_to wf_stats[:workflow].title, wf_stats[:workflow] -%></td>
+        <td class="text-left"><%= link_to wf_stats[:workflow].title, wf_stats[:workflow] -%></td>
         <td><%= wf_stats[:public] -%></td>
         <td><%= wf_stats[:runs_count] -%></td>
         <td><%= wf_stats[:sweep_count] -%></td>

--- a/app/views/admins/registration_form.html.erb
+++ b/app/views/admins/registration_form.html.erb
@@ -1,15 +1,15 @@
 <br/>
 <div style="background-color: white;font-size: larger;">
-<p style="text-align: center;">
+<p class="text-center">
   If you have not already done so, please take a moment to fill out and submit our short registration form. Doing so is optional, but will help the ongoing development and support of SEEK.
 </p>
 <% if params[:during_setup]=="true" -%>
-<p style="text-align: center;">
+<p class="text-center">
   If you wish to leave this for a later time, the registration form is still accessible through the Admin pages - at <%= link_to "SEEK Registration",registration_form_admin_path -%>
 </p>
 <% end -%>
 </div>
 
-<div style="text-align:center">
+<div class="text-center">
   <iframe src="https://docs.google.com/spreadsheet/embeddedform?formkey=dE9FY1dPSEUwa3VuZWZ0bUFndGRYcWc6MQ" width="100%" height="1024" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>
 </div>

--- a/app/views/assets/_asset_avatars.html.erb
+++ b/app/views/assets/_asset_avatars.html.erb
@@ -11,7 +11,7 @@
 %>
 <% cache cache_key do -%>
     <% unless creators.empty? -%>
-        <div style="text-align: center">
+        <div class="text-center">
           <% if creators.size <= 2 %>
               <% creators.each do |a|  -%>
                   <%=  favouritable_icon(a, 60) -%>
@@ -34,7 +34,7 @@
         </div>
     <% else %>
         <% if !resource.contributor -%>
-            <div style="text-align: center">
+            <div class="text-center">
               <%= the_jerm :size=>30 -%>
             </div>
         <% end -%>

--- a/app/views/assets/_sharing_form.html.erb
+++ b/app/views/assets/_sharing_form.html.erb
@@ -184,7 +184,7 @@
                   <%= link_to "Add", "", :id => "add_f_group_link", :style => "font-weight: bold; vertical-align: middle;", :disabled => (favourite_groups.blank?),
                               :onclick => "javascript: if($('favourite_group_select').disabled) return(false); addContributor('FavouriteGroup', $('favourite_group_select').options[$('favourite_group_select').selectedIndex].text, parseInt($('favourite_group_select').options[$('favourite_group_select').selectedIndex].value), #{Policy::DETERMINED_BY_GROUP}); return(false);" -%>
                 </p>
-                <ul style="text-align: left; margin: 1em 0 0.5em 3.2em;">
+                <ul class="text-left" style="margin: 1em 0 0.5em 3.2em;">
                   <li id="edit_f_group_li" style="display: <%= favourite_groups.blank? ? "none" : "block" -%>; list-style-type: disc; padding: 0;"><%= favourite_group_popup_link_action_edit(@resource.class.name) -%></li>
                   <li id="delete_f_group_li" style="display: <%= favourite_groups.blank? ? "none" : "block" -%>; list-style-type: disc; padding: 0;">
                     <%= link_to "Delete selected favourite group", delete_favourite_group_path(0), :onclick => "deleteSelectedFavouriteGroup(); return(false);" -%>
@@ -268,7 +268,7 @@
                               :help_text => "Here you can specify individual people to share this #{@resource_type} with.") do %>
                 <div id="facebook" class="clearfix">
 
-                  <p style="text-align: justify;">
+                  <p class="text-justify">
                     Please type names of people to share this <%= @resource_type -%> with into the box below -
                     suggestions will be displayed as you type.
                     Select access rights from drop-down menu; these will be applied to all chosen people.

--- a/app/views/assets/_sharing_form_biovel.html.erb
+++ b/app/views/assets/_sharing_form_biovel.html.erb
@@ -159,7 +159,7 @@
                   <%= link_to "Add", "", :id => "add_f_group_link", :style => "font-weight: bold; vertical-align: middle;", :disabled => (favourite_groups.blank?),
                               :onclick => "javascript: if($('favourite_group_select').disabled) return(false); addContributor('FavouriteGroup', $('favourite_group_select').options[$('favourite_group_select').selectedIndex].text, parseInt($('favourite_group_select').options[$('favourite_group_select').selectedIndex].value), #{Policy::DETERMINED_BY_GROUP}); return(false);" -%>
                 </p>
-                <ul style="text-align: left; margin: 1em 0 0.5em 3.2em;">
+                <ul class="text-left" style="margin: 1em 0 0.5em 3.2em;">
                   <li id="edit_f_group_li" style="display: <%= favourite_groups.blank? ? "none" : "block" -%>; list-style-type: disc; padding: 0;"><%= favourite_group_popup_link_action_edit(@resource.class.name) -%></li>
                   <li id="delete_f_group_li" style="display: <%= favourite_groups.blank? ? "none" : "block" -%>; list-style-type: disc; padding: 0;">
                     <%= link_to "Delete selected #{t('favourite_group').pluralize}", main_app.delete_favourite_group_path(0), :onclick => "deleteSelectedFavouriteGroup(); return(false);" -%>
@@ -243,7 +243,7 @@
                               :help_text => "Here you can specify individual people to share this #{@resource_type} with.") do %>
                 <div id="facebook" class="clearfix">
 
-                  <p style="text-align: justify;">
+                  <p class="text-justify">
                     Please type names of people to share this <%= @resource_type -%> with into the box below -
                     suggestions will be displayed as you type.
                     Select access rights from drop-down menu; these will be applied to all chosen people.

--- a/app/views/avatars/_selector_hlist.html.erb
+++ b/app/views/avatars/_selector_hlist.html.erb
@@ -6,17 +6,17 @@
 	  <li><%= image_tag_for_key('avatar', new_avatar_link(avatar_for_instance), nil, nil, "Upload New Picture") -%></li>
 	</ul>
 		
-	<p class="box_standout" style="text-align: center; padding: 0.3em 0.5em; margin: 1.5em 0 1em 0;">
+	<p class="box_standout text-center" style="padding: 0.3em 0.5em; margin: 1.5em 0 1em 0;">
 		Choose your default display picture using a radio button below a picture and clicking 'Update' at the bottom of the page.
 	</p>
 	
 	<div id="hlist">
     <ul>
-	    <li style="text-align: center;">
+	    <li class="text-center">
 	      <%= default_avatar(avatar_for_instance.class.name, 60, "Anonymous", "$('#{object_type}_avatar_id_').checked = true;") %><br/><%= form_instance.radio_button :avatar_id, nil -%>
 	    </li>
 	    <% avatar_for_instance.avatars.each do |a| -%>
-	      <li style="text-align: center;">
+	      <li class="text-center">
 	      	<%= image_tag avatar_url(avatar_for_instance, a.id, 60), :alt => h(avatar_for_instance.title), :onclick => "$('#{object_type}_avatar_id_#{a.id}').checked = true;" -%>
 					<br/>
 					<%= form_instance.radio_button :avatar_id, a.id -%>

--- a/app/views/favourite_groups/_popup_content.html.erb
+++ b/app/views/favourite_groups/_popup_content.html.erb
@@ -39,7 +39,7 @@
 
       <fieldset style="margin-top: 2em;">
         <legend>&nbsp;Add Members&nbsp;</legend>
-        <p style="text-align: justify;">
+        <p class="text-justify">
           Please type names of people to add to this group into the box below - suggestions will be displayed as you type.
           Select access rights from drop-down menu; these will be applied to all chosen people.
           Clicking "Add" will add selected people as group members.
@@ -82,7 +82,7 @@
       </fieldset>
 
       <% if action_create -%>
-          <div style="text-align: left; margin-bottom: 1.3em;">
+          <div class="text-left" style="margin-bottom: 1.3em;">
             <%= check_box_tag "group_sharing_required", "1", true -%>
             <label for="group_sharing_required">Share with this group when it is created</label>
           </div>

--- a/app/views/forums/_form.html.erb
+++ b/app/views/forums/_form.html.erb
@@ -9,7 +9,7 @@
     <label><%= 'Title'[:title_title] %></label><br/>
     <%= form.text_field :name, :class => "primary" %>
   </td>
-  <td style="text-align:right">
+  <td class="text-right">
     <label><%= 'Position'[:position_title] %></label><br/>
     <%= form.text_field :position, :size => 5 %>
 

--- a/app/views/gadgets/_my_project_gadget.html.erb
+++ b/app/views/gadgets/_my_project_gadget.html.erb
@@ -14,7 +14,7 @@
         Go to my <%= t('project') %>
       </div>
       <div class="contents curved_bottom">
-        <div style="text-align: center">
+        <div class="text-center">
 
             <input type=button id="my_project_button" class="<%= button_class %>" value="My <%= t('project') %>" onclick="javascript:myProjectClicked();"/>
 

--- a/app/views/gadgets/_new_object_gadget.html.erb
+++ b/app/views/gadgets/_new_object_gadget.html.erb
@@ -16,7 +16,7 @@
           </div>
 
           <div class="contents curved_bottom">
-            <div style="text-align: center;">
+            <div class="text-center">
               <input type=button id="new_asset_button" class="<%= button_class %>" value="<%= t('gadget.create_button')%>" onclick="javascript:toggleDynamicMenu('new_asset_menu');"/>
               <ul id="new_asset_menu" class='dynamic_menu with_smaller_shadow' style="display:none;">
 

--- a/app/views/general/landing_page_for_hidden_item.html.erb
+++ b/app/views/general/landing_page_for_hidden_item.html.erb
@@ -2,13 +2,13 @@
   <% asset_type =  t("#{controller_name.singularize}") %>
   <h2 class="forbidden">The <%= asset_type %> is not visible to you.</h2>
   <% unless logged_in? %>
-    <p style="text-align: center;">You may need to login to access this <%= asset_type %>.</p>
+    <p class="text-center">You may need to login to access this <%= asset_type %>.</p>
   <% end %>
 
   <% if item.class.authorization_supported? %>
       <%  hidden_item_contributor_links = hidden_item_contributor_links([item])%>
       <% unless hidden_item_contributor_links.empty? %>
-        <p style="text-align: center;">You may want to contact the authors: <%= hidden_item_contributor_links([item]).join(', ').html_safe%></p>
+        <p class="text-center">You may want to contact the authors: <%= hidden_item_contributor_links([item]).join(', ').html_safe%></p>
       <% end %>
   <% end %>
 
@@ -17,7 +17,7 @@
       <% asset_doi_log = AssetDoiLog.where(asset_type: item.class.name, asset_id: item.id, asset_version: version, action: AssetDoiLog::UNPUBLISH).last %>
       <% comment = asset_doi_log.try(:comment) %>
       <% unless comment.blank? %>
-        <p class="comment" style="text-align: center;">The authors left the reason for un-publishing the <%= asset_type %>: <%= comment.html_safe %></p>
+        <p class="comment text-center">The authors left the reason for un-publishing the <%= asset_type %>: <%= comment.html_safe %></p>
       <% end %>
   <% end %>
 </div>

--- a/app/views/layouts/_contributor_avatar.html.erb
+++ b/app/views/layouts/_contributor_avatar.html.erb
@@ -1,9 +1,9 @@
 <%
 contributor = resource.contributor
 %>
-<div style="text-align: center">
+<div class="text-center">
   <% if resource.contributor -%>
-    <%= favouritable_icon(resource.contributor.person, 60) -%>      
+    <%= favouritable_icon(resource.contributor.person, 60) -%>
   <% else %>    
     <%= the_jerm :size=>30 -%>
   <% end -%>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,18 +1,18 @@
 <% cache "header" do -%>
     <table width="100%">
       <tr>
-      <td style="text-align:left">
+      <td class="text-left">
         <%= link_to image_tag("seek-logo-smaller.png",:alt=>"SEEK",:title=>"SEEK"),
           root_path %>
       </td>
       <td style="width:90%;">
         <%= render :partial=>"layouts/header_text_main" -%>
       </td>
-      <td style="text-align:right;">
+      <td class="text-right">
         <% if Seek::Config.header_image_enabled %>
             <%= header_logo_image %>
         <% end %>
       </td>
     </tr>
-    </table>      
+    </table>
 <% end -%>

--- a/app/views/model_images/_image_selector.html.erb
+++ b/app/views/model_images/_image_selector.html.erb
@@ -4,7 +4,7 @@
 		<li><%= image_tag_for_key('avatar', new_model_image_link(image_for_instance), nil, {:onclick => "store_and_submit_unsaved_data(this, 'edit_model_#{image_for_instance.id}'); return(false);"}, 'Upload New Image') -%></li>
 	</ul>
 		
-	<p class="box_standout" style="text-align: center; padding: 0.3em 0.5em; margin: 1.5em 0 1em 0;">
+	<p class="box_standout text-center" style="padding: 0.3em 0.5em; margin: 1.5em 0 1em 0;">
 		Choose your default display image using a radio button below a image and clicking 'Update' at the bottom of the page.
 	</p>
 	
@@ -12,7 +12,7 @@
     <ul>
 	    
 	    <% image_for_instance.model_images.each do |image| -%>
-	      <li style="text-align: center;">
+	      <li class="text-center">
 	      	<%= image_tag model_image_url(image_for_instance, image.id, 60), :alt => h(image_for_instance.title), :onclick => "$('model_model_image_id_#{image.id}').checked = true;" -%>
 					<br/>
 					<%= form_instance.radio_button :model_image_id, image.id -%>

--- a/app/views/model_images/index.html.erb
+++ b/app/views/model_images/index.html.erb
@@ -46,9 +46,9 @@
 <% else -%>
 
 <div class="show_basic">
-  <p class="none_text" style="text-align: center; font-size: 123.1%;">
-  	No images yet!
-	</p>
+  <p class="none_text text-center" style="font-size: 123.1%;">
+    No images yet!
+  </p>
 </div>
 
 <% end -%>

--- a/app/views/people/_discipline_select.html.erb
+++ b/app/views/people/_discipline_select.html.erb
@@ -1,6 +1,6 @@
 
 
-<div style="text-align: center;">
+<div class="text-center">
   <div style="width: 95%;">
     <p>
       <%= f.label "Disciplines" %><br/>

--- a/app/views/people/_project_subscriptions.html.erb
+++ b/app/views/people/_project_subscriptions.html.erb
@@ -11,7 +11,7 @@
           </tr>
           <% project_subscriptions.sort{|ps1,ps2|ps1.project.title <=> ps2.project.title}.each do |project_subscription| %>
               <tr>
-                <td style="text-align: left"> <%= link_to project_subscription.project.title, project_subscription.project %> </td>
+                <td class="text-left"> <%= link_to project_subscription.project.title, project_subscription.project %> </td>
                 <td> <%= project_subscription.frequency %> </td>
               </tr>
           <% end %>

--- a/app/views/taverna_player/runs/embedded/new.html.erb
+++ b/app/views/taverna_player/runs/embedded/new.html.erb
@@ -30,7 +30,7 @@
     <%= render :partial => 'inputs_form', :locals => {:title => "Parameters", :inputs => @workflow_version.parameter_input_ports, :form => f} %>
   <% end %>
 
-  <div style="text-align: center;">
+  <div class="text-center">
     <%= f.submit 'Start Run', :id => "embedded-start-button" %>
   </div>
 <% end %>

--- a/app/views/work_groups/review_popup.html.erb
+++ b/app/views/work_groups/review_popup.html.erb
@@ -27,7 +27,7 @@
 					<table>
 				  	<% group_members.each do |p| -%>
 						  <tr>
-						  	<td id="work_group_member_person_<%= p.id -%>" style="text-align: left;"><%= "#{p.first_name} #{p.last_name}" -%></td>
+						  	<td id="work_group_member_person_<%= p.id -%>" class="text-left"><%= "#{p.first_name} #{p.last_name}" -%></td>
 								<td>
 									<select id="work_group_access_rights_select_person_<%= p.id -%>" style="width: 220px; vertical-align: middle;">
 									  <%= policy_selection_options(nil, resource, @access_type)-%>
@@ -42,7 +42,7 @@
 			<% end -%>
 			
 			
-			<p style="text-align: center; margin-top: 1em;">
+			<p class="text-center" style="margin-top: 1em;">
 				<input type="button" value="Add" style="width: 150px;" onclick="javascript: addProjectInstitutionReviewed(); return(false);" />
 				<input type="button" value="Cancel" style="width: 150px;" onclick="javascript: RedBox.close(); return(false);" />
 			</p>

--- a/lib/only_writes_unique.rb
+++ b/lib/only_writes_unique.rb
@@ -5,7 +5,7 @@ module OnlyWritesUnique
       load_target
       args = flatten_deeper(args).reject {|record| target.include? record}.uniq
     end
-    concat_without_ignore_duplicates *args
+    concat_without_ignore_duplicates(*args)
   end
 
   def self.included base

--- a/lib/seek/active_record_extensions.rb
+++ b/lib/seek/active_record_extensions.rb
@@ -8,7 +8,7 @@ module Seek
         #define the instance method if it does not exist
         def self.after_initialize_with_ensure_base_exists *args
           define_method(:after_initialize) {} unless method_defined? :after_initialize
-          after_initialize_without_ensure_base_exists *args
+          after_initialize_without_ensure_base_exists(*args)
         end
 
         class_alias_method_chain :after_initialize, :ensure_base_exists

--- a/lib/seek/acts_as_fleximage_extension.rb
+++ b/lib/seek/acts_as_fleximage_extension.rb
@@ -68,7 +68,7 @@ module Seek
       def filter_size(size)
         size = size[0..-(Regexp.last_match(1).length.to_i + 2)] if size =~ /[0-9]+x[0-9]+\.([a-z0-9]+)/ # trim file extension
         max_size = MAX_SIZE
-        matches = size.match /([0-9]+)x([0-9]+).*/
+        matches = size.match(/([0-9]+)x([0-9]+).*/)
         if matches
           width = matches[1].to_i
           height = matches[2].to_i
@@ -76,7 +76,7 @@ module Seek
           height = max_size if height > max_size
           return "#{width}x#{height}"
         else
-          matches = size.match /([0-9]+)/
+          matches = size.match(/([0-9]+)/)
           if matches
             width = matches[1].to_i
             width = max_size if width > max_size

--- a/lib/seek/faceted_browsing.rb
+++ b/lib/seek/faceted_browsing.rb
@@ -59,7 +59,7 @@ module Seek
         if clazz.respond_to?(:authorize_asset_collection)
           items = clazz.authorize_asset_collection(items,"view")
         else
-          items = items.select &:can_view?
+          items = items.select(&:can_view?)
         end
       end
 

--- a/lib/seek/project_hierarchies/project_extension.rb
+++ b/lib/seek/project_hierarchies/project_extension.rb
@@ -31,9 +31,9 @@ module Seek
 
           def touch_for_hierarchy_updates
             if changed_attributes.include? :parent_id
-              Permission.find_by_contributor_type("Project", :conditions => {:contributor_id => ([id] + ancestors.map(&:id) + descendants.map(&:id))}).each &:touch
-              ancestors.each &:touch
-              descendants.each &:touch
+              Permission.find_by_contributor_type("Project", :conditions => {:contributor_id => ([id] + ancestors.map(&:id) + descendants.map(&:id))}).each(&:touch)
+              ancestors.each(&:touch)
+              descendants.each(&:touch)
             end
           end
 

--- a/lib/seek/rdf/rdf_repository.rb
+++ b/lib/seek/rdf/rdf_repository.rb
@@ -26,17 +26,17 @@ module Seek
 
         #execute a selection query, which delegates to Rdf::Repository#query
         def select *args
-          get_repository_object.select *args
+          get_repository_object.select(*args)
         end
 
         #execute a insert query, which delegates to Rdf::Repository#query
         def insert *args
-          get_repository_object.insert *args
+          get_repository_object.insert(*args)
         end
 
         #execute a deletion query, which delegates to Rdf::Repository#query
         def delete *args
-          get_repository_object.delete *args
+          get_repository_object.delete(*args)
         end
 
         #send the rdf related to item to the repository, and update the rdf file

--- a/spec/magic_lamp_config.rb
+++ b/spec/magic_lamp_config.rb
@@ -4,11 +4,11 @@ FactoryGirl.find_definitions #It looks like requiring factory_girl _should_ do t
 
 FactoryGirl.class_eval do
   def self.create_with_privileged_mode *args
-    disable_authorization_checks {create_without_privileged_mode *args}
+    disable_authorization_checks {create_without_privileged_mode(*args)}
   end
 
   def self.build_with_privileged_mode *args
-    disable_authorization_checks {build_without_privileged_mode *args}
+    disable_authorization_checks {build_without_privileged_mode(*args)}
   end
 
   class_alias_method_chain :create, :privileged_mode

--- a/test/functional/data_files_controller_test.rb
+++ b/test/functional/data_files_controller_test.rb
@@ -1930,7 +1930,7 @@ class DataFilesControllerTest < ActionController::TestCase
 
     get :show,:id=>df
     assert_response :forbidden
-    assert_select "p[class=comment]",:text=>/#{comment}/
+    assert_select "p.comment",:text=>/#{comment}/
   end
 
   test "landing page for non-existing item" do
@@ -2366,7 +2366,7 @@ class DataFilesControllerTest < ActionController::TestCase
       post :extract_samples, id: data_file.id, confirm: 'true'
     end
 
-    assert (samples = assigns(:samples))
+    assert(samples = assigns(:samples))
     assert_equal 3, samples.count
     assert_equal samples.sort, data_file.extracted_samples.sort
   end
@@ -2396,7 +2396,7 @@ class DataFilesControllerTest < ActionController::TestCase
 
     assert_redirected_to data_file_path(data_file)
 
-    assert (samples = assigns(:samples))
+    assert(samples = assigns(:samples))
     assert_equal 3, samples.count
     assert_not_includes samples.map {|s| s.get_attribute(:full_name) }, "Bob"
 

--- a/test/functional/statistics_controller_test.rb
+++ b/test/functional/statistics_controller_test.rb
@@ -26,7 +26,7 @@ class StatisticsControllerTest < ActionController::TestCase
         logout
         get :application_status
         assert_response :success
-        assert_match /Euro SEEK is running \| search is enabled \| [0-9] delayed jobs running/,@response.body
+        assert_match(/Euro SEEK is running \| search is enabled \| [0-9] delayed jobs running/,@response.body)
       end
     end
   end

--- a/test/integration/project_hierarchy/subscription_with_hierarchy_test.rb
+++ b/test/integration/project_hierarchy/subscription_with_hierarchy_test.rb
@@ -75,7 +75,7 @@ class SubscriptionWithHierarchyTest < ActionController::IntegrationTest
         child_project.parent_id = @proj.id
         child_project.save!
       end
-      @subscribables_in_proj.each &:reload
+      @subscribables_in_proj.each(&:reload)
       assert @subscribables_in_proj.all?(&:subscribed?)
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -37,11 +37,11 @@ FactoryGirl.find_definitions #It looks like requiring factory_girl _should_ do t
 
 FactoryGirl.class_eval do
   def self.create_with_privileged_mode *args
-    disable_authorization_checks {create_without_privileged_mode *args}
+    disable_authorization_checks {create_without_privileged_mode(*args)}
   end
 
   def self.build_with_privileged_mode *args
-    disable_authorization_checks {build_without_privileged_mode *args}
+    disable_authorization_checks {build_without_privileged_mode(*args)}
   end
 
   class_alias_method_chain :create, :privileged_mode

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -15,10 +15,10 @@ class ApplicationHelperTest < ActionView::TestCase
       #   <a href="http://test.host/assays/1035386651">http://test.host/assays/1035386651</a>
       # </p>
       assert_equal 'label',blocks.first.name
-      assert_match /TEST-TEST-TEST ID/,blocks.first.children.first.content
+      assert_match(/TEST-TEST-TEST ID/,blocks.first.children.first.content)
       assert_equal 'a',blocks.last.name
-      assert_match /http:\/\/test.host\/assays\/#{assay.id}/,blocks.last['href']
-      assert_match /http:\/\/test.host\/assays\/#{assay.id}/,blocks.last.children.first.content
+      assert_match(/http:\/\/test.host\/assays\/#{assay.id}/,blocks.last['href'])
+      assert_match(/http:\/\/test.host\/assays\/#{assay.id}/,blocks.last.children.first.content)
 
       versioned_sop=Factory(:sop_version)
       html = persistent_resource_id(versioned_sop)
@@ -29,14 +29,13 @@ class ApplicationHelperTest < ActionView::TestCase
       #   <a href="http://test.host/sops/1055250457?version=2">http://test.host/sops/1055250457?version=2</a>
       # </p>
       assert_equal 'label',blocks.first.name
-      assert_match /TEST-TEST-TEST ID/,blocks.first.children.first.content
+      assert_match(/TEST-TEST-TEST ID/,blocks.first.children.first.content)
       assert_equal 'a',blocks.last.name
-      assert_match /http:\/\/test.host\/sops\/#{versioned_sop.parent.id}\?version=#{versioned_sop.version}/,blocks.last['href']
-      assert_match /http:\/\/test.host\/sops\/#{versioned_sop.parent.id}\?version=#{versioned_sop.version}/,blocks.last.children.first.content
-
+      assert_match(/http:\/\/test.host\/sops\/#{versioned_sop.parent.id}\?version=#{versioned_sop.version}/,blocks.last['href'])
+      assert_match(/http:\/\/test.host\/sops\/#{versioned_sop.parent.id}\?version=#{versioned_sop.version}/,blocks.last.children.first.content)
     end
   end
-  
+
   def test_join_with_and
     assert_equal "a, b and c",join_with_and(["a","b","c"])
     assert_equal "a",join_with_and(["a"])

--- a/test/unit/jws_interaction_module_test.rb
+++ b/test/unit/jws_interaction_module_test.rb
@@ -10,7 +10,7 @@ class JwsInteractionModuleTest < ActiveSupport::TestCase
     token = determine_csrf_token
     refute_nil token
     assert token.length > 5
-    assert_match /^[a-zA-Z0-9]+$/,token
+    assert_match(/^[a-zA-Z0-9]+$/,token)
   end
 
   test "upload model blob" do
@@ -18,7 +18,7 @@ class JwsInteractionModuleTest < ActiveSupport::TestCase
     blob = model.content_blobs.first
     slug = upload_model_blob(blob)
     refute_nil slug
-    assert_match /^[a-zA-Z0-9-]+$/,slug
+    assert_match(/^[a-zA-Z0-9-]+$/,slug)
   end
 
   test "upload model blob using https" do
@@ -27,7 +27,7 @@ class JwsInteractionModuleTest < ActiveSupport::TestCase
       blob = model.content_blobs.first
       slug = upload_model_blob(blob)
       refute_nil slug
-      assert_match /^[a-zA-Z0-9-]+$/,slug
+      assert_match(/^[a-zA-Z0-9-]+$/,slug)
     end
   end
 

--- a/test/unit/search_biomodels_adaptor_test.rb
+++ b/test/unit/search_biomodels_adaptor_test.rb
@@ -27,7 +27,7 @@ class SearchBiomodelsAdaptorTest < ActiveSupport::TestCase
     assert_equal "M. J. Herrgard", result.authors.first
     assert_equal "Herrgård2008_MetabolicNetwork_Yeast", result.title
     assert_equal "18846089", result.publication_id
-    assert_match /Genomic data allow the large-scale manual or semi-automated assembly/, result.abstract
+    assert_match(/Genomic data allow the large-scale manual or semi-automated assembly/, result.abstract)
     assert_equal DateTime.parse("2008-10-11"), result.published_date
     assert_equal "MODEL0072364382", result.model_id
     assert_equal DateTime.parse("2012-02-03T13:12:17+00:00"), result.last_modification_date
@@ -45,7 +45,7 @@ class SearchBiomodelsAdaptorTest < ActiveSupport::TestCase
     assert_equal "M. J. Herrgard", result.authors.first
     assert_equal "Herrgård2008_MetabolicNetwork_Yeast", result.title
     assert_equal "18846089", result.publication_id
-    assert_match /Genomic data allow the large-scale manual or semi-automated assembly/, result.abstract
+    assert_match(/Genomic data allow the large-scale manual or semi-automated assembly/, result.abstract)
     assert_equal DateTime.parse("2008-10-11"), result.published_date
     assert_equal "MODEL0072364382", result.model_id
     assert_equal DateTime.parse("2012-02-03T13:12:17+00:00"), result.last_modification_date

--- a/test/unit/send_periodic_emails_job_test.rb
+++ b/test/unit/send_periodic_emails_job_test.rb
@@ -95,9 +95,9 @@ class SendPeriodicEmailsJobTest < ActiveSupport::TestCase
     assert_equal 2*count, SendPeriodicEmailsJob.new('monthly').activity_logs_since(1.month.ago).count
 
     Factory(:activity_log, :action => 'create', :activity_loggable => activity_loggable, :culprit => culprit, :created_at => 2.days.ago)
-    assert_equal 2*count, SendPeriodicEmailsJob.new('daily').activity_logs_since(Time.now.yesterday.utc).count
-    assert_equal (2*count + 1), SendPeriodicEmailsJob.new('weekly').activity_logs_since(7.days.ago).count
-    assert_equal (2*count + 1), SendPeriodicEmailsJob.new('monthly').activity_logs_since(1.month.ago).count
+    assert_equal 2*count    , SendPeriodicEmailsJob.new('daily').activity_logs_since(Time.now.yesterday.utc).count
+    assert_equal 2*count + 1, SendPeriodicEmailsJob.new('weekly').activity_logs_since(7.days.ago).count
+    assert_equal 2*count + 1, SendPeriodicEmailsJob.new('monthly').activity_logs_since(1.month.ago).count
   end
 
   test "create job" do

--- a/test/unit/snapshot_test.rb
+++ b/test/unit/snapshot_test.rb
@@ -40,7 +40,7 @@ class SnapshotTest < ActiveSupport::TestCase
     assert_equal s1.content_blob.md5sum,s1.md5sum
     assert_equal s1.content_blob.sha1sum,s1.sha1sum
 
-    assert_match /\b([a-f0-9]{40})\b/,s1.sha1sum
+    assert_match(/\b([a-f0-9]{40})\b/,s1.sha1sum)
   end
 
   test 'can access snapshot metadata' do


### PR DESCRIPTION
I took the liberty in 'fixing' some ruby warnings.
Additionally, I thought it might be nicer to use the bootstrap alignment classes (http://getbootstrap.com/css/#type-alignment) for aligning elements center or left instead of using 'style="text-align:...' on these elements

If there is a reason to not use bootstrap classes in those cases, please ignore the request.
If there is a reason to ignore the ruby warnings, please ignore the request also.