### PR TITLE
bugfix: footer does not cover part of the content anymore in IE

### DIFF
--- a/app/assets/stylesheets/new_styles.css.scss
+++ b/app/assets/stylesheets/new_styles.css.scss
@@ -94,7 +94,6 @@ ul.feed .file-type-icon img {
   position: absolute;
   text-align: center;
   right: 0;
-  bottom: 0;
   left: 0;
   margin-top: 2em;
   padding: 1em 0.5em;


### PR DESCRIPTION
Before, lower parts of the content were not shown in internet explorer (tested with IE11). That made some forms (e.g. "Edit Profile") unusable, because the update and cancel buttons were not visible. All other browsers worked as expected.

The reason was that the footer covered parts of the content in IE.

The solution is to get rid of the "bottom: 0px;" style for id "#ft".