### PR TITLE
Attempt to add RO-Crate tooltip

### DIFF
--- a/app/views/assets/_asset_buttons.html.erb
+++ b/app/views/assets/_asset_buttons.html.erb
@@ -35,10 +35,11 @@
       <% if asset.content_blob.file_exists? %>
         <%= button_link_to('Download RO Crate', 'ro_crate_file', ro_crate_workflow_path(asset, version: version, code: params[:code])) %>
         <% if asset.can_run? %>
-          <%= button_link_to("Run on #{Seek::Config.galaxy_instance_name || 'Galaxy'}", 'run_galaxy', run_workflow_url(display_asset)) %>
+          <%= button_link_to("Run on #{Seek::Config.galaxy_instance_name || 'Galaxy'}", 'run_galaxy', run_workflow_url(display_asset)),
+              'data-tooltip' => tooltip("The Workflow RO-Crate is a package containing the workflow definition, its metadata and supporting resources like test data") ) %>
         <% end %>
       <% else %>
-        <%= button_link_to('Download RO Crate', 'ro_crate_file', nil,
+        <%= button_link_to('Download RO-Crate', 'ro_crate_file', nil,
                            disabled_reason: 'This workflow is still being processed, check back later.') %>
       <% end %>
     <% else %>

--- a/app/views/assets/_asset_buttons.html.erb
+++ b/app/views/assets/_asset_buttons.html.erb
@@ -33,10 +33,10 @@
   <% if can_download_asset?(asset, params[:code]) -%>
     <% if asset.is_a?(Workflow) %>
       <% if asset.content_blob.file_exists? %>
-        <%= button_link_to('Download RO Crate', 'ro_crate_file', ro_crate_workflow_path(asset, version: version, code: params[:code])) %>
+        <%= button_link_to('Download RO Crate', 'ro_crate_file', ro_crate_workflow_path(asset, version: version, code: params[:code]),
+              'data-tooltip' => tooltip("The Workflow RO-Crate is a package containing the workflow definition, its metadata and supporting resources like test data")) %>
         <% if asset.can_run? %>
-          <%= button_link_to("Run on #{Seek::Config.galaxy_instance_name || 'Galaxy'}", 'run_galaxy', run_workflow_url(display_asset)),
-              'data-tooltip' => tooltip("The Workflow RO-Crate is a package containing the workflow definition, its metadata and supporting resources like test data") ) %>
+          <%= button_link_to("Run on #{Seek::Config.galaxy_instance_name || 'Galaxy'}", 'run_galaxy', run_workflow_url(display_asset)) %>
         <% end %>
       <% else %>
         <%= button_link_to('Download RO-Crate', 'ro_crate_file', nil,


### PR DESCRIPTION
New users of WorkflowHub won't know what is an RO-Crate or that it contains the workflow. This adds a tooltip trying to explain what is included.