### PR TITLE
Ensure Gender neutral They instead of he/she in email template

### DIFF
--- a/app/views/mailer/request_contact.text.erb
+++ b/app/views/mailer/request_contact.text.erb
@@ -3,7 +3,7 @@ Hi <%= @owners.collect{|o| o.name}.join(", ") -%>,
 
   The <%= Seek::Config.application_name %> user <%= @requester.name -%>, <%= person_url(@requester) -%>, has interest in the file "<%= @resource.title -%>": <%= url_for(:action=>:show,:controller=>controller,:id=>@resource, :only_path => false) -%>.
 
-  He/She would like to initiate a discussion with you.
+  They would like to initiate a discussion with you.
 
 <% unless @details.blank? -%>
   <%=@requester.first_name.capitalize -%> also provided some additional details:

--- a/test/fixtures/mailer/request_contact
+++ b/test/fixtures/mailer/request_contact
@@ -2,7 +2,7 @@ Hi Maximilian Maxi-Mum,
 
   The Sysmo SEEK user Aaron Spiggle, http://localhost:3000/people/-person_id-, has interest in the file "--title--": http://localhost:3000/presentations/-resource_id-.
 
-  He/She would like to initiate a discussion with you.
+  They would like to initiate a discussion with you.
 
   Aaron also provided some additional details:
 

--- a/test/functional/models_controller_test.rb
+++ b/test/functional/models_controller_test.rb
@@ -129,7 +129,7 @@ class ModelsControllerTest < ActionController::TestCase
     assert model.creators.include?(p2)
     assert_select '.list_item_title a[href=?]', model_path(model), 'ZZZZZ', 'the data file for this test should appear as a list item'
 
-    # check for avatars: uploader won't be shown if he/she is not creator
+    # check for avatars: uploader won't be shown if they are not creator
     assert_select '.list_item_avatar' do
       assert_select 'a[href=?]', person_path(p2) do
         assert_select 'img'


### PR DESCRIPTION
Some of the email templates still used "he/she" to talk about a user in third person. Changed to gender-neutral "they" to avoid assumption of binary gender.