### PR TITLE
Seek 1.12 gatekeeper improvement

### DIFF
--- a/app/assets/stylesheets/publishing.css
+++ b/app/assets/stylesheets/publishing.css
@@ -18,3 +18,7 @@ ul.publishing_options li.secondary {
     color: limegreen;
 }
 
+.type_and_title {
+    margin-top: 20px;
+}
+

--- a/app/models/resource_publish_log.rb
+++ b/app/models/resource_publish_log.rb
@@ -27,6 +27,17 @@ class ResourcePublishLog < ApplicationRecord
     requested_approval_assets.reject!(&:is_published?)
     requested_approval_assets.select! { |asset| gatekeeper.is_asset_gatekeeper_of? asset }
     requested_approval_assets.uniq
+
+    isa_order = %w[Investigation Study Assay]
+
+    isa_assets = requested_approval_assets.select { |a| a.is_isa? }
+    non_isa_assets = requested_approval_assets - isa_assets
+
+    # seperate isa and non-isa items and sort them by different standards
+    isa = isa_assets.sort_by { |a| [a.is_isa? ? -1 : 1, isa_order.index(a.class.name), a.class.name] }
+    non_isa = non_isa_assets.sort_by{ |a| a.resource_publish_logs.last.created_at}.reverse!
+
+    isa+non_isa
   end
 
   def self.waiting_approval_assets_for(user)

--- a/app/views/assets/publishing/requested_approval_assets.html.erb
+++ b/app/views/assets/publishing/requested_approval_assets.html.erb
@@ -1,3 +1,5 @@
+<div  style="margin:auto;width:70%;">
+
 <div class="alert alert-info">
   <p>
     <% project_names = current_user.person.projects_for_role(Seek::Roles::ASSET_GATEKEEPER).collect(&:title) %>
@@ -20,63 +22,38 @@
     <%= button_link_to "Back to your profile", 'back', person_path(params[:id].to_i) -%>
 <% else %>
     <%= form_tag :action => :gatekeeper_decide do %>
-        <% if @requested_approval_assets.count > 1 %>
-            <h2>The following items have been requested to be published</h2>
-        <% else %>
-            <h2>The following item has been requested to be published</h2>
-        <% end %>
-
-        <% isa_order = ['Investigation', 'Study', 'Assay']%>
-        <% @requested_approval_assets.sort_by { |a| [a.is_isa? ? -1 : 1, isa_order.index(a.class.name), a.class.name] }.each do |asset| %>
+    <h1><%= (@requested_approval_assets.count > 1)? 'The following items have been requested to be published' : 'The following item has been requested to be published' %></h1>
+        <% @requested_approval_assets.each do |asset| %>
             <div class="item_for_decision row">
-              <div class="col-sm-6">
-
+              <div class="col-sm-10">
                 <div class="type_and_title form-group">
-                  <label><%= text_for_resource asset -%></label>
-                  <p class="form-control-static">
-                    <%= link_to (asset.title), asset -%>
+                  <b><%= text_for_resource asset -%> : </b>
+                    <%= link_to(asset.title, asset,option={target: :_blank}) -%>
                     <%= list_item_visibility(asset) -%>
-                  </p>
                 </div>
 
                 <div class="request_info form-group">
-                  <label>Requested by</label>
-                  <p class="form-control-static">
+                  <label>Requested by </label>
                     <% asset.publish_requesters.each do |requester| %>
-                        <%= link_to(requester.name, requester) %>
+                        <%= link_to(requester.name, requester, option={target: :_blank}) %>
                         on
-                        <%
-                           log = ResourcePublishLog.where(["resource_type=? AND resource_id=? AND publish_state=? AND user_id=?",
-                                                           asset.class.name, asset.id, ResourcePublishLog::WAITING_FOR_APPROVAL, requester.user.id]).last
-                        %>
-                        <%= date_as_string(log.created_at,true) %>
+                        <%= date_as_string(asset.resource_publish_logs.last.created_at,true) %>
                     <% end %>
-                  </p>
                 </div>
 
+                <div class="container">
+                  <div class="row">
+                    <div class="col-md-4">
+                      <label class="radio-inline"><input type="radio" name="gatekeeper_decide[<%= asset.class.name %>][<%= asset.id %>][decision]" value="1">Approve</label>
+                      <label class="radio-inline"><input type="radio" name="gatekeeper_decide[<%= asset.class.name %>][<%= asset.id %>][decision]" value="0">Reject</label>
+                      <label class="radio-inline"><input type="radio" name="gatekeeper_decide[<%= asset.class.name %>][<%= asset.id %>][decision]" value="-1" checked>Decide later</label></div>
+                    <div class="col-md-6">
+                        <label>Reason or other comments (optional)</label>
+                        <%= text_area_tag "gatekeeper_decide[#{asset.class.name}][#{asset.id}][comment]", nil,
+                                          :rows => 3, :class => 'form-control' -%>
 
-                <div class="form-group">
-                  <label>Decision</label>
-                  <div class="btn-group btn-group-justified" data-toggle="buttons">
-                    <label class="btn btn-default">
-                      <input type="radio" name="gatekeeper_decide[<%= asset.class.name %>][<%= asset.id %>][decision]" value="1" autocomplete="off"/>
-                      Approve
-                    </label>
-                    <label class="btn btn-default">
-                      <input type="radio" name="gatekeeper_decide[<%= asset.class.name %>][<%= asset.id %>][decision]" value="0" autocomplete="off"/>
-                      Reject
-                    </label>
-                    <label class="btn btn-default active">
-                      <input type="radio" name="gatekeeper_decide[<%= asset.class.name %>][<%= asset.id %>][decision]" value="-1" autocomplete="off" checked="checked"/>
-                      Decide later
-                    </label>
+                    </div>
                   </div>
-                </div>
-
-                <div class="form-group">
-                  <label>Reason or other comments (optional)</label>
-                  <%= text_area_tag "gatekeeper_decide[#{asset.class.name}][#{asset.id}][comment]", nil,
-                                    :rows => 3, :class => 'form-control' -%>
                 </div>
               </div>
             </div>
@@ -89,3 +66,4 @@
         </p>
     <% end %>
 <% end %>
+</div>

--- a/lib/seek/download_handling/http_handler.rb
+++ b/lib/seek/download_handling/http_handler.rb
@@ -9,7 +9,7 @@ module Seek
     class HTTPHandler
       include Seek::UploadHandling::ContentInspection
 
-      attr_reader :url
+      attr_reader :url, :fallback_to_get
 
       def initialize(url, fallback_to_get: true)
         @url = url
@@ -38,8 +38,8 @@ module Seek
             content_type = response.headers[:content_tyspe]
             content_length = response.headers[:content_length]
             code = response.code
-          rescue RestClient::MethodNotAllowed,RestClient::NotFound => e # Try a GET if HEAD isn't allowed, but don't download anything
-            if @fallback_to_get
+          rescue RestClient::Exception => e # Try a GET if HEAD isn't allowed, but don't download anything
+            if fallback_to_get
               begin
                 uri = URI.parse(url)
                 Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
@@ -56,8 +56,6 @@ module Seek
             else
               code = e.http_code
             end
-          rescue RestClient::Exception => e
-            code = e.http_code
           rescue SocketError, Errno::ECONNREFUSED, Errno::EHOSTUNREACH
             code = 404
           end

--- a/lib/seek/permissions/publishing_permissions.rb
+++ b/lib/seek/permissions/publishing_permissions.rb
@@ -42,10 +42,13 @@ module Seek
             policy.access_type = Policy::ACCESSIBLE
             policy.sharing_scope = Policy::EVERYONE # anything but ALL_USERS
             policy.save
-            # FIXME: may need to add comment
+
             resource_publish_logs.create(publish_state: ResourcePublishLog::PUBLISHED,
                                          user: User.current_user,
                                          comment: comment)
+
+            resource_publish_logs.find_or_initialize_by(publish_state: ResourcePublishLog::WAITING_FOR_APPROVAL, resource_id: self.id, user_id: self.contributor.id)
+                                 .update(publish_state:ResourcePublishLog::PUBLISHED, comment:comment)
             touch
           end
         else
@@ -57,6 +60,9 @@ module Seek
         resource_publish_logs.create(publish_state: ResourcePublishLog::REJECTED,
                                      user: User.current_user,
                                      comment: comment)
+
+        resource_publish_logs.find_or_initialize_by(publish_state: ResourcePublishLog::WAITING_FOR_APPROVAL, resource_id: self.id, user_id: self.contributor.id)
+                             .update(publish_state:ResourcePublishLog::REJECTED, comment:comment)
       end
 
       def is_published?

--- a/lib/seek/permissions/publishing_permissions.rb
+++ b/lib/seek/permissions/publishing_permissions.rb
@@ -113,7 +113,7 @@ module Seek
       end
 
       def publish_requesters
-        user_requesters = resource_publish_logs.includes(:user).where(publish_state: ResourcePublishLog::WAITING_FOR_APPROVAL).map(&:user)
+        user_requesters = resource_publish_logs.select{|log| !log.user.person.is_asset_gatekeeper_of?(self)}.map(&:user)
 
         user_requesters.uniq.compact.collect(&:person).compact
       end

--- a/lib/seek/publishing/publishing_common.rb
+++ b/lib/seek/publishing/publishing_common.rb
@@ -239,7 +239,12 @@ module Seek
         notify_owner_of_publishing_request @notified_items
 
         @waiting_for_publish_items.each do |item|
-          ResourcePublishLog.add_log ResourcePublishLog::WAITING_FOR_APPROVAL, item
+          if item.is_rejected?
+            item.resource_publish_logs.where('user_id != ?',current_user.id).destroy_all
+            item.resource_publish_logs.first.update(publish_state:ResourcePublishLog::WAITING_FOR_APPROVAL)
+          else
+            ResourcePublishLog.add_log ResourcePublishLog::WAITING_FOR_APPROVAL, item
+          end
         end
 
         notify_gatekeepers_of_approval_request @waiting_for_publish_items

--- a/test/functional/content_blobs_controller_test.rb
+++ b/test/functional/content_blobs_controller_test.rb
@@ -139,6 +139,7 @@ class ContentBlobsControllerTest < ActionController::TestCase
   test 'examine url forbidden' do
     # forbidden
     stub_request(:head, 'http://unauth.com/file.pdf').to_return(status: 403, headers: { 'Content-Type' => 'application/pdf' })
+    stub_request(:get, 'http://unauth.com/file.pdf').to_return(status: 403, headers: { 'Content-Type' => 'application/pdf' })
     get :examine_url, xhr: true, params: { data_url: 'http://unauth.com/file.pdf' }
     assert_response 200
     assert_equal 403, assigns(:info)[:code]
@@ -150,6 +151,7 @@ class ContentBlobsControllerTest < ActionController::TestCase
   test 'examine url unauthorized' do
     # unauthorized
     stub_request(:head, 'http://unauth.com/file.pdf').to_return(status: 401, headers: { 'Content-Type' => 'application/pdf' })
+    stub_request(:get, 'http://unauth.com/file.pdf').to_return(status: 401, headers: { 'Content-Type' => 'application/pdf' })
     get :examine_url, xhr: true, params: { data_url: 'http://unauth.com/file.pdf' }
     assert_response :success
     assert @response.body.include?('Access to this link is unauthorized')

--- a/test/functional/publishing/batch_publishing_test.rb
+++ b/test/functional/publishing/batch_publishing_test.rb
@@ -115,7 +115,7 @@ class BatchPublishingTest < ActionController::TestCase
       params[:publish][asset.class.name][asset.id.to_s] = '1'
     end
 
-    assert_difference('ResourcePublishLog.count', total_assets.count) do
+    assert_difference('ResourcePublishLog.count', publish_immediately_assets.count+gatekeeper_required_assets.count*2) do
       assert_enqueued_emails gatekeeper_required_assets.count do
         post :publish, params: params.merge(id: User.current_user.person.id)
       end

--- a/test/functional/publishing/gatekeeper_publish_test.rb
+++ b/test/functional/publishing/gatekeeper_publish_test.rb
@@ -110,7 +110,7 @@ class GatekeeperPublishTest < ActionController::TestCase
     login_as(@gatekeeper.user)
 
     assert_difference('ResourcePublishLog.count', 2) do
-      assert_enqueued_emails 1 do
+      assert_enqueued_emails 2 do
         post :gatekeeper_decide, params: params.merge(id: @gatekeeper.id)
       end
     end

--- a/test/functional/publishing/gatekeeper_publish_test.rb
+++ b/test/functional/publishing/gatekeeper_publish_test.rb
@@ -104,7 +104,7 @@ class GatekeeperPublishTest < ActionController::TestCase
     params = params_for df, model, sop
     login_as(@gatekeeper.user)
 
-    assert_difference('ResourcePublishLog.count', 2) do
+    assert_difference('ResourcePublishLog.count', 4) do
       assert_enqueued_emails 2 do
         post :gatekeeper_decide, params: params.merge(id: @gatekeeper.id)
       end

--- a/test/functional/publishing/gatekeeper_publish_test.rb
+++ b/test/functional/publishing/gatekeeper_publish_test.rb
@@ -86,7 +86,7 @@ class GatekeeperPublishTest < ActionController::TestCase
       assert_select 'a[href=?]', person_path(user.person), count: 3
     end
 
-    assert_select '.btn-group', count: 3 do
+    assert_select '.radio-inline', count: 9 do
       [df, model, sop].each do |asset|
         assert_select 'input[type=radio][name=?][value=?]', "gatekeeper_decide[#{asset.class.name}][#{asset.id}][decision]", '1'
         assert_select 'input[type=radio][name=?][value=?]', "gatekeeper_decide[#{asset.class.name}][#{asset.id}][decision]", '0'

--- a/test/functional/publishing/gatekeeper_publish_test.rb
+++ b/test/functional/publishing/gatekeeper_publish_test.rb
@@ -110,7 +110,6 @@ class GatekeeperPublishTest < ActionController::TestCase
     login_as(@gatekeeper.user)
 
     assert_difference('ResourcePublishLog.count', 2) do
-      # @todo bug fix should send an email when item is rejected, so actually shouold be 2 emails enqueued.
       assert_enqueued_emails 1 do
         post :gatekeeper_decide, params: params.merge(id: @gatekeeper.id)
       end

--- a/test/functional/publishing/log_publishing_test.rb
+++ b/test/functional/publishing/log_publishing_test.rb
@@ -132,15 +132,18 @@ class LogPublishingTest < ActionController::TestCase
     params[:gatekeeper_decide][df.class.name][df.id.to_s] ||= {}
     params[:gatekeeper_decide][df.class.name][df.id.to_s]['decision'] = 1
 
-    assert_difference('ResourcePublishLog.count', 2) do
+    assert_difference('ResourcePublishLog.count', 1) do
       post :gatekeeper_decide, params: params.merge(id: @gatekeeper.id)
     end
 
-    publish_log = ResourcePublishLog.last
-    assert_equal ResourcePublishLog::PUBLISHED, publish_log.publish_state.to_i
-    assert_equal df, publish_log.resource
-    assert_equal @gatekeeper.user, ResourcePublishLog.second_to_last.user
-    assert_equal df.contributor.id, publish_log.user_id
+
+    contributor_publish_log = df.resource_publish_logs.first
+    gatekeeper_publish_log = df.resource_publish_logs.last
+
+    assert_equal ResourcePublishLog::PUBLISHED, contributor_publish_log.publish_state.to_i
+    assert_equal df, contributor_publish_log.resource
+    assert_equal @gatekeeper.user, gatekeeper_publish_log.user
+    assert_equal df.contributor.user, contributor_publish_log.user
   end
 
   test 'gatekeeper cannot approve an item from another project' do

--- a/test/functional/publishing/log_publishing_test.rb
+++ b/test/functional/publishing/log_publishing_test.rb
@@ -132,14 +132,15 @@ class LogPublishingTest < ActionController::TestCase
     params[:gatekeeper_decide][df.class.name][df.id.to_s] ||= {}
     params[:gatekeeper_decide][df.class.name][df.id.to_s]['decision'] = 1
 
-    assert_difference ('ResourcePublishLog.count') do
+    assert_difference('ResourcePublishLog.count', 2) do
       post :gatekeeper_decide, params: params.merge(id: @gatekeeper.id)
     end
 
     publish_log = ResourcePublishLog.last
     assert_equal ResourcePublishLog::PUBLISHED, publish_log.publish_state.to_i
     assert_equal df, publish_log.resource
-    assert_equal @gatekeeper.user, publish_log.user
+    assert_equal @gatekeeper.user, ResourcePublishLog.second_to_last.user
+    assert_equal df.contributor.id, publish_log.user_id
   end
 
   test 'gatekeeper cannot approve an item from another project' do
@@ -200,7 +201,7 @@ class LogPublishingTest < ActionController::TestCase
     params[:publish][request_publishing_df.class.name] ||= {}
     params[:publish][request_publishing_df.class.name][request_publishing_df.id.to_s] = '1'
 
-    assert_difference('ResourcePublishLog.count', 2) do
+    assert_difference('ResourcePublishLog.count', 3) do
       post :publish, params: params.merge(id: df)
       a = 1
     end

--- a/test/functional/publishing/single_publishing_test.rb
+++ b/test/functional/publishing/single_publishing_test.rb
@@ -213,7 +213,7 @@ class SinglePublishingTest < ActionController::TestCase
     params[:publish][df.class.name] ||= {}
     params[:publish][df.class.name][df.id.to_s] = '1'
 
-    assert_difference('ResourcePublishLog.count', 1) do
+    assert_difference('ResourcePublishLog.count', 2) do
       post :publish, params: params.merge(id: df.id)
     end
 

--- a/test/functional/publishing/single_publishing_test.rb
+++ b/test/functional/publishing/single_publishing_test.rb
@@ -223,6 +223,9 @@ class SinglePublishingTest < ActionController::TestCase
 
     df.reload
     assert df.is_published?, 'The data file should be published after doing single_publish'
+    refute df.is_waiting_approval? 'The data file should not be waiting for approval after doing single_publish'
+    refute df.is_rejected? 'The data file should not be be rejected after doing single_publish'
+
   end
 
   test "sending publishing request when doing publish for asset that need gatekeeper's approval" do

--- a/test/functional/publishing/single_publishing_test.rb
+++ b/test/functional/publishing/single_publishing_test.rb
@@ -223,8 +223,8 @@ class SinglePublishingTest < ActionController::TestCase
 
     df.reload
     assert df.is_published?, 'The data file should be published after doing single_publish'
-    refute df.is_waiting_approval? 'The data file should not be waiting for approval after doing single_publish'
-    refute df.is_rejected? 'The data file should not be be rejected after doing single_publish'
+    refute df.is_waiting_approval?(User.current_user), 'The data file should not be waiting for approval after doing single_publish'
+    refute df.is_rejected?, 'The data file should not be be rejected after doing single_publish'
 
   end
 

--- a/test/unit/permissions/publishing_permissions_test.rb
+++ b/test/unit/permissions/publishing_permissions_test.rb
@@ -278,7 +278,7 @@ class PublishingPermissionsTest < ActiveSupport::TestCase
     User.with_current_user person.user do
       assert df.resource_publish_logs.empty?
       assert df.publish!
-      assert_equal 1, df.resource_publish_logs.count
+      assert_equal 2, df.resource_publish_logs.count
       log = df.resource_publish_logs.first
       assert_equal ResourcePublishLog::PUBLISHED, log.publish_state
     end

--- a/test/unit/permissions/publishing_permissions_test.rb
+++ b/test/unit/permissions/publishing_permissions_test.rb
@@ -143,7 +143,7 @@ class PublishingPermissionsTest < ActiveSupport::TestCase
       refute df.is_waiting_approval?(User.current_user), 'This item must be waiting for approval for the test to be meaningful'
       assert df.is_rejected?, 'This item must not be rejected for the test to succeed'
 
-      refute df.can_publish?, 'This item should not be publishable'
+      assert df.can_publish?, 'This item should not be publishable'
     end
   end
 

--- a/test/unit/permissions/publishing_permissions_test.rb
+++ b/test/unit/permissions/publishing_permissions_test.rb
@@ -157,8 +157,8 @@ class PublishingPermissionsTest < ActiveSupport::TestCase
       refute df.is_waiting_approval?(User.current_user), 'This item must be waiting for approval for the test to be meaningful'
       assert df.is_rejected?, 'This item must not be rejected for the test to succeed'
       refute df.can_publish?, 'This item should not be publishable'
-      sleep(3)
-      df.update! title: 'new title'
+      df.updated_at = Time.now+3.second
+      df.save!
       assert df.is_updated_since_be_rejected?
       assert df.can_publish?, 'This item should be publishable after update'
     end


### PR DESCRIPTION
- after the gatekeeper makes a decision (approve or reject), the publishing state of the resource for the contributor is not updated. For the contributor of the resource `is_waiting_approval?= true`, it should be updated to PUBLISHED or REJECTED

-  in 'requested_approval_assets' page, the recently updated items should be listed at the top.

-  should be able to open the resource link in a new tab on the 'requested_approval_assets' page ( better UX)

-  better UI of requested_approval_assets page. ( https://hostname/people/id/requested_approval_assets)
- 
-  bug fix: After `reject/decide late` decision is made, the approval is not working;  the error message is "Items that were decided to make published but were not published due to an unforeseen problem" 

-  The resource can be re-published after it is rejected by the gatekeeper before.  The "publish" button will appear again in the "Action" menu when the resource is updated. 
