### PR TITLE
Sharing form wording and programme button fix

### DIFF
--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -99,7 +99,7 @@ module ProjectsHelper
 
   def projects_grouped_by_programme(selected = nil)
     if Seek::Config.programmes_enabled
-      array = Project.order(:title).to_a.group_by { |p| p.programme.try(:title) || "#{I18n.t('project').capitalize.pluralize} without a #{t('programme')}" }.each_value do |projects|
+      array = Project.order(:title).to_a.group_by { |p| p.programme.try(:title) || "#{I18n.t('project').pluralize} without a #{t('programme')}" }.each_value do |projects|
         projects.map! { |p| [p.title, p.id] }
       end.to_a
 

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -99,7 +99,7 @@ module ProjectsHelper
 
   def projects_grouped_by_programme(selected = nil)
     if Seek::Config.programmes_enabled
-      array = Project.order(:title).to_a.group_by { |p| p.programme.try(:title) || "Independent #{I18n.t('project').downcase.pluralize}" }.each_value do |projects|
+      array = Project.order(:title).to_a.group_by { |p| p.programme.try(:title) || "#{I18n.t('project').capitalize.pluralize} without a #{t('programme')}" }.each_value do |projects|
         projects.map! { |p| [p.title, p.id] }
       end.to_a
 

--- a/app/views/sharing/_form.html.erb
+++ b/app/views/sharing/_form.html.erb
@@ -16,7 +16,7 @@
 
     <div class="alert alert-info">
       <% if object.is_a?(Project) %>
-          Here you can configure a default sharing policy that is applied to new resources created as part of this <%= t('project').downcase -%>.
+          Here you can configure a default sharing policy that is applied to new resources created as part of this <%= t('project') -%>.
       <% else %>
           Here you can specify who can <b>view</b> the summary of<% if object.is_downloadable? %>,
               <b>get</b> access to the content of,<% end %> and <b>edit</b> the <%= resource_type -%>.

--- a/app/views/sharing/_group_permission_modal.html.erb
+++ b/app/views/sharing/_group_permission_modal.html.erb
@@ -1,18 +1,18 @@
-<%= button_link_to("Share with a #{t('project').downcase}/#{t('institution').downcase}", 'add', '#', id: 'add-project-permission-button') %>
+<%= button_link_to("Share with a #{t('project')} / #{t('institution')}", 'add', '#', id: 'add-project-permission-button') %>
 
 <%= modal(id: 'add-project-permission-modal', size: 'm') do %>
-    <%= modal_header("Share with a #{t('project').downcase} and/or #{t('institution').downcase}") %>
+    <%= modal_header("Share with a #{t('project')} and/or #{t('institution')}") %>
     <%= modal_body do %>
         <div class="form-group">
           <label>Members of...</label>
           <%= select_tag('permission-project-id', projects_grouped_by_programme, name: nil,
-                         prompt: "any #{t('project').downcase}", class: 'form-control', autocomplete: 'off') -%>
+                         prompt: "any #{t('project')}", class: 'form-control', autocomplete: 'off') -%>
         </div>
         <div class="form-group">
           <label>working at...</label>
           <%= select_tag('permission-institution-id',
                          options_for_select(Institution.all.sort_by(&:title).map { |i| [i.title, i.id] }), name: nil,
-                         prompt: "any #{t('institution').downcase}", class: 'form-control', autocomplete: 'off') -%>
+                         prompt: "any #{t('institution')}", class: 'form-control', autocomplete: 'off') -%>
         </div>
         <div class="form-group">
           <label>can...</label>
@@ -94,7 +94,7 @@
           data: { 'id': projectId },
           success: function (data) {
             institutionSelect.html('');
-            institutionSelect.html('<option value="">any <%= t('institution').downcase -%></option>');
+            institutionSelect.html('<option value="">any <%= t('institution') -%></option>');
             data.institution_list.forEach(function (i) {
                 var opt = $j('<option>');
                 opt.attr('value', i[idIndex]);

--- a/app/views/sharing/_permissions_table.html.erb
+++ b/app/views/sharing/_permissions_table.html.erb
@@ -7,7 +7,7 @@
 
 <%= render partial: 'sharing/person_permission_modal', locals: { object: object } %>
 <%= render partial: 'sharing/group_permission_modal', locals: { object: object } %>
-<%= render partial: 'sharing/programme_permission_modal', locals: { object: object } %>
+<%= render partial: 'sharing/programme_permission_modal', locals: { object: object } if Seek::Config.programmes_enabled %>
 
 <script>
   var policy = <%= policy_json(policy, projects) -%>;

--- a/app/views/sharing/_person_permission_modal.html.erb
+++ b/app/views/sharing/_person_permission_modal.html.erb
@@ -1,12 +1,12 @@
-<%= button_link_to('Share with a person', 'add', '#', id: 'add-person-permission-button') %>
+<%= button_link_to("Share with a #{t('person')}", 'add', '#', id: 'add-person-permission-button') %>
 
 <%= modal(id: 'add-person-permission-modal', size: 'm') do %>
-    <%= modal_header('Share with people') %>
+    <%= modal_header("Share with #{t('person').pluralize}") %>
     <%= modal_body do %>
         <div class="form-group">
-          <label>The following people...</label>
+          <label>The following <%= t('person').pluralize %>...</label>
           <%= objects_input('permission-people-ids', [], typeahead: { values: Person.all.map { |p| { id: p.id, name: p.name, hint: p.typeahead_hint } } }, name: nil) -%>
-          <p class="help-block">Start typing a person's name and select from the list that appears. You can select multiple people.</p>
+          <p class="help-block">Start typing a <%= t('person') %>'s name and select from the list that appears. You can select multiple <%= t('person').pluralize %>.</p>
         </div>
         <div class="form-group">
           <label>can...</label>

--- a/app/views/sharing/_programme_permission_modal.html.erb
+++ b/app/views/sharing/_programme_permission_modal.html.erb
@@ -1,12 +1,12 @@
-<%= button_link_to("Share with a #{t('programme').downcase}", 'add', '#', id: 'add-programme-permission-button') %>
+<%= button_link_to("Share with a #{t('programme')}", 'add', '#', id: 'add-programme-permission-button') %>
 
 <%= modal(id: 'add-programme-permission-modal', size: 'm') do %>
-    <%= modal_header("Share with #{t('programme').downcase.pluralize}") %>
+    <%= modal_header("Share with #{t('programme').pluralize}") %>
     <%= modal_body do %>
         <div class="form-group">
-          <label>The following <%= t('programme').downcase.pluralize -%>...</label>
+          <label>The following <%= t('programme').pluralize -%>...</label>
           <%= objects_input('permission-programmes-ids', [], typeahead: { values: Programme.all.map { |p| { id: p.id, name: p.title } } }, name: nil) -%>
-          <p class="help-block">Start typing a <%= t('programme').downcase -%>'s title and select from the list that appears. You can select multiple <%= t('programme').downcase.pluralize -%>.</p>
+          <p class="help-block">Start typing a <%= t('programme') -%>'s title and select from the list that appears. You can select multiple <%= t('programme').pluralize -%>.</p>
         </div>
         <div class="form-group">
           <label>can...</label>

--- a/test/functional/documents_controller_test.rb
+++ b/test/functional/documents_controller_test.rb
@@ -1206,6 +1206,26 @@ class DocumentsControllerTest < ActionController::TestCase
     end
   end
 
+  test 'sharing with programme only shows if enabled' do
+    doc = Factory :document
+    login_as(doc.contributor)
+
+    with_config_value :programmes_enabled, true do
+      get :manage, params: { id: doc }
+      assert_response :success
+
+      assert_select 'a#add-programme-permission-button', text: /Share with a Programme/, count: 1
+    end
+
+    with_config_value :programmes_enabled, false do
+      get :manage, params: { id: doc }
+      assert_response :success
+
+      assert_select 'a#add-programme-permission-button', text: /Share with a Programme/, count: 0
+    end
+
+  end
+
   private
 
   def valid_document


### PR DESCRIPTION
Reworded Independent projects as Projects without a Programme ( #573 )
.. also fixed used of locale for People/Person, and capitalized for consistency with other views

Share with Programme button should only show if enabled #1069 