### PR TITLE
Publication import multiple

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -33,6 +33,7 @@
 *= require jquery-ui-drag-drop
 *= require bootstrap-typeahead
 *= require bootstrap-tagsinput
+*= require bootstrap-multiselect
 *= require calendar_date_select/default
 *= require organisms
 *= require tweaks

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -141,12 +141,12 @@ class Publication < ActiveRecord::Base
 
   # @param bibtex_record BibTeX entity from bibtex-ruby gem
   def extract_bibtex_metadata(bibtex_record)
-    self.title           = bibtex_record.title
-    self.abstract        = bibtex_record[:abstract] || ""
-    self.journal         = bibtex_record.journal
+    self.title           = bibtex_record.title.try(:to_s)
+    self.abstract        = bibtex_record[:abstract].try(:to_s) || ""
+    self.journal         = bibtex_record.journal.try(:to_s)
     self.published_date  = Date.new( bibtex_record.year.try(:to_i), bibtex_record.month_numeric || 1, bibtex_record[:day].try(:to_i) || 1 )
-    self.doi             = bibtex_record[:doi]
-    self.pubmed_id       = bibtex_record[:pubmed_id]
+    self.doi             = bibtex_record[:doi].try(:to_s)
+    self.pubmed_id       = bibtex_record[:pubmed_id].try(:to_s)
     plain_authors = bibtex_record[:author].split(" and ") # by bibtex definition
     plain_authors.each_with_index do |author, index| # multiselect
       if author.empty?
@@ -273,7 +273,7 @@ class Publication < ActiveRecord::Base
       if !existing.empty?
         matching_projects = existing.collect(&:projects).flatten.uniq & projects
         if !matching_projects.empty?
-          self.errors[:base] << "You cannot register the same DOI within the same project"
+          self.errors[:doi] << "You cannot register the same DOI within the same project"
           return false
         end
       end
@@ -283,7 +283,7 @@ class Publication < ActiveRecord::Base
       if !existing.empty?
         matching_projects = existing.collect(&:projects).flatten.uniq & projects
         if !matching_projects.empty?
-          self.errors[:base] << "You cannot register the same PubMed ID within the same project"
+          self.errors[:pubmed_id] << "You cannot register the same PubMed ID within the same project"
           return false
         end
       end
@@ -296,7 +296,7 @@ class Publication < ActiveRecord::Base
     if !existing.empty?
       matching_projects = existing.collect(&:projects).flatten.uniq & projects
       if !matching_projects.empty?
-        self.errors[:base] << "You cannot register the same Title within the same project"
+        self.errors[:title] << "You cannot register the same Title \"#{self.title}\" within the same project: \"#{matching_projects[0].title}\""
         return false
       end
     end

--- a/app/views/publications/new.html.erb
+++ b/app/views/publications/new.html.erb
@@ -57,9 +57,9 @@
 <%= form_for @publication, :html => { :class => 'form-horizontal' } do |publication_form| %>
   <%= publication_form.hidden_field :parent_name %>
   <div class="form-group">
-  <%= label_tag :project_ids, 'Projects', :class => 'control-label col-sm-2' %>
-  <div class="col-sm-10">
-      <%= publication_form.collection_select :project_ids, User.current_user.person.projects, :id, :title, {}, :class => 'form-control', :multiple => 'multiple' %>
+    <%= label_tag :project_ids, 'Projects', :class => 'control-label col-sm-2' %>
+    <div class="col-sm-10">
+      <%= publication_form.collection_select :project_ids, User.current_user.person.projects, :id, :title, {}, :class => 'form-control projects-multiselect', :multiple => 'multiple' %>
     </div>
   </div>
   <div class="form-group">
@@ -136,8 +136,12 @@
 
 <div role="tabpanel" class="tab-pane" id="Import">
   <%= form_for @publication, :html => { :class => 'form-horizontal' } do |publication_form| %>
-    <div class="col-sm-12">
-      <p>On successful import, the 'Enter manually' tab will be opened and the form will be populated with the data from the imported file.</p>
+    <%= publication_form.hidden_field :parent_name %>
+    <div class="form-group">
+      <%= label_tag :project_ids, 'Projects', :class => 'control-label col-sm-2' %>
+      <div class="col-sm-10">
+        <%= publication_form.collection_select :project_ids, User.current_user.person.projects, :id, :title, {}, :class => 'form-control projects-multiselect', :multiple => 'multiple' %>
+      </div>
     </div>
     <div class="form-group">
       <%= label_tag :bibtex_file, nil, :class => 'control-label col-sm-2' %>
@@ -146,9 +150,19 @@
       </div>
     </div>
     <div class="form-group">
-      <div class="col-sm-2 col-sm-offset-2">
-        <%= publication_form.submit 'Import', :name => "subaction", :value => 'Import', :class => 'btn btn-primary' %>
+      <div class="col-sm-5 col-sm-offset-2">
+        <p>On successful import, the 'Enter manually' tab will be opened and the form will be populated with the data from the first article from the imported file.</p>
       </div>
+      <div class="col-sm-5">
+        <p>On successful import, all publications will be saved. Any changes will need to be made inidividually afterwards.</p>
+      </div>
+      <div class="col-sm-5 col-sm-offset-2">
+        <%= publication_form.button 'Import first', :name => "subaction", :value => 'Import', :class => 'btn btn-primary' %>
+      </div>
+      <div class="col-sm-5">
+        <%= publication_form.button 'Import all', :name => "subaction", :value => 'ImportMultiple', :class => 'btn btn-primary' %>
+      </div>
+
     </div>
   <% end %>
 </div>
@@ -210,7 +224,7 @@ jQuery(document).ready(function() {
   // activate popovers
   jQuery('[data-toggle="popover"]').popover();
   
-  jQuery('div[id="Create"] select[id="publication_project_ids"]').multiselect({
+  jQuery('select.projects-multiselect').multiselect({
     enableCaseInsensitiveFiltering: true
   });
   

--- a/test/fixtures/files/publications.bibtex
+++ b/test/fixtures/files/publications.bibtex
@@ -1,0 +1,16 @@
+@article{PMID:16845108,
+  author       = {Hull, D. and Wolstencroft, K. and Stevens, R. and Goble, C. and Pocock, M. R. and Li, P. and Oinn, T.},
+  title        = {Taverna: a tool for building and running workflows of services.},
+  journal      = {Nucleic Acids Res},
+  year         = {2006},
+  volume       = {34},
+  number       = {Web Server issue},
+  pages        = {W729--W732},
+  url          = {http://www.ncbi.nlm.nih.gov/pubmed/16845108},
+}
+@article{PMID:,
+  author       = {Shmoe, J. and Mustermann, M.},
+  title        = {Yet another tool for importing publications},
+  journal      = {The second best journal},
+  year         = {2016}
+}

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -148,6 +148,46 @@ class PublicationsControllerTest < ActionController::TestCase
     assert_equal publication[:authors].collect(&:full_name), p.publication_authors.collect(&:full_name)
     assert_equal publication[:published_date], p.published_date
   end
+  
+  test "should import multiple from bibtex file" do
+    publications = [{
+      :title        => "Taverna: a tool for building and running workflows of services.",
+      :journal      => "Nucleic Acids Res",
+      :authors      => [
+        PublicationAuthor.new({ :first_name => "D."   , :last_name => "Hull"        , :author_index => 0}),
+        PublicationAuthor.new({ :first_name => "K."   , :last_name => "Wolstencroft", :author_index => 1}),
+        PublicationAuthor.new({ :first_name => "R."   , :last_name => "Stevens"     , :author_index => 2}),
+        PublicationAuthor.new({ :first_name => "C."   , :last_name => "Goble"       , :author_index => 3}),
+        PublicationAuthor.new({ :first_name => "M. R.", :last_name => "Pocock"      , :author_index => 4}),
+        PublicationAuthor.new({ :first_name => "P."   , :last_name => "Li"          , :author_index => 5}),
+        PublicationAuthor.new({ :first_name => "T."   , :last_name => "Oinn"        , :author_index => 6})
+      ],
+      :published_date => Date.new(2006)
+    },
+    {
+      :authors        => [
+        PublicationAuthor.new({ :first_name => "J."   , :last_name => "Shmoe"     , :author_index => 0}),
+        PublicationAuthor.new({ :first_name => "M."   , :last_name => "Mustermann", :author_index => 1}),
+      ],
+      :title          => "Yet another tool for importing publications",
+      :journal        => "The second best journal",
+      :published_date =>  Date.new(2016)
+    }]
+    assert_difference('Publication.count',2) do
+      post :create, :subaction => "ImportMultiple", :publication => { :bibtex_file => fixture_file_upload('files/publications.bibtex'), :project_ids => [projects(:one).id] }
+      publication0 = Publication.find_by_title(publications[0][:title])
+      assert_not_nil publication0
+      assert_equal publications[0][:journal], publication0.journal
+      assert_equal publications[0][:authors].collect(&:full_name), publication0.publication_authors.collect(&:full_name)
+      assert_equal publications[0][:published_date], publication0.published_date
+      
+      publication1 = Publication.find_by_title(publications[1][:title])
+      assert_not_nil publication1
+      assert_equal publications[1][:journal], publication1.journal
+      assert_equal publications[1][:authors].collect(&:full_name), publication1.publication_authors.collect(&:full_name)
+      assert_equal publications[1][:published_date], publication1.published_date
+    end
+  end
 
   test "should only show the year for 1st Jan" do
     publication = Factory(:publication,:published_date=>Date.new(2013,1,1))


### PR DESCRIPTION
Allow for importing of multiple @article from a single uploaded bibtex file
-The new publication with the 'Import from file' tab has an additional submit action, which will parse the bibtex file for all articles and will create a Publication entity for each of them (if possible)
-additionally, the application.css contains the bootstrap-multiple.css for the correct styling of the multi-select element