### PR TITLE
Link DOIs to preferred resolver

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -4,5 +4,5 @@ Katherine Wolstencroft, Stuart Owen, Olga Krebs, Quyen Nguyen, Natalie J Stanfor
 SEEK: a systems biology data and model management platform
 BMC Systems Biology  2015 9:33
 doi:10.1186/s12918-015-0174-y
-http://dx.doi.org/10.1186/s12918-015-0174-y
+https://doi.org/10.1186/s12918-015-0174-y
 

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -81,7 +81,7 @@ class Publication < ActiveRecord::Base
   end
 
   def doi_uri
-    "https://dx.doi.org/#{doi}" if doi
+    "https://doi.org/#{doi}" if doi
   end
 
   # Automatically extract the actual DOI if the user put in the full URL

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -86,7 +86,7 @@ class Publication < ActiveRecord::Base
 
   # Automatically extract the actual DOI if the user put in the full URL
   def doi=(doi)
-    doi = doi.gsub(/(https?:\/\/)?dx\.doi\.org\//,'') if doi
+    doi = doi.gsub(/(https?:\/\/)?(dx\.)?doi\.org\//,'') if doi
     super(doi)
   end
 

--- a/app/serializers/publication_serializer.rb
+++ b/app/serializers/publication_serializer.rb
@@ -7,7 +7,7 @@ class PublicationSerializer < BaseSerializer
     if :pubmed_id
       'https://www.ncbi.nlm.nih.gov/pubmed/' + object.pubmed_id.to_s
     elsif :doi
-      'http://dx.doi.org/' + object.doi.to_s
+      'https://doi.org/' + object.doi.to_s
     else
       ''
     end

--- a/app/views/publications/new.html.erb
+++ b/app/views/publications/new.html.erb
@@ -311,7 +311,7 @@ jQuery(document).ready(function() {
     e.preventDefault(); // prevent the default form submit action
 
     var doi = jQuery('#publication_doi').val();
-    doi = doi.replace(/^https?:\/\/(dx\.)?doi\.org/, '');
+    doi = doi.replace(/^(https?:\/\/)?(dx\.)?doi\.org/, '');
 
     jQuery.ajax({
       url: 'https://doi.org/' + doi,

--- a/app/views/publications/new.html.erb
+++ b/app/views/publications/new.html.erb
@@ -314,7 +314,7 @@ jQuery(document).ready(function() {
     doi = doi.replace(/^http:\/\/dx\.doi\.org/, '');
 
     jQuery.ajax({
-      url: 'https://dx.doi.org/' + doi,
+      url: 'https://doi.org/' + doi,
       accepts: { 'citeproc': "application/vnd.citationstyles.csl+json" },
       dataType: 'json',
       success: function(data, textStatus, jqXHR) {

--- a/app/views/publications/new.html.erb
+++ b/app/views/publications/new.html.erb
@@ -311,7 +311,7 @@ jQuery(document).ready(function() {
     e.preventDefault(); // prevent the default form submit action
 
     var doi = jQuery('#publication_doi').val();
-    doi = doi.replace(/^http:\/\/dx\.doi\.org/, '');
+    doi = doi.replace(/^https?:\/\/(dx\.)?doi\.org/, '');
 
     jQuery.ajax({
       url: 'https://doi.org/' + doi,

--- a/db/seeds/sample_attribute_types.seeds.rb
+++ b/db/seeds/sample_attribute_types.seeds.rb
@@ -46,7 +46,7 @@ uri_type = SampleAttributeType.find_or_initialize_by(title:'URI')
 uri_type.update_attributes(base_type: Seek::Samples::BaseType::STRING, regexp: URI.regexp.to_s, placeholder: 'http://www.example.com/123', resolution:'\\0')
 
 doi_type = SampleAttributeType.find_or_initialize_by(title:'DOI')
-doi_type.update_attributes(base_type: Seek::Samples::BaseType::STRING, regexp: '(DOI:)?(.*)', placeholder: 'DOI:10.1109/5.771073', resolution:'https://dx.doi.org/\\2')
+doi_type.update_attributes(base_type: Seek::Samples::BaseType::STRING, regexp: '(DOI:)?(.*)', placeholder: 'DOI:10.1109/5.771073', resolution:'https://doi.org/\\2')
 
 puts "Seeded #{SampleAttributeType.count - count} sample attribute types"
 

--- a/lib/seek/citation_generator.rb
+++ b/lib/seek/citation_generator.rb
@@ -17,7 +17,7 @@ module Seek
 
     def csl
       Rails.cache.fetch("citation-#{@doi}") do
-        resp = RestClient.get("https://dx.doi.org/#{@doi}", accept: 'application/vnd.citationstyles.csl+json')
+        resp = RestClient.get("https://doi.org/#{@doi}", accept: 'application/vnd.citationstyles.csl+json')
         JSON.parse(resp)
       end
     end

--- a/test/factories/publications.rb
+++ b/test/factories/publications.rb
@@ -15,7 +15,7 @@ Factory.define(:max_publication, class: Publication) do |f|
   f.title 'A Maximal Publication'
   f.journal 'Journal of Molecular Biology'
   f.published_date '2017-10-10'
-  f.doi 'http://dx.doi.org/10.5072/abcd'
+  f.doi 'https://doi.org/10.5072/abcd'
   f.pubmed_id '873864488'
   f.citation 'JMB Oct 2017, 12:234-245'
   f.publication_authors {[Factory(:publication_author), Factory(:publication_author)]}

--- a/test/functional/models_controller_test.rb
+++ b/test/functional/models_controller_test.rb
@@ -1179,11 +1179,11 @@ class ModelsControllerTest < ActionController::TestCase
         .with(headers: { 'Accept' => 'application/vnd.citationstyles.csl+json' })
         .to_return(body: File.new("#{Rails.root}/test/fixtures/files/mocking/doi_metadata.json"), status: 200)
 
-    stub_request(:get, 'https://dx.doi.org/10.5072/test')
+    stub_request(:get, 'https://doi.org/10.5072/test')
         .with(headers: { 'Accept' => 'application/vnd.citationstyles.csl+json' })
         .to_return(body: File.new("#{Rails.root}/test/fixtures/files/mocking/doi_metadata.json"), status: 200)
 
-    stub_request(:get, 'https://dx.doi.org/10.5072/broken')
+    stub_request(:get, 'https://doi.org/10.5072/broken')
         .with(headers: { 'Accept' => 'application/vnd.citationstyles.csl+json' })
         .to_return(body: File.new("#{Rails.root}/test/fixtures/files/mocking/broken_doi_metadata_response.html"), status: 200)
   end

--- a/test/functional/models_controller_test.rb
+++ b/test/functional/models_controller_test.rb
@@ -1175,7 +1175,7 @@ class ModelsControllerTest < ActionController::TestCase
   end
 
   def doi_citation_mock
-    stub_request(:get, /https:\/\/dx\.doi\.org\/.+/)
+    stub_request(:get, /(https?:\/\/)?(dx\.)?doi\.org\/.+/)
         .with(headers: { 'Accept' => 'application/vnd.citationstyles.csl+json' })
         .to_return(body: File.new("#{Rails.root}/test/fixtures/files/mocking/doi_metadata.json"), status: 200)
 

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -782,7 +782,7 @@ class PublicationsControllerTest < ActionController::TestCase
 
     assert_difference('Publication.count') do
       post :create, publication: { project_ids: ['', project.id.to_s],
-                                   doi: 'http://dx.doi.org/10.5072/abcd',
+                                   doi: 'https://doi.org/10.5072/abcd',
                                    title: 'Cool stuff',
                                    publication_authors: ['', User.current_user.person.name],
                                    abstract: 'We did stuff',

--- a/test/functional/sops_controller_test.rb
+++ b/test/functional/sops_controller_test.rb
@@ -1025,11 +1025,11 @@ class SopsControllerTest < ActionController::TestCase
         .with(headers: { 'Accept' => 'application/vnd.citationstyles.csl+json' })
         .to_return(body: File.new("#{Rails.root}/test/fixtures/files/mocking/doi_metadata.json"), status: 200)
 
-    stub_request(:get, 'https://dx.doi.org/10.5072/test')
+    stub_request(:get, 'https://doi.org/10.5072/test')
         .with(headers: { 'Accept' => 'application/vnd.citationstyles.csl+json' })
         .to_return(body: File.new("#{Rails.root}/test/fixtures/files/mocking/doi_metadata.json"), status: 200)
 
-    stub_request(:get, 'https://dx.doi.org/10.5072/broken')
+    stub_request(:get, 'https://doi.org/10.5072/broken')
         .with(headers: { 'Accept' => 'application/vnd.citationstyles.csl+json' })
         .to_return(body: File.new("#{Rails.root}/test/fixtures/files/mocking/broken_doi_metadata_response.html"), status: 200)
   end

--- a/test/functional/sops_controller_test.rb
+++ b/test/functional/sops_controller_test.rb
@@ -1021,7 +1021,7 @@ class SopsControllerTest < ActionController::TestCase
   private
 
   def doi_citation_mock
-    stub_request(:get, /https:\/\/dx\.doi\.org\/.+/)
+    stub_request(:get, /(https?:\/\/)?(dx\.)?doi\.org\/.+/)
         .with(headers: { 'Accept' => 'application/vnd.citationstyles.csl+json' })
         .to_return(body: File.new("#{Rails.root}/test/fixtures/files/mocking/doi_metadata.json"), status: 200)
 

--- a/test/mock_helper.rb
+++ b/test/mock_helper.rb
@@ -63,11 +63,11 @@ module MockHelper
       .with(headers: { 'Accept' => 'application/vnd.citationstyles.csl+json' })
       .to_return(body: File.new("#{Rails.root}/test/fixtures/files/mocking/doi_metadata.json"), status: 200)
 
-    stub_request(:get, 'https://dx.doi.org/10.5072/test')
+    stub_request(:get, 'https://doi.org/10.5072/test')
       .with(headers: { 'Accept' => 'application/vnd.citationstyles.csl+json' })
       .to_return(body: File.new("#{Rails.root}/test/fixtures/files/mocking/doi_metadata.json"), status: 200)
 
-    stub_request(:get, 'https://dx.doi.org/10.5072/broken')
+    stub_request(:get, 'https://doi.org/10.5072/broken')
       .with(headers: { 'Accept' => 'application/vnd.citationstyles.csl+json' })
       .to_return(body: File.new("#{Rails.root}/test/fixtures/files/mocking/broken_doi_metadata_response.html"), status: 200)
   end

--- a/test/mock_helper.rb
+++ b/test/mock_helper.rb
@@ -59,7 +59,7 @@ module MockHelper
   end
 
   def doi_citation_mock
-    stub_request(:get, /https:\/\/dx\.doi\.org\/.+/)
+    stub_request(:get, /(https?:\/\/)?(dx\.)?doi\.org\/.+/)
       .with(headers: { 'Accept' => 'application/vnd.citationstyles.csl+json' })
       .to_return(body: File.new("#{Rails.root}/test/fixtures/files/mocking/doi_metadata.json"), status: 200)
 

--- a/test/unit/publication_test.rb
+++ b/test/unit/publication_test.rb
@@ -415,11 +415,11 @@ class PublicationTest < ActiveSupport::TestCase
     assert pub.valid?
     assert_equal '10.5072/abc', pub.doi
 
-    pub.doi = 'http://dx.doi.org/10.5072/abc'
+    pub.doi = 'https://doi.org/10.5072/abc'
     assert pub.valid?
     assert_equal '10.5072/abc', pub.doi
 
-    pub.doi = 'https://dx.doi.org/10.5072/abc'
+    pub.doi = 'https://doi.org/10.5072/abc'
     assert pub.valid?
     assert_equal '10.5072/abc', pub.doi
 

--- a/test/unit/publication_test.rb
+++ b/test/unit/publication_test.rb
@@ -419,7 +419,15 @@ class PublicationTest < ActiveSupport::TestCase
     assert pub.valid?
     assert_equal '10.5072/abc', pub.doi
 
-    pub.doi = 'https://doi.org/10.5072/abc'
+    pub.doi = 'https://dx.doi.org/10.5072/abc'
+    assert pub.valid?
+    assert_equal '10.5072/abc', pub.doi
+
+    pub.doi = 'http://dx.doi.org/10.5072/abc'
+    assert pub.valid?
+    assert_equal '10.5072/abc', pub.doi
+
+    pub.doi = 'http://doi.org/10.5072/abc'
     assert pub.valid?
     assert_equal '10.5072/abc', pub.doi
 

--- a/test/unit/research_objects/json_metadata_test.rb
+++ b/test/unit/research_objects/json_metadata_test.rb
@@ -48,7 +48,7 @@ class JsonMetaTest < ActiveSupport::TestCase
     assert_empty json['contains']
 
     assert_equal '10.1111/ecog.01552', json['doi']
-    assert_equal 'https://dx.doi.org/10.1111/ecog.01552', json['doi_uri']
+    assert_equal 'https://doi.org/10.1111/ecog.01552', json['doi_uri']
     assert_nil json['pubmed_id']
     assert_nil json['pubmed_uri']
 


### PR DESCRIPTION
related to #29

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). This PR implements that recommendation by updating static DOI links, as well as code that generates new ones.

Since I updated some test code as well, please let me know if that depends on external services who still answer with the "old" resolver URL, and I'll revert that part.

Cheers :-)