### PR TITLE
Handle Ominauth auth failure

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -44,6 +44,10 @@ class SessionsController < ApplicationController
     password_authentication
   end
 
+  def failure
+    failed_login "Invalid username/password.".html_safe
+  end
+
   def destroy
     logout_user
     flash[:notice] = 'You have been logged out.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -720,6 +720,7 @@ SEEK::Application.routes.draw do
   post '/auth/:provider' => 'sessions#create', as: :omniauth_authorize # For security, ONLY POST should be enabled on this route.
   match '/auth/:provider/callback' => 'sessions#create', as: :omniauth_callback, via: [:get, :post] # Callback routes need both GET and POST enabled.
   match '/identities/auth/:provider/callback' => 'sessions#create', via: [:get, :post] # Needed for legacy support..
+  get '/auth/failure' => 'sessions#failure'
 
   get '/activate(/:activation_code)' => 'users#activate', as: :activate
   get '/forgot_password' => 'users#forgot_password', as: :forgot_password


### PR DESCRIPTION
Hi,
This is a fix for #559 : added a route and action to properly handle authentication failure when using omniauth.
Instead of a 404 error, you get an error like that:

![image](https://user-images.githubusercontent.com/238755/117015227-c957c380-acf1-11eb-9664-c79548f11c50.png)

There is no "forgotten your password?" link in this case as we can't guess how the user is supposed to get its forgotten password from the external auth provider.