### PR TITLE
fix for HITS-SDBV/seek#7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -716,7 +716,7 @@ GEM
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    sqlite3 (1.3.10)
+    sqlite3 (1.3.12)
     sunspot (2.2.0)
       pr_geohash (~> 1.0)
       rsolr (~> 1.0.7)

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -142,12 +142,12 @@ class Publication < ActiveRecord::Base
 
   # @param bibtex_record BibTeX entity from bibtex-ruby gem
   def extract_bibtex_metadata(bibtex_record)
-    self.title           = bibtex_record.title.try(:to_s)
-    self.abstract        = bibtex_record[:abstract].try(:to_s) || ""
-    self.journal         = bibtex_record.journal.try(:to_s)
+    self.title           = bibtex_record.title.try(:to_s).try(:encode!)
+    self.abstract        = bibtex_record[:abstract].try(:to_s).try(:encode!) || ""
+    self.journal         = bibtex_record.journal.try(:to_s).try(:encode!)
     self.published_date  = Date.new( bibtex_record.year.try(:to_i), bibtex_record.month_numeric || 1, bibtex_record[:day].try(:to_i) || 1 )
-    self.doi             = bibtex_record[:doi].try(:to_s)
-    self.pubmed_id       = bibtex_record[:pubmed_id].try(:to_s)
+    self.doi             = bibtex_record[:doi].try(:to_s).try(:encode!)
+    self.pubmed_id       = bibtex_record[:pubmed_id].try(:to_s).try(:encode!)
     plain_authors = bibtex_record[:author].split(" and ") # by bibtex definition
     plain_authors.each_with_index do |author, index| # multiselect
       if author.empty?
@@ -156,8 +156,8 @@ class Publication < ActiveRecord::Base
       last_name, first_name = author.split(", ") # by bibtex definition
       pa = PublicationAuthor.new({
         :publication  => self,
-        :first_name   => first_name,
-        :last_name    => last_name,
+        :first_name   => first_name.try(:encode),
+        :last_name    => last_name.try(:encode),
         :author_index => index
       })
       self.publication_authors << pa

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -174,20 +174,22 @@ class PublicationsControllerTest < ActionController::TestCase
       :journal        => "The second best journal",
       :published_date =>  Date.new(2016)
     }]
+
     assert_difference('Publication.count',2) do
       post :create, :subaction => "ImportMultiple", :publication => { :bibtex_file => fixture_file_upload('files/publications.bibtex'), :project_ids => [projects(:one).id] }
-      publication0 = Publication.find_by_title(publications[0][:title])
-      assert_not_nil publication0
-      assert_equal publications[0][:journal], publication0.journal
-      assert_equal publications[0][:authors].collect(&:full_name), publication0.publication_authors.collect(&:full_name)
-      assert_equal publications[0][:published_date], publication0.published_date
-      
-      publication1 = Publication.find_by_title(publications[1][:title])
-      assert_not_nil publication1
-      assert_equal publications[1][:journal], publication1.journal
-      assert_equal publications[1][:authors].collect(&:full_name), publication1.publication_authors.collect(&:full_name)
-      assert_equal publications[1][:published_date], publication1.published_date
     end
+
+    publication0 = Publication.where( title: publications[0][:title]).first
+    assert_not_nil publication0
+    assert_equal publications[0][:journal], publication0.journal
+    assert_equal publications[0][:authors].collect(&:full_name), publication0.publication_authors.collect(&:full_name)
+    assert_equal publications[0][:published_date], publication0.published_date
+
+    publication1 = Publication.where( title: publications[1][:title]).first
+    assert_not_nil publication1
+    assert_equal publications[1][:journal], publication1.journal
+    assert_equal publications[1][:authors].collect(&:full_name), publication1.publication_authors.collect(&:full_name)
+    assert_equal publications[1][:published_date], publication1.published_date
   end
 
   test "should only show the year for 1st Jan" do


### PR DESCRIPTION
it seems that the encoding of the strings coming from a bibtex import is not quite correct - and sqlite will store them as binary - so that querying them does not work on those