### PR TITLE
Debian 10 dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6-stretch
+FROM ruby:2.6-buster
 
 MAINTAINER Stuart Owen <orcid.org/0000-0003-2130-0865>, Finn Bacall
 
@@ -44,9 +44,6 @@ RUN chown -R www-data solr config docker public /var/www db/schema.rb
 USER www-data
 RUN touch config/using-docker #allows us to see within SEEK we are running in a container
 
-# Workaround for deprecated Python 3.5 from Debian base image, 
-# latest compatible cwltool version is from 2020-08
-RUN sed -i s/cwltool.*/cwltool==3.0.20200807132242/ requirements.txt
 # Python dependencies from requirements.txt
 RUN pip3 install -r requirements.txt
 


### PR DESCRIPTION
Use Debian 10 base image ruby:2.6-buster
    
As this has Python 3.7 instead of 3.5 this should fix #646 –  however more testing might be needed as other dependencies also change version. 


So I am making this WIP pull requests to see if the tests work https://github.com/seek4science/seek/runs/2915756586
