### PR TITLE
Fixing issues with Obis Sync

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'rails', '~> 4.2.11'
 gem 'rdoc'
 
 #database adaptors
-gem 'mysql2'
+gem 'mysql2', '0.4.10'
 gem 'pg'
 gem 'sqlite3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -415,7 +415,7 @@ GEM
     multi_json (1.12.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
-    mysql2 (0.4.5)
+    mysql2 (0.4.10)
     namae (0.11.3)
     nenv (0.3.0)
     nesty (1.0.2)
@@ -846,7 +846,7 @@ DEPENDENCIES
   minitest-reporters
   my_annotations!
   my_responds_to_parent!
-  mysql2
+  mysql2 (= 0.4.10)
   nokogiri (~> 1.8.1)
   omniauth (~> 1.3.1)
   omniauth-ldap (~> 1.0.5)

--- a/app/models/openbis_endpoint.rb
+++ b/app/models/openbis_endpoint.rb
@@ -11,8 +11,8 @@ class OpenbisEndpoint < ActiveRecord::Base
   validates :web_endpoint, url: { allow_nil: true, allow_blank: true }
   validates :project, :as_endpoint, :dss_endpoint, :web_endpoint, :username,
             :password, :space_perm_id, :refresh_period_mins, :policy, presence: true
-  validates :refresh_period_mins, numericality: { greater_than_or_equal_to: 1 }
-  # validates :refresh_period_mins, numericality: { greater_than_or_equal_to: 60 }
+  # validates :refresh_period_mins, numericality: { greater_than_or_equal_to: 1 }
+  validates :refresh_period_mins, numericality: { greater_than_or_equal_to: 60 }
   validates :space_perm_id, uniqueness: { scope: %i[dss_endpoint as_endpoint space_perm_id project_id],
                                           message: 'the endpoints and the space must be unique for this project' }
 

--- a/app/models/openbis_endpoint.rb
+++ b/app/models/openbis_endpoint.rb
@@ -11,7 +11,8 @@ class OpenbisEndpoint < ActiveRecord::Base
   validates :web_endpoint, url: { allow_nil: true, allow_blank: true }
   validates :project, :as_endpoint, :dss_endpoint, :web_endpoint, :username,
             :password, :space_perm_id, :refresh_period_mins, :policy, presence: true
-  validates :refresh_period_mins, numericality: { greater_than_or_equal_to: 60 }
+  validates :refresh_period_mins, numericality: { greater_than_or_equal_to: 1 }
+  # validates :refresh_period_mins, numericality: { greater_than_or_equal_to: 60 }
   validates :space_perm_id, uniqueness: { scope: %i[dss_endpoint as_endpoint space_perm_id project_id],
                                           message: 'the endpoints and the space must be unique for this project' }
 


### PR DESCRIPTION
Firstly syn job now runs as the user who registered an asset so that depending assays/datafiles can be created.
Secondly improved error handling so that the messages are more meangful and better propagate.