### PR TITLE
Cache settings

### DIFF
--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -155,6 +155,6 @@ class Settings < ActiveRecord::Base
   end
 
   def clear_cache
-    Seek::Config.clear_cache if self.target.nil?
+    Seek::Config.clear_cache if target_id.nil? && target_type.nil?
   end
 end

--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -29,6 +29,7 @@ class Settings < ActiveRecord::Base
 
   attr_encrypted :value, key: proc { Seek::Config.attr_encrypted_key }, marshal: true, marshaler: Marshal
   before_save :ensure_no_plaintext, if: :encrypt?
+  after_commit :clear_cache, on: %i[create update destroy]
 
   # Support old plugin
   if defined?(SettingsDefaults::DEFAULTS)
@@ -51,7 +52,7 @@ class Settings < ActiveRecord::Base
     vars = vars.where("var LIKE ?", "'#{starting_with}%'") if starting_with
 
     result = HashWithIndifferentAccess.new
-    vars.each do |record|
+    vars.to_a.each do |record|
       result[record.var] = record.value
     end
     result
@@ -151,5 +152,9 @@ class Settings < ActiveRecord::Base
 
   def ensure_no_plaintext
     self[:value] = nil if will_save_change_to_encrypted_value?
+  end
+
+  def clear_cache
+    Seek::Config.clear_cache if self.target.nil?
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 require_relative 'boot'
 
 require 'rails/all'
+require_relative '../lib/rack/settings_cache'
 
 if defined?(Bundler)
   # If you precompile assets before deploying to production, use this line
@@ -47,6 +48,7 @@ module SEEK
                           include: %w(text/html application/xml application/json text/css application/javascript)
     config.middleware.use Rack::Attack
     config.middleware.use I18n::JS::Middleware
+    config.middleware.use Rack::SettingsCache
 
     config.exceptions_app = self.routes
 

--- a/lib/rack/settings_cache.rb
+++ b/lib/rack/settings_cache.rb
@@ -1,0 +1,15 @@
+module Rack
+  class SettingsCache
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      Seek::Config.enable_cache!
+      response = @app.call(env)
+      Seek::Config.disable_cache!
+
+      response
+    end
+  end
+end

--- a/lib/seek/config.rb
+++ b/lib/seek/config.rb
@@ -168,6 +168,10 @@ module Seek
       end
     end
 
+    def filestore_path
+      'filestore'
+    end
+
     def rdf_filestore_path
       append_filestore_path 'rdf'
     end

--- a/lib/seek/config.rb
+++ b/lib/seek/config.rb
@@ -376,11 +376,12 @@ module Seek
 
     if use_db
       def get_value(setting, conversion = nil)
-        result = Settings.global.fetch(setting)
-        if result
-          val = result.value
+        val = Settings.defaults[setting.to_s]
+        if Thread.current[:use_settings_cache]
+          val = settings_cache[setting] if settings_cache.key?(setting)
         else
-          val = Settings.defaults[setting.to_s]
+          result = Settings.global.fetch(setting)
+          val = result.value if result
         end
         val = val.send(conversion) if conversion && val
         val
@@ -493,6 +494,30 @@ module Seek
 
     def self.schema_org_supported?
       true
+    end
+
+    def self.enable_cache!
+      Thread.current[:use_settings_cache] = true
+    end
+
+    def self.disable_cache!
+      Thread.current[:use_settings_cache] = nil
+    end
+
+    def self.settings_cache
+      RequestStore.fetch(:config_cache) do
+        Rails.cache.fetch(cache_key, expires_in: 1.week) do
+          Settings.global.to_hash
+        end
+      end
+    end
+
+    def self.clear_cache
+      Rails.cache.delete(cache_key)
+    end
+
+    def self.cache_key
+      'seek_config'
     end
   end
 end

--- a/lib/seek/config.rb
+++ b/lib/seek/config.rb
@@ -503,9 +503,15 @@ module Seek
     def self.settings_cache
       RequestStore.fetch(:config_cache) do
         Rails.cache.fetch(cache_key, expires_in: 1.week) do
-          hash = {}
-          Settings.global.to_a.each { |s| hash[s.var] = s }
-          hash
+          cache_setting = Thread.current[:use_settings_cache]
+          begin
+            hash = {}
+            disable_cache! # Disable cache whilst loading settings to prevent infinite loop via `attr_encrypted_key_path`
+            Settings.global.to_a.each { |s| hash[s.var] = s }
+            hash
+          ensure
+            Thread.current[:use_settings_cache] = cache_setting
+          end
         end
       end
     end

--- a/lib/seek/config.rb
+++ b/lib/seek/config.rb
@@ -168,10 +168,6 @@ module Seek
       end
     end
 
-    def filestore_path
-      Rails.env.test? ? 'tmp/testing-filestore' : 'filestore'
-    end
-
     def rdf_filestore_path
       append_filestore_path 'rdf'
     end

--- a/lib/seek/config.rb
+++ b/lib/seek/config.rb
@@ -169,7 +169,7 @@ module Seek
     end
 
     def filestore_path
-      'filestore'
+      Rails.env.test? ? 'tmp/testing-filestore' : 'filestore'
     end
 
     def rdf_filestore_path
@@ -378,11 +378,11 @@ module Seek
       def get_value(setting, conversion = nil)
         val = Settings.defaults[setting.to_s]
         if Thread.current[:use_settings_cache]
-          val = settings_cache[setting] if settings_cache.key?(setting)
+          result = settings_cache[setting]
         else
           result = Settings.global.fetch(setting)
-          val = result.value if result
         end
+        val = result.value if result
         val = val.send(conversion) if conversion && val
         val
       end
@@ -507,7 +507,9 @@ module Seek
     def self.settings_cache
       RequestStore.fetch(:config_cache) do
         Rails.cache.fetch(cache_key, expires_in: 1.week) do
-          Settings.global.to_hash
+          hash = {}
+          Settings.global.to_a.each { |s| hash[s.var] = s }
+          hash
         end
       end
     end

--- a/lib/seek/config_setting_attributes.yml
+++ b/lib/seek/config_setting_attributes.yml
@@ -44,6 +44,7 @@ project_news_feed_urls:
 community_news_enabled:
 community_news_feed_urls:
 blacklisted_feeds:
+filestore_path:
 tagline_prefix:
 modelling_analysis_enabled:
 allow_publications_fulltext:

--- a/lib/seek/config_setting_attributes.yml
+++ b/lib/seek/config_setting_attributes.yml
@@ -44,7 +44,6 @@ project_news_feed_urls:
 community_news_enabled:
 community_news_feed_urls:
 blacklisted_feeds:
-filestore_path:
 tagline_prefix:
 modelling_analysis_enabled:
 allow_publications_fulltext:

--- a/test/unit/settings_cache_test.rb
+++ b/test/unit/settings_cache_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+require 'minitest/mock'
+
+class SettingsCacheTest < ActiveSupport::TestCase
+  class TestCacheExpiryException < StandardError; end # Dummy exception raised via a stub so we can check cache expiry
+
+  test 'adding a setting expires the settings cache' do
+    Seek::Config.stub(:clear_cache, -> () { raise TestCacheExpiryException }) do
+      assert_difference('Settings.count', 1) do
+        assert_raises(TestCacheExpiryException) do
+          Seek::Config.data_files_enabled = true
+        end
+      end
+    end
+  end
+
+  test 'changing a setting expires the settings cache' do
+    Seek::Config.data_files_enabled = false
+    Seek::Config.stub(:clear_cache, -> () { raise TestCacheExpiryException }) do
+      assert_no_difference('Settings.count') do
+        assert_raises(TestCacheExpiryException) do
+          Seek::Config.data_files_enabled = true
+        end
+      end
+    end
+  end
+
+  test 'removing a setting expires the settings cache' do
+    Seek::Config.stub(:clear_cache, -> () { raise TestCacheExpiryException }) do
+      assert_difference('Settings.count', -1) do
+        assert_raises(TestCacheExpiryException) do
+          Settings.global.last.destroy!
+        end
+      end
+    end
+  end
+
+  test 'setting project settings does not expire settings cache' do
+    project = Factory(:project)
+
+    Seek::Config.stub(:clear_cache, -> () { raise 'oh no!' }) do
+      assert_nothing_raised do
+        assert_difference('Settings.count', 1) do
+          project.settings['nels_enabled'] = true
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Stores settings in a cache which is expired whenever they change. Also caches all settings in memory for the duration of the request.

In local production tests it cuts front page load times from ~120ms to ~75ms after cache warming.