### PR TITLE
Clear cached sample resource list item title when sample type changed

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -743,7 +743,7 @@ class ProjectsController < ApplicationController
           membership.update(time_left_at: left_at)
         end
         member = Person.find(membership.person_id)
-        Rails.cache.delete_matched("rli_title_#{member.cache_key}_.*")
+        Rails.cache.delete_matched(/#{member.list_item_title_cache_key_prefix}.*/)
       end
     end
   end

--- a/app/helpers/resource_list_item_helper.rb
+++ b/app/helpers/resource_list_item_helper.rb
@@ -32,7 +32,7 @@ module ResourceListItemHelper
 
     html = nil
 
-    cache_key = "rli_title_#{resource.cache_key}_#{resource.authorization_supported? && resource.can_manage?}"
+    cache_key = "#{resource.list_item_title_cache_key_prefix}_#{resource.authorization_supported? && resource.can_manage?}"
     result = Rails.cache.fetch(cache_key) do
       title = options[:title]
       url = options[:url]

--- a/app/jobs/sample_type_update_job.rb
+++ b/app/jobs/sample_type_update_job.rb
@@ -7,7 +7,12 @@ class SampleTypeUpdateJob < ApplicationJob
   # if refresh_samples is false, then the associated samples won't be refreshed, only the constraints cache rebuilt
   # - defaults to true
   def perform(sample_type, refresh_samples)
-    sample_type.refresh_samples if refresh_samples
+    if refresh_samples
+      sample_type.refresh_samples
+      sample_type.samples.each do |sample|
+        Rails.cache.delete_matched(/#{sample.list_item_title_cache_key_prefix}.*/)
+      end
+    end
     Seek::Samples::SampleTypeEditingConstraints.new(sample_type).refresh_cache
   end
 end

--- a/app/jobs/sample_type_update_job.rb
+++ b/app/jobs/sample_type_update_job.rb
@@ -9,10 +9,9 @@ class SampleTypeUpdateJob < ApplicationJob
   def perform(sample_type, refresh_samples)
     if refresh_samples
       sample_type.refresh_samples
-
-      Rails.cache.delete_matched(/#{sample_type.list_item_title_cache_key_prefix}.*/)
-
+      Rails.cache.delete_matched(%r{#{sample_type.list_item_title_cache_key_prefix}/samples.*})
     end
+
     Seek::Samples::SampleTypeEditingConstraints.new(sample_type).refresh_cache
   end
 end

--- a/app/jobs/sample_type_update_job.rb
+++ b/app/jobs/sample_type_update_job.rb
@@ -9,9 +9,9 @@ class SampleTypeUpdateJob < ApplicationJob
   def perform(sample_type, refresh_samples)
     if refresh_samples
       sample_type.refresh_samples
-      sample_type.samples.each do |sample|
-        Rails.cache.delete_matched(/#{sample.list_item_title_cache_key_prefix}.*/)
-      end
+
+      Rails.cache.delete_matched(/#{sample_type.list_item_title_cache_key_prefix}.*/)
+
     end
     Seek::Samples::SampleTypeEditingConstraints.new(sample_type).refresh_cache
   end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -173,4 +173,9 @@ class ApplicationRecord < ActiveRecord::Base
     Seek::IndexTableColumnDefinitions.required_columns(self)
   end
 
+  #TODO: this could potentially be moved into a module that pulls together all the generated cache keys into one place
+  def list_item_title_cache_key_prefix
+    "rli_title_#{cache_key}"
+  end
+
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -175,7 +175,7 @@ class ApplicationRecord < ActiveRecord::Base
 
   #TODO: this could potentially be moved into a module that pulls together all the generated cache keys into one place
   def list_item_title_cache_key_prefix
-    "rli_title_#{cache_key}"
+    "rli_title_#{cache_key_with_version}"
   end
 
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -175,7 +175,7 @@ class ApplicationRecord < ActiveRecord::Base
 
   #TODO: this could potentially be moved into a module that pulls together all the generated cache keys into one place
   def list_item_title_cache_key_prefix
-    "rli_title_#{cache_key_with_version}"
+    "rli_title_#{cache_key}"
   end
 
 end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -130,6 +130,11 @@ class Sample < ApplicationRecord
     organism_ids | ncbi_linked_organisms.map(&:id)
   end
 
+  #overides default to include sample_type key at the start
+  def list_item_title_cache_key_prefix
+    "#{sample_type.list_item_title_cache_key_prefix}/#{cache_key_with_version}"
+  end
+
   private
 
   # organisms linked through an NCBI attribute type
@@ -181,4 +186,5 @@ class Sample < ApplicationRecord
   def attribute_class
     SampleAttribute
   end
+
 end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -132,7 +132,7 @@ class Sample < ApplicationRecord
 
   #overides default to include sample_type key at the start
   def list_item_title_cache_key_prefix
-    "#{sample_type.list_item_title_cache_key_prefix}/#{cache_key_with_version}"
+    "#{sample_type.list_item_title_cache_key_prefix}/#{cache_key}"
   end
 
   private

--- a/config/application.rb
+++ b/config/application.rb
@@ -62,6 +62,7 @@ module SEEK
     # openbis_endpoints/26-20170404142724000000000...
     # openbis_endpoints/26-20170404142724224014370...
     config.active_record.cache_timestamp_format = :usec
+    config.active_record.cache_versioning = false
 
     config.action_mailer.deliver_later_queue_name = 'mailers'
 

--- a/test/unit/asset_test.rb
+++ b/test/unit/asset_test.rb
@@ -489,4 +489,14 @@ class AssetTest < ActiveSupport::TestCase
     assert ActiveRecord::Relation,Investigation.filter_by_projects(projects).is_a?(ActiveRecord::Relation)
   end
 
+  test 'cache key includes version' do
+    df = Factory(:data_file)
+
+    # check it hasn't be overridden
+    assert_nil df.method(:cache_key).super_method
+
+    assert_equal df.cache_key_with_version, df.cache_key
+    refute ActiveRecord::Base.cache_versioning
+  end
+
 end

--- a/test/unit/jobs/sample_type_update_job_test.rb
+++ b/test/unit/jobs/sample_type_update_job_test.rb
@@ -31,6 +31,8 @@ class SampleTypeUpdateJobTest < ActiveSupport::TestCase
   test 'clear resource list item title cache' do
     type = sample_type_with_samples
 
+    refute type.samples.empty?
+
     type.samples.each do |sample|
       refute Rails.cache.exist?("#{sample.list_item_title_cache_key_prefix}_wibble")
     end

--- a/test/unit/sample_test.rb
+++ b/test/unit/sample_test.rb
@@ -1166,7 +1166,7 @@ class SampleTest < ActiveSupport::TestCase
     sample = Factory(:sample)
     sample_type = sample.sample_type
 
-    assert_equal "#{sample_type.list_item_title_cache_key_prefix}/#{sample.cache_key_with_version}", sample.list_item_title_cache_key_prefix
+    assert_equal "#{sample_type.list_item_title_cache_key_prefix}/#{sample.cache_key}", sample.list_item_title_cache_key_prefix
 
     #check it changes
     old = sample.list_item_title_cache_key_prefix

--- a/test/unit/sample_test.rb
+++ b/test/unit/sample_test.rb
@@ -1162,4 +1162,20 @@ class SampleTest < ActiveSupport::TestCase
     assert_equal 'key must remain capitalised', attribute_map['CAPITAL key']
   end
 
+  test 'list_item_title_cache_key_prefix' do
+    sample = Factory(:sample)
+    sample_type = sample.sample_type
+
+    assert_equal "#{sample_type.list_item_title_cache_key_prefix}/#{sample.cache_key_with_version}", sample.list_item_title_cache_key_prefix
+
+    #check it changes
+    old = sample.list_item_title_cache_key_prefix
+    disable_authorization_checks { sample_type.update(title:'changed', updated_at: 1.minute.from_now) }
+    refute_equal old, sample.list_item_title_cache_key_prefix
+    old = sample.list_item_title_cache_key_prefix
+    disable_authorization_checks { sample.update(title:'changed', updated_at: 1.minute.from_now) }
+    refute_equal old, sample.list_item_title_cache_key_prefix
+
+  end
+
 end


### PR DESCRIPTION
clears the cache in the sample type update job if refresh samples selected #449 