### PR TITLE
Signposting profile for RO-Crate zip

### DIFF
--- a/app/controllers/concerns/fair_signposting.rb
+++ b/app/controllers/concerns/fair_signposting.rb
@@ -1,5 +1,7 @@
 module FairSignposting
   extend ActiveSupport::Concern
+  # registered in https://www.iana.org/assignments/profile-uris/profile-uris.xhtml
+  RO_CRATE_PROFILE='https://w3id.org/ro/crate'
 
   def fair_signposting
     parent_asset = resource_for_controller
@@ -18,7 +20,10 @@ module FairSignposting
 
     # item
     if display_asset.respond_to?(:ro_crate)
-      links << [polymorphic_url([:ro_crate, parent_asset], **url_opts), { rel: :item, type: :zip }]
+      ro_crate_url = polymorphic_url([:ro_crate, parent_asset], **url_opts)
+      links << [ro_crate_url, { rel: :item, type: :zip}]
+      # RFC6906 profile to indicate the zip has an RO-Crate
+      links << [RO_CRATE_PROFILE, { rel: :profile, anchor: ro_crate_url}]
     elsif display_asset.respond_to?(:content_blobs) && display_asset.content_blobs.any?
       links << [polymorphic_url([:download, parent_asset], **url_opts), { rel: :item, type: :zip }]
     elsif display_asset.respond_to?(:content_blob) && display_asset.content_blob

--- a/app/controllers/concerns/fair_signposting.rb
+++ b/app/controllers/concerns/fair_signposting.rb
@@ -20,10 +20,7 @@ module FairSignposting
 
     # item
     if display_asset.respond_to?(:ro_crate)
-      ro_crate_url = polymorphic_url([:ro_crate, parent_asset], **url_opts)
-      links << [ro_crate_url, { rel: :item, type: :zip}]
-      # RFC6906 profile to indicate the zip has an RO-Crate
-      links << [RO_CRATE_PROFILE, { rel: :profile, anchor: ro_crate_url}]
+      links << [polymorphic_url([:ro_crate, parent_asset], **url_opts), { rel: :item, type: :zip, profile: RO_CRATE_PROFILE}]
     elsif display_asset.respond_to?(:content_blobs) && display_asset.content_blobs.any?
       links << [polymorphic_url([:download, parent_asset], **url_opts), { rel: :item, type: :zip }]
     elsif display_asset.respond_to?(:content_blob) && display_asset.content_blob

--- a/test/integration/fair_signposting_test.rb
+++ b/test/integration/fair_signposting_test.rb
@@ -44,10 +44,11 @@ class FairSignpostingTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     links = parse_link_header
-    assert_equal 3, links.size
+    assert_equal 4, links.size
     assert_link(links, workflow_url(wf, version: 1), rel: 'describedby', type: :datacite_xml)
     assert_link(links, workflow_url(wf, version: 1), rel: 'describedby', type: :jsonld)
     assert_link(links, ro_crate_workflow_url(wf, version: 1), rel: 'item', type: :zip)
+    assert_link(links, 'https://w3id.org/ro/crate', rel: 'profile', anchor: ro_crate_workflow_url(wf, version: 1))
   end
 
   test 'fair signposting for publication' do

--- a/test/integration/fair_signposting_test.rb
+++ b/test/integration/fair_signposting_test.rb
@@ -44,11 +44,10 @@ class FairSignpostingTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     links = parse_link_header
-    assert_equal 4, links.size
+    assert_equal 3, links.size
     assert_link(links, workflow_url(wf, version: 1), rel: 'describedby', type: :datacite_xml)
     assert_link(links, workflow_url(wf, version: 1), rel: 'describedby', type: :jsonld)
-    assert_link(links, ro_crate_workflow_url(wf, version: 1), rel: 'item', type: :zip)
-    assert_link(links, 'https://w3id.org/ro/crate', rel: 'profile', anchor: ro_crate_workflow_url(wf, version: 1))
+    assert_link(links, ro_crate_workflow_url(wf, version: 1), rel: 'item', type: :zip, profile: 'https://w3id.org/ro/crate')
   end
 
   test 'fair signposting for publication' do


### PR DESCRIPTION
```
Link: <http://127.0.0.1:3000/workflows/1?version=1> ; rel="describedby" ; type="application/vnd.datacite.datacite+xml",
  <http://127.0.0.1:3000/workflows/1?version=1> ; rel="describedby" ; type="application/ld+json", 
  <http://127.0.0.1:3000/workflows/1/ro_crate?version=1> ; rel="item" ; type="application/zip"; profile="https://w3id.org/ro/crate"
```

Adds the `profile` attribute to indicate what type of ZIP file.