### PR TITLE
Import bibtex

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,6 +109,7 @@ gem 'rspec-rails'
 gem 'citeproc-ruby', '~> 1.1.4'
 gem 'citeproc', '~> 1.0.4'
 gem 'csl-styles', '~> 1.0.1.7'
+gem 'bibtex-ruby', '~> 4.4.2'
 
 gem 'omniauth', '~> 1.3.1'
 gem 'omniauth-ldap', '~> 1.0.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,6 +203,8 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     bcp47 (0.3.3)
       i18n
+    bibtex-ruby (4.4.2)
+      latex-decode (~> 0.0)
     bio (1.5.0)
     bives (1.0)
       open4 (~> 1.3.0)
@@ -355,6 +357,8 @@ GEM
     json-ld (1.1.8)
       rdf (~> 1.1, >= 1.1.7)
     kgio (2.9.3)
+    latex-decode (0.2.2)
+      unicode (~> 0.4)
     libxml-ruby (2.8.0)
     link_header (0.0.8)
     linkeddata (1.1.11)
@@ -757,6 +761,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.1)
+    unicode (0.4.4.2)
     unicorn (4.9.0)
       kgio (~> 2.6)
       rack
@@ -811,6 +816,7 @@ DEPENDENCIES
   acts_as_tree
   app_version!
   auto_strip_attributes
+  bibtex-ruby (~> 4.4.2)
   bio (~> 1.5.0)
   bioportal (>= 2.3)!
   bives

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -14,7 +14,23 @@ class PublicationsController < ApplicationController
   include Seek::BreadCrumbs
 
   include Seek::IsaGraphExtensions
-    
+  
+  def index
+    if request.format.xml? || request.format.html?
+      super
+    else
+      respond_to do |format|
+        format.any( *Publication::EXPORT_TYPES.keys ) {
+          send_data(
+            @publications.collect { |publication| publication.export(request.format.to_sym) }.join("\n\n"),
+            :type => request.format.to_sym,
+            :filename => "publications.#{request.format.to_sym}"
+          )
+        }
+      end
+    end
+  end
+
   # GET /publications/1
   # GET /publications/1.xml
   def show
@@ -44,9 +60,13 @@ class PublicationsController < ApplicationController
   # POST /publications
   # POST /publications.xml
   def create
-    publication_params = params[:publication].dup
-
     @subaction = params[:subaction] || 'Register'
+
+    if @subaction == 'Import'
+      return import_publication
+    end
+
+    publication_params = params[:publication].dup
 
     # publication authors need to be added separately
     publication_params.delete(:publication_authors)
@@ -54,82 +74,21 @@ class PublicationsController < ApplicationController
     @publication = Publication.new(publication_params)
     @publication.pubmed_id=nil if @publication.pubmed_id.blank?
     @publication.doi=nil if @publication.doi.blank?
-    pubmed_id,doi = preprocess_doi_or_pubmed @publication.pubmed_id,@publication.doi
+    pubmed_id,doi = preprocess_pubmed_or_doi @publication.pubmed_id,@publication.doi
     @publication.doi = doi
     @publication.pubmed_id = pubmed_id
 
     if @subaction == 'Register'
-      result = get_data(@publication, @publication.pubmed_id, @publication.doi)
-      assay_ids = params[:assay_ids] || []
-
-      if @publication.save
-        update_scales @publication
-        result.authors.each_with_index do |author, index|
-          pa = PublicationAuthor.new()
-          pa.publication = @publication
-          pa.first_name = author.first_name
-          pa.last_name = author.last_name
-          pa.author_index = index
-          pa.save
-        end
-
-        create_or_update_associations assay_ids, "Assay", "edit"
-        if !@publication.parent_name.blank?
-          render :partial=>"assets/back_to_fancy_parent", :locals=>{:child=>@publication, :parent_name=>@publication.parent_name}
-        else
-          respond_to do |format|
-            flash[:notice] = 'Publication was successfully created.'
-            format.html { redirect_to(edit_publication_url(@publication)) }
-            format.xml  { render :xml => @publication, :status => :created, :location => @publication }
-          end
-        end
-      else # Publication save not successful
-        respond_to do |format|
-          format.html { render :action => "new" }
-          format.xml  { render :xml => @publication.errors, :status => :unprocessable_entity }
-        end
-      end
+      register_publication
     end # Register publication from doi or pubmedid
 
     if @subaction == 'Create'
-      assay_ids = params[:assay_ids] || []
-      # create publication authors
-      plain_authors = params[:publication][:publication_authors]
-      # plain_authors.split(',').each_with_index do |author, index| # text_field
-      plain_authors.each_with_index do |author, index| # multiselect
-        if author.empty?
-          next
-        end
-        first_name, last_name = PublicationAuthor.split_full_name author
-        pa = PublicationAuthor.new({
-          :publication  => @publication,
-          :first_name   => first_name,
-          :last_name    => last_name,
-          :author_index => index
-        })
-        @publication.publication_authors << pa
-      end
-
-      if @publication.save
-        update_scales @publication
-
-        create_or_update_associations assay_ids, "Assay", "edit"
-        if !@publication.parent_name.blank?
-          render :partial=>"assets/back_to_fancy_parent", :locals=>{:child=>@publication, :parent_name=>@publication.parent_name}
-        else
-          respond_to do |format|
-            flash[:notice] = 'Publication was successfully created.'
-            format.html { redirect_to(edit_publication_url(@publication)) }
-            format.xml  { render :xml => @publication, :status => :created, :location => @publication }
-          end
-        end
-      else # Publication save not successful
-        respond_to do |format|
-          format.html { render :action => "new" }
-          format.xml  { render :xml => @publication.errors, :status => :unprocessable_entity }
-        end
-      end
+      create_publication
     end # Create publication from all fields
+
+    # if @subaction == 'Import'
+      # import_publication
+    # end # import publication from file
   end
 
   # PUT /publications/1
@@ -213,7 +172,7 @@ class PublicationsController < ApplicationController
     elsif protocol == "doi"
       doi = key
     end
-    pubmed_id,doi = preprocess_doi_or_pubmed pubmed_id,doi
+    pubmed_id,doi = preprocess_pubmed_or_doi pubmed_id,doi
     result = get_data(@publication, pubmed_id, doi)
     if !@error.nil?
       if protocol == "pubmed"
@@ -438,10 +397,120 @@ class PublicationsController < ApplicationController
     publication.extract_metadata(result) unless @error
     result
   end
-        
+
   private
 
-  def preprocess_doi_or_pubmed pubmed_id,doi
+  # the original way of creating a bublication by either doi or pubmedid, where all data is set server-side
+  def register_publication
+    result = get_data(@publication, @publication.pubmed_id, @publication.doi)
+    assay_ids = params[:assay_ids] || []
+
+    if @publication.save
+      update_scales @publication
+      result.authors.each_with_index do |author, index|
+        pa = PublicationAuthor.new()
+        pa.publication = @publication
+        pa.first_name = author.first_name
+        pa.last_name = author.last_name
+        pa.author_index = index
+        pa.save
+      end
+
+      create_or_update_associations assay_ids, "Assay", "edit"
+      if !@publication.parent_name.blank?
+        render :partial=>"assets/back_to_fancy_parent", :locals=>{:child=>@publication, :parent_name=>@publication.parent_name}
+      else
+        respond_to do |format|
+          flash[:notice] = 'Publication was successfully created.'
+          format.html { redirect_to(edit_publication_url(@publication)) }
+          format.xml  { render :xml => @publication, :status => :created, :location => @publication }
+        end
+      end
+    else # Publication save not successful
+      respond_to do |format|
+        format.html { render :action => "new" }
+        format.xml  { render :xml => @publication.errors, :status => :unprocessable_entity }
+      end
+    end
+  end
+
+  # create a publication from a form that contains all the data
+  def create_publication
+    assay_ids = params[:assay_ids] || []
+    # create publication authors
+    plain_authors = params[:publication][:publication_authors]
+    plain_authors.each_with_index do |author, index| # multiselect
+      if author.empty?
+        next
+      end
+      first_name, last_name = PublicationAuthor.split_full_name author
+      pa = PublicationAuthor.new({
+        :publication  => @publication,
+        :first_name   => first_name,
+        :last_name    => last_name,
+        :author_index => index
+      })
+      @publication.publication_authors << pa
+    end
+
+    if @publication.save
+      update_scales @publication
+
+      create_or_update_associations assay_ids, "Assay", "edit"
+      if !@publication.parent_name.blank?
+        render :partial=>"assets/back_to_fancy_parent", :locals=>{:child=>@publication, :parent_name=>@publication.parent_name}
+      else
+        respond_to do |format|
+          flash[:notice] = 'Publication was successfully created.'
+          format.html { redirect_to(edit_publication_url(@publication)) }
+          format.xml  { render :xml => @publication, :status => :created, :location => @publication }
+        end
+      end
+    else # Publication save not successful
+      respond_to do |format|
+        format.html { render :action => "new" }
+        format.xml  { render :xml => @publication.errors, :status => :unprocessable_entity }
+      end
+    end
+  end
+
+  # create a publication from a reference file, at the moment supports only bibtex
+  def import_publication
+    @publication = Publication.new
+
+    require 'bibtex'
+    if !params.has_key?(:publication) || !params[:publication].has_key?(:bibtex_file)
+      @publication.errors[:bibtex_file] = "Upload a file!"
+    else
+      bibtex_file = params[:publication][:bibtex_file]
+      bibtex = BibTeX.parse( bibtex_file.read)
+      if bibtex['@article'].length < 1
+        @publication.errors[:bibtex_file] = "The bibtex file should contain at least one @article"
+      else
+        # warning if there are more than one article
+        if bibtex['@article'].length > 1
+          flash[:error] = "The bibtex file did contain more than one @article: #{bibtex['@article'].length}; only the first one is parsed"
+        end
+        article = bibtex['@article'][0]
+        @publication.extract_bibtex_metadata(article)
+        # the new form will be rendered with the information from the imported bibtex article
+        @subaction = "Create"
+      end
+    end
+
+    if @publication.errors.any?
+      respond_to do |format|
+        format.html { render :action => "new" }
+        format.xml  { render :xml => @publication.errors, :status => :unprocessable_entity }
+      end
+    else
+      respond_to do |format|
+        format.html { render :action => "new" }
+      end
+    end
+  end
+
+  def preprocess_pubmed_or_doi pubmed_id,doi
     doi = doi.sub(%r{doi\.*:}i,"").strip unless doi.nil?
     doi.strip! unless doi.nil?
     pubmed_id.strip! unless pubmed_id.nil? || pubmed_id.is_a?(Fixnum)

--- a/app/views/publications/new.html.erb
+++ b/app/views/publications/new.html.erb
@@ -8,6 +8,7 @@
 <ul class="nav nav-tabs" role="tablist" id="new_publication_tabs" data-subaction="<%= subaction %>">
   <li role="presentation"><a href="#Register" aria-controls="Register" role="tab" data-toggle="tab">From Identifier</a></li>
   <li role="presentation"><a href="#Create" aria-controls="Create" role="tab" data-toggle="tab">Enter manually</a></li>
+  <li role="presentation"><a href="#Import" aria-controls="Import" role="tab" data-toggle="tab">Import from file</a></li>
 </ul>
 
 <!-- Tab panes -->
@@ -19,7 +20,8 @@
                              :success => "Element.show('publication_preview_container'); Element.hide('publication_error'); new Effect.Highlight('publication_preview_container', { duration: 1.0 });",
                              :failure => "Element.show('publication_error'); Element.hide('publication_preview_container');new Effect.Highlight('publication_error', { duration: 1.0, startcolor: '#FF5555' });",
                              :loading => "Element.hide('publication_preview_container');Element.show('spinner');$('fetch_button').disabled=true;",
-                             :complete => "Element.hide('spinner');$('fetch_button').disabled=false;"}) do %>    <p>
+                             :complete => "Element.hide('spinner');$('fetch_button').disabled=false;"}) do %>
+    <p>
       Choose whether to search by PubMed ID or DOI using the dropdown menu below, then enter the document identifier into the text box and click "Fetch".<br>
       If SEEK successfully retrieves your publication, click "Register" to process to the next step.
     </p>
@@ -79,10 +81,10 @@
     </div>
   </div>
   <div class="form-group">
-  <%= label_tag :title, 'Title', :class => 'control-label col-sm-2' %>  
-  <div class="col-sm-10">
-    <%= publication_form.text_area :title, :class => 'form-control', :rows => 2, :cols => 100 %>
-  </div>
+    <%= label_tag :title, 'Title', :class => 'control-label col-sm-2' %>
+    <div class="col-sm-10">
+      <%= publication_form.text_area :title, :class => 'form-control', :rows => 2, :cols => 100 %>
+    </div>
   </div>
   <div class="form-group">
     <%= label_tag :publication_authors, 'Authors', :class => 'control-label col-sm-2' %>
@@ -99,11 +101,10 @@
         Explain
       </button>
     </div>
-
   </div>
   <div class="form-group">
-  <%= label_tag :abstract, nil, :class => 'control-label col-sm-2' %>  
-  <div class="col-sm-10">
+    <%= label_tag :abstract, nil, :class => 'control-label col-sm-2' %>
+    <div class="col-sm-10">
       <%= publication_form.text_area :abstract, :class => 'form-control', :rows => 5, :cols => 100 %>
     </div>
   </div>
@@ -114,13 +115,13 @@
     </div>
   </div>
   <div class="form-group">
-  <%= label_tag :citation, nil, :class => 'control-label col-sm-2' %>
-  <div class="col-sm-10">
+    <%= label_tag :citation, nil, :class => 'control-label col-sm-2' %>
+    <div class="col-sm-10">
       <%= publication_form.text_field :citation, :class => 'form-control' %>
     </div>
   </div>
   <div class="form-group date-select">
-  <%= label_tag :published_date, nil, :class => 'control-label col-sm-2' %>  
+  <%= label_tag :published_date, nil, :class => 'control-label col-sm-2' %>
   <div class="col-sm-10">
       <%= publication_form.calendar_date_select :published_date, :class => 'form-control' %>
     </div>
@@ -130,9 +131,26 @@
       <%= publication_form.submit 'Create', :name => "subaction", :value => 'Create', :class => 'btn btn-primary' %>
     </div>
   </div>
-
 <% end %>
-  
+</div>
+
+<div role="tabpanel" class="tab-pane" id="Import">
+  <%= form_for @publication, :html => { :class => 'form-horizontal' } do |publication_form| %>
+    <div class="col-sm-12">
+      <p>On successful import, the 'Enter manually' tab will be opened and the form will be populated with the data from the imported file.</p>
+    </div>
+    <div class="form-group">
+      <%= label_tag :bibtex_file, nil, :class => 'control-label col-sm-2' %>
+      <div class="col-sm-10">
+        <%= publication_form.file_field :bibtex_file %>
+      </div>
+    </div>
+    <div class="form-group">
+      <div class="col-sm-2 col-sm-offset-2">
+        <%= publication_form.submit 'Import', :name => "subaction", :value => 'Import', :class => 'btn btn-primary' %>
+      </div>
+    </div>
+  <% end %>
 </div>
 
 </div><!--end Tab panes -->

--- a/lib/seek/bio_extension.rb
+++ b/lib/seek/bio_extension.rb
@@ -73,7 +73,9 @@ module Seek
       def name
         return self.first_name + " " + self.last_name
       end
-      
+
+      alias_method :full_name, :name
+
       def to_s
         return self.last_name + ", " + self.first_name
       end

--- a/test/fixtures/files/publication.bibtex
+++ b/test/fixtures/files/publication.bibtex
@@ -1,0 +1,10 @@
+@article{PMID:16845108,
+  author       = {Hull, D. and Wolstencroft, K. and Stevens, R. and Goble, C. and Pocock, M. R. and Li, P. and Oinn, T.},
+  title        = {Taverna: a tool for building and running workflows of services.},
+  journal      = {Nucleic Acids Res},
+  year         = {2006},
+  volume       = {34},
+  number       = {Web Server issue},
+  pages        = {W729--W732},
+  url          = {http://www.ncbi.nlm.nih.gov/pubmed/16845108},
+}

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -98,6 +98,57 @@ class PublicationsControllerTest < ActionController::TestCase
     assert_redirected_to edit_publication_path(assigns(:publication))
   end
 
+  test "should create publication from details" do
+    publication = {
+      :doi => "10.1371/journal.pone.0004803",
+      :title => "Clickstream Data Yields High-Resolution Maps of Science",
+      :abstract => "Intricate maps of science have been created from citation data to visualize the structure of scientific activity. However, most scientific publications are now accessed online. Scholarly web portals record detailed log data at a scale that exceeds the number of all existing citations combined. Such log data is recorded immediately upon publication and keeps track of the sequences of user requests (clickstreams) that are issued by a variety of users across many different domains. Given these advantages of log datasets over citation data, we investigate whether they can produce high-resolution, more current maps of science.",
+      :publication_authors => ["Johan Bollen", "Herbert Van de Sompel", "Aric Hagberg", "Luis Bettencourt", "Ryan Chute", "Marko A. Rodriguez", "Lyudmila Balakireva"],
+      :journal => "Public Library of Science (PLoS)",
+      :published_date => Date.new(2011,3),
+      :project_ids=>[projects(:sysmo_project).id]
+    }
+
+    assert_difference('Publication.count') do
+      post :create, :subaction => "Create", :publication => publication
+    end
+
+    assert_redirected_to edit_publication_path(assigns(:publication))
+    p=assigns(:publication)
+
+    assert_nil p.pubmed_id
+    assert_equal publication[:doi], p.doi
+    assert_equal publication[:title], p.title
+    assert_equal publication[:abstract], p.abstract
+    assert_equal publication[:journal], p.journal
+    assert_equal publication[:published_date], p.published_date
+    assert_equal publication[:publication_authors], p.publication_authors.collect { |author| author.full_name }
+    assert_equal publication[:project_ids], p.projects.collect { |project| project.id }
+  end
+
+  test "should import from bibtex file" do
+    publication = {
+      :title        => "Taverna: a tool for building and running workflows of services.",
+      :journal      => "Nucleic Acids Res",
+      :authors      => [
+        PublicationAuthor.new({ :first_name => "D."   , :last_name => "Hull"        , :author_index => 0}),
+        PublicationAuthor.new({ :first_name => "K."   , :last_name => "Wolstencroft", :author_index => 1}),
+        PublicationAuthor.new({ :first_name => "R."   , :last_name => "Stevens"     , :author_index => 2}),
+        PublicationAuthor.new({ :first_name => "C."   , :last_name => "Goble"       , :author_index => 3}),
+        PublicationAuthor.new({ :first_name => "M. R.", :last_name => "Pocock"      , :author_index => 4}),
+        PublicationAuthor.new({ :first_name => "P."   , :last_name => "Li"          , :author_index => 5}),
+        PublicationAuthor.new({ :first_name => "T."   , :last_name => "Oinn"        , :author_index => 6})
+      ],
+      :published_date => Date.new(2006)
+    }
+    post :create, :subaction => "Import", :publication => { :bibtex_file => fixture_file_upload('files/publication.bibtex') }
+    p = assigns(:publication)
+    assert_equal publication[:title], p.title
+    assert_equal publication[:journal], p.journal
+    assert_equal publication[:authors].collect(&:full_name), p.publication_authors.collect(&:full_name)
+    assert_equal publication[:published_date], p.published_date
+  end
+
   test "should only show the year for 1st Jan" do
     publication = Factory(:publication,:published_date=>Date.new(2013,1,1))
     get :show,:id=>publication


### PR DESCRIPTION
HITS-SDBV/seek#3
The two commits should explain sufficiently what the pull-request contains
In short: a bibtex file can be uploaded in the 'publications/new' view and the form to create a publication manually will be populated; from there it is as if a publication would be created manually
Additionally, all publications can be exported in different formats through the /publications.{format} route; an export link will be added later (once the query parameters are available)
The publications controller is reorganized a bit.
There are also some tests for the Publication.extract_{...}_metadata functions now