### PR TITLE
Add an option to disable users registration

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -69,6 +69,10 @@ class AdminsController < ApplicationController
     Seek::Config.exception_notification_enabled = string_to_boolean params[:exception_notification_enabled]
 
     Seek::Config.hide_details_enabled = string_to_boolean params[:hide_details_enabled]
+
+    Seek::Config.registration_disabled = string_to_boolean params[:registration_disabled]
+    Seek::Config.registration_disabled_description = params[:registration_disabled_description]
+
     Seek::Config.activation_required_enabled = string_to_boolean params[:activation_required_enabled]
 
     Seek::Config.google_analytics_tracker_id = params[:google_analytics_tracker_id]

--- a/app/helpers/homes_helper.rb
+++ b/app/helpers/homes_helper.rb
@@ -11,6 +11,10 @@ module HomesHelper
     Seek::Config.home_description.html_safe
   end
 
+  def registration_disabled_description_text
+    Seek::Config.registration_disabled_description.html_safe
+  end
+
   def imprint_text
     simple_format(auto_link(Seek::Config.imprint_description.html_safe, sanitize: false), {}, sanitize: false)
   end

--- a/app/views/admins/features_enabled.html.erb
+++ b/app/views/admins/features_enabled.html.erb
@@ -31,7 +31,7 @@
                                "Activation required", "Whether activation is required when registering, as an additional check that the person is genuine and provided a correct email address. Since an activation email is sent, you need to make sure email is setup and working") %>
 
     <%= admin_checkbox_setting(:registration_disabled, 1, Seek::Config.registration_disabled,
-                              "Registration disabled", "Whether creating new accounts is disabled. Can be useful with external authentification (e.g. LDAP)",
+                              "Registration disabled", "Whether new accounts creation is disabled. Can be useful in combinaison with external authentification (e.g. LDAP)",
                               :onchange=>toggle_appear_javascript('registration_disabled_textarea')) %>
 
     <div id="registration_disabled_textarea" class="additional_settings" style="<%= show_or_hide_block Seek::Config.registration_disabled -%>">

--- a/app/views/admins/features_enabled.html.erb
+++ b/app/views/admins/features_enabled.html.erb
@@ -1,6 +1,6 @@
 <h1>Enable or disable features</h1>
 
-<%= form_tag :action=>"update_features_enabled" do -%>    
+<%= form_tag :action=>"update_features_enabled" do -%>
     <%= admin_checkbox_setting(:events_enabled, 1,Seek::Config.events_enabled,
                                "#{t('event').pluralize} enabled","Whether the #{t('event').pluralize} are displayed and can be added.") %>
 
@@ -29,6 +29,16 @@
 
     <%= admin_checkbox_setting(:activation_required_enabled, 1, Seek::Config.activation_required_enabled,
                                "Activation required", "Whether activation is required when registering, as an additional check that the person is genuine and provided a correct email address. Since an activation email is sent, you need to make sure email is setup and working") %>
+
+    <%= admin_checkbox_setting(:registration_disabled, 1, Seek::Config.registration_disabled,
+                              "Registration disabled", "Whether creating new accounts is disabled. Can be useful with external authentification (e.g. LDAP)",
+                              :onchange=>toggle_appear_javascript('registration_disabled_textarea')) %>
+
+    <div id="registration_disabled_textarea" class="additional_settings" style="<%= show_or_hide_block Seek::Config.registration_disabled -%>">
+
+      <%= admin_textarea_setting(:registration_disabled_description, Seek::Config.registration_disabled_description,
+                                 "Registration disabled message", "Sets the description text on the registration page when registration is disabled") %>
+    </div>
 
     <%= admin_checkbox_setting(:jws_enabled, 1, Seek::Config.jws_enabled,
                                "JWS Online enabled", "Whether integration with JWS Online is enabled. Enabling this allows simulation of SBML models with JWS Online.",

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -8,47 +8,56 @@
     <% end %>
 <% end -%>
 
-<div class="row">
-  <div class="col-md-5 col-md-push-7">
-    <p>
-      <b>By registering, you are indicating that you have read and agree that:</b>
-      You are responsible for any content that you upload. We receive and store certain types of information whenever you
-      interact with us which we will use only for operational purposes. We will not make
-      personally identifiable data available to third parties without consent.
-      Please contact us if you have any queries about our terms or our privacy policy.
-    </p>
-    <p>
-      If you have previously provided a login and password but didn't select or create a profile, then your details have already been stored
-      and you should Login to continue the registration process.
-    </p>
-  </div>
-  <div class="col-md-7 col-md-pull-5">
-    <%= form_for @user do |f| -%>
 
-
-        <div class="form-group">
-          <label>Login name</label>
-          <%= f.text_field :login, :class => 'form-control' %>
-          <p class="help-block">Login should contain a minimum of 3 characters.</p>
-        </div>
-
-        <div class="form-group">
-          <label>Email address</label>
-          <%= f.text_field :email, :class => 'form-control' %>
-        </div>
-
-        <div class="form-group">
-          <label>Password</label>
-          <%= f.password_field :password, :class => 'form-control' %>
-          <p class="help-block">Password should contain a minimum of 4 characters.</p>
-        </div>
-
-        <div class="form-group">
-          <label>Confirm Password</label>
-          <%= f.password_field :password_confirmation, :class => 'form-control' %>
-        </div>
-
-        <%= submit_tag 'Register', :disable_with=>"Registering...", :class => 'btn btn-primary' %>
-    <% end -%>
+<% if Seek::Config.registration_disabled -%>
+<div class="panel panel-default" id="home_description">
+  <div class="panel-body">
+    <%= registration_disabled_description_text -%>
   </div>
 </div>
+<% else  %>
+  <div class="row">
+    <div class="col-md-5 col-md-push-7">
+      <p>
+        <b>By registering, you are indicating that you have read and agree that:</b>
+        You are responsible for any content that you upload. We receive and store certain types of information whenever you
+        interact with us which we will use only for operational purposes. We will not make
+        personally identifiable data available to third parties without consent.
+        Please contact us if you have any queries about our terms or our privacy policy.
+      </p>
+      <p>
+        If you have previously provided a login and password but didn't select or create a profile, then your details have already been stored
+        and you should Login to continue the registration process.
+      </p>
+    </div>
+    <div class="col-md-7 col-md-pull-5">
+      <%= form_for @user do |f| -%>
+
+
+          <div class="form-group">
+            <label>Login name</label>
+            <%= f.text_field :login, :class => 'form-control' %>
+            <p class="help-block">Login should contain a minimum of 3 characters.</p>
+          </div>
+
+          <div class="form-group">
+            <label>Email address</label>
+            <%= f.text_field :email, :class => 'form-control' %>
+          </div>
+
+          <div class="form-group">
+            <label>Password</label>
+            <%= f.password_field :password, :class => 'form-control' %>
+            <p class="help-block">Password should contain a minimum of 4 characters.</p>
+          </div>
+
+          <div class="form-group">
+            <label>Confirm Password</label>
+            <%= f.password_field :password_confirmation, :class => 'form-control' %>
+          </div>
+
+          <%= submit_tag 'Register', :disable_with=>"Registering...", :class => 'btn btn-primary' %>
+      <% end -%>
+    </div>
+  </div>
+<% end -%>

--- a/config/initializers/seek_configuration.rb-biovel
+++ b/config/initializers/seek_configuration.rb-biovel
@@ -21,6 +21,8 @@ SEEK::Application.configure do
   Seek::Config.default :exception_notification_enabled,false
   Seek::Config.default :exception_notification_recipients,""
   Seek::Config.default :hide_details_enabled,false
+  Seek::Config.default :registration_disabled,false
+  Seek::Config.default :registration_disabled_description,'Registration is not available, please contact your administrator'
   Seek::Config.default :activation_required_enabled,false
   Seek::Config.default :google_analytics_enabled, false
   Seek::Config.default :google_analytics_tracker_id, '000-000'
@@ -159,4 +161,3 @@ SEEK::Application.configure do
 
   Seek::Config.default :front_page_buttons_enabled, false
 end
-

--- a/config/initializers/seek_configuration.rb-openseek
+++ b/config/initializers/seek_configuration.rb-openseek
@@ -22,6 +22,8 @@ SEEK::Application.configure do
   Seek::Config.default :exception_notification_enabled,false
   Seek::Config.default :exception_notification_recipients,""
   Seek::Config.default :hide_details_enabled,false
+  Seek::Config.default :registration_disabled,false
+  Seek::Config.default :registration_disabled_description,'Registration is not available, please contact your administrator'
   Seek::Config.default :activation_required_enabled,false
   Seek::Config.default :google_analytics_enabled, false
   Seek::Config.default :google_analytics_tracker_id, '000-000'
@@ -155,7 +157,7 @@ SEEK::Application.configure do
 
   #MERGENOTE - remove this from config and replace with alternative partial
   Seek::Config.default :seek_video_link, "http://www.youtube.com/user/elinawetschHITS?feature=mhee#p/u"
-  
+
   # Set default permissions
   Seek::Config.default :default_associated_projects_access_type, Policy::ACCESSIBLE
   Seek::Config.default :default_consortium_access_type, Policy::VISIBLE

--- a/config/initializers/seek_configuration.rb-vln
+++ b/config/initializers/seek_configuration.rb-vln
@@ -22,6 +22,8 @@ SEEK::Application.configure do
   Seek::Config.default :exception_notification_enabled,false
   Seek::Config.default :exception_notification_recipients,""
   Seek::Config.default :hide_details_enabled,false
+  Seek::Config.default :registration_disabled,false
+  Seek::Config.default :registration_disabled_description,'Registration is not available, please contact your administrator'
   Seek::Config.default :activation_required_enabled,false
   Seek::Config.default :google_analytics_enabled, false
   Seek::Config.default :google_analytics_tracker_id, '000-000'
@@ -162,4 +164,3 @@ SEEK::Application.configure do
 
   Seek::Config.default :front_page_buttons_enabled, false
 end
-

--- a/lib/seek/config_setting_attributes.yml
+++ b/lib/seek/config_setting_attributes.yml
@@ -1,4 +1,4 @@
-#keys that create the Seek::Config settigs.
+#keys that create the Seek::Config settings.
 #e.g. Seek::Config.home_description
 
 # N.B. Settings that require a conversion to integer should NOT be set here.
@@ -14,6 +14,8 @@ jws_online_root:
 internal_help_enabled:
 external_help_url:
 hide_details_enabled:
+registration_disabled:
+registration_disabled_description:
 activation_required_enabled:
 project_name:
 smtp:
@@ -173,4 +175,3 @@ omniauth_enabled:
 omniauth_user_create:
 omniauth_user_activate:
 omniauth_providers:
-

--- a/test/functional/admins_controller_test.rb
+++ b/test/functional/admins_controller_test.rb
@@ -151,7 +151,7 @@ class AdminsControllerTest < ActionController::TestCase
     login_as(:quentin)
     quentin=people(:quentin_person)
     aaron=people(:aaron_person)
-    
+
     assert quentin.is_admin?
     assert !aaron.is_admin?
 

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -318,7 +318,7 @@ end
       assert_equal 'http', Seek::Config.host_scheme
     end
   end
-  
+
   test 'copyright_addendum_enabled' do
     assert !Seek::Config.copyright_addendum_enabled
   end
@@ -395,6 +395,12 @@ end
     assert_equal 'You can configure the text that goes here within the Admin pages: Site Configuration->Home page settings.', Seek::Config.home_description
     Seek::Config.home_description = 'A new description'
     assert_equal 'A new description', Seek::Config.home_description
+  end
+
+  test 'registration_disabled_description' do
+    assert_equal 'Registration is not available, please contact your administrator', Seek::Config.registration_disabled_description
+    Seek::Config.registration_disabled_description = 'A new description'
+    assert_equal 'A new description', Seek::Config.registration_disabled_description
   end
 
   test 'sabiork_ws_base_url' do


### PR DESCRIPTION
Hello,

 I think it's important to disable the public registration. For example when we want limit the number of users or when we use an external authentification (e.g. LDAP).

So I've added an option in the admin panel in order to disable the registration. This plugin replace the registration form by a message. This message can be modify in the option.