### PR TITLE
Updated api names for edam attributes

### DIFF
--- a/app/serializers/base_serializer.rb
+++ b/app/serializers/base_serializer.rb
@@ -146,7 +146,7 @@ class BaseSerializer < SimpleBaseSerializer
     end
   end
 
-  def edam_annotations(property)
+  def ontology_annotations(property)
     terms = object.annotations_with_attribute(property, true).collect(&:value).sort_by(&:label)
     terms.collect do |term|
       {

--- a/app/serializers/file_template_serializer.rb
+++ b/app/serializers/file_template_serializer.rb
@@ -4,11 +4,11 @@ class FileTemplateSerializer < ContributedResourceSerializer
   has_many :data_files
   has_many :placeholders
 
-  attribute :edam_data do
-    edam_annotations('edam_data')
+  attribute :data_annotations do
+    ontology_annotations('edam_data')
   end
-  attribute :edam_formats do
-    edam_annotations('edam_formats')
+  attribute :format_annotations do
+    ontology_annotations('edam_formats')
   end
 
 end

--- a/app/serializers/placeholder_serializer.rb
+++ b/app/serializers/placeholder_serializer.rb
@@ -5,11 +5,11 @@ class PlaceholderSerializer < ContributedResourceSerializer
   has_one :file_template
   has_one :data_file
 
-  attribute :edam_data do
-    edam_annotations('edam_data')
+  attribute :data_annotations do
+    ontology_annotations('edam_data')
   end
-  attribute :edam_formats do
-    edam_annotations('edam_formats')
+  attribute :format_annotations do
+    ontology_annotations('edam_formats')
   end
 
 end

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -28,8 +28,8 @@ class ProjectSerializer < AvatarObjSerializer
     BaseSerializer.convert_policy object.default_policy
   end
 
-  attribute :edam_topics do
-    edam_annotations('edam_topics')
+  attribute :topic_annotations do
+    ontology_annotations('edam_topics')
   end
 
   has_many :organisms,  include_data: true

--- a/app/serializers/workflow_serializer.rb
+++ b/app/serializers/workflow_serializer.rb
@@ -7,11 +7,11 @@ class WorkflowSerializer < ContributedResourceSerializer
     }
   end
 
-  attribute :edam_operations do
-    edam_annotations('edam_operations')
+  attribute :operation_annotations do
+    ontology_annotations('edam_operations')
   end
-  attribute :edam_topics do
-    edam_annotations('edam_topics')
+  attribute :topic_annotations do
+    ontology_annotations('edam_topics')
   end
 
 

--- a/lib/seek/api/parameter_converter.rb
+++ b/lib/seek/api/parameter_converter.rb
@@ -66,16 +66,16 @@ module Seek
             end
           },
 
-          edam_operations: proc {|value|
+          operation_annotations: proc {|value|
             value.collect{|v| v[:identifier]}.join(', ')
           },
-          edam_topics: proc {|value|
+          topic_annotations: proc {|value|
             value.collect{|v| v[:identifier]}.join(', ')
           },
-          edam_data: proc {|value|
+          data_annotations: proc {|value|
             value.collect{|v| v[:identifier]}.join(', ')
           },
-          edam_formats: proc {|value|
+          format_annotations: proc {|value|
             value.collect{|v| v[:identifier]}.join(', ')
           },
           funding_codes: proc { |value|
@@ -153,7 +153,11 @@ module Seek
         template: :template_attributes,
         creators: :api_assets_creators,
         administrator_ids: :programme_administrator_ids,
-        attribute_map: :data
+        attribute_map: :data,
+        topic_annotations: :edam_topics,
+        operation_annotations: :edam_operations,
+        data_annotations: :edam_data,
+        format_annotations: :edam_formats
       }.freeze
 
       # Parameters to "elevate" out of params[bla] to the top-level.

--- a/public/api/definitions/_schemas.yml
+++ b/public/api/definitions/_schemas.yml
@@ -2326,7 +2326,7 @@ projectPost:
               $ref: "#/components/schemas/nullableLicense"
             discussion_links:
               $ref: "#/components/schemas/assetLinkPostList"
-            edam_topics:
+            topic_annotations:
               $ref: "#/components/schemas/ontologyTermsList"
           required:
             - title
@@ -2377,7 +2377,7 @@ projectPatch:
               $ref: "#/components/schemas/nullableLicense"
             discussion_links:
               $ref: "#/components/schemas/assetLinkPatchList"
-            edam_topics:
+            topic_annotations:
               $ref: "#/components/schemas/ontologyTermsList"
           additionalProperties: false
         relationships:
@@ -2883,9 +2883,9 @@ workflowPost:
           properties:
             tags:
               $ref: "#/components/schemas/tags"
-            edam_topics:
+            topic_annotations:
               $ref: "#/components/schemas/ontologyTermsList"
-            edam_operations:
+            operation_annotations:
               $ref: "#/components/schemas/ontologyTermsList"
             title:
               $ref: "#/components/schemas/nonEmptyString"
@@ -2961,9 +2961,9 @@ workflowPatch:
           properties:
             tags:
               $ref: "#/components/schemas/tags"
-            edam_topics:
+            topic_annotations:
               $ref: "#/components/schemas/ontologyTermsList"
-            edam_operations:
+            operation_annotations:
               $ref: "#/components/schemas/ontologyTermsList"
             title:
               $ref: "#/components/schemas/nonEmptyString"
@@ -4134,7 +4134,7 @@ projectResponse:
               $ref: "#/components/schemas/nullableLicense"
             discussion_links:
               $ref: "#/components/schemas/assetLinkList"
-            edam_topics:
+            topic_annotations:
               $ref: "#/components/schemas/ontologyTermsList"
             start_date:
               $ref: "#/components/schemas/nullableDateString"
@@ -4758,9 +4758,9 @@ workflowResponse:
           properties:
             tags:
               $ref: "#/components/schemas/tags"
-            edam_topics:
+            topic_annotations:
               $ref: "#/components/schemas/ontologyTermsList"
-            edam_operations:
+            operation_annotations:
               $ref: "#/components/schemas/ontologyTermsList"
             title:
               $ref: "#/components/schemas/nonEmptyString"

--- a/public/api/examples/dataFilePatch.json
+++ b/public/api/examples/dataFilePatch.json
@@ -17,7 +17,7 @@
         "permissions": [
           {
             "resource": {
-              "id": "780",
+              "id": "555",
               "type": "projects"
             },
             "access": "edit"
@@ -29,7 +29,7 @@
       "creators": {
         "data": [
           {
-            "id": "719",
+            "id": "538",
             "type": "people"
           }
         ]
@@ -37,7 +37,7 @@
       "projects": {
         "data": [
           {
-            "id": "780",
+            "id": "555",
             "type": "projects"
           }
         ]
@@ -45,7 +45,7 @@
       "assays": {
         "data": [
           {
-            "id": "114",
+            "id": "61",
             "type": "assays"
           }
         ]
@@ -53,7 +53,7 @@
       "publications": {
         "data": [
           {
-            "id": "66",
+            "id": "41",
             "type": "publications"
           }
         ]
@@ -61,7 +61,7 @@
       "events": {
         "data": [
           {
-            "id": "30",
+            "id": "37",
             "type": "events"
           }
         ]
@@ -69,7 +69,7 @@
       "workflows": {
         "data": [
           {
-            "id": "40",
+            "id": "37",
             "type": "workflows"
           }
         ]

--- a/public/api/examples/dataFilePatchResponse.json
+++ b/public/api/examples/dataFilePatchResponse.json
@@ -8,7 +8,7 @@
         "permissions": [
           {
             "resource": {
-              "id": "780",
+              "id": "555",
               "type": "projects"
             },
             "access": "edit"
@@ -37,8 +37,8 @@
       ],
       "version": 1,
       "revision_comments": null,
-      "created_at": "2022-06-07T14:14:15.000Z",
-      "updated_at": "2022-06-07T14:14:16.000Z",
+      "created_at": "2022-07-18T09:03:19.000Z",
+      "updated_at": "2022-07-18T09:03:19.000Z",
       "doi": null,
       "content_blobs": [
         {
@@ -47,16 +47,16 @@
           "md5sum": "565ae8a7a743c3bfd9f15c69647f5b8b",
           "sha1sum": "b9d2148740050b7f37975edd0fb97faa508ff767",
           "content_type": "application/pdf",
-          "link": "http://localhost:3000/data_files/52/content_blobs/331",
+          "link": "http://localhost:3000/data_files/52/content_blobs/185",
           "size": 8827
         }
       ],
       "creators": [
         {
-          "profile": "/people/719",
+          "profile": "/people/538",
           "family_name": "Last",
-          "given_name": "Person601",
-          "affiliation": "An Institution: 729",
+          "given_name": "Person437",
+          "affiliation": "An Institution: 565",
           "orcid": null
         }
       ],
@@ -66,7 +66,7 @@
       "creators": {
         "data": [
           {
-            "id": "719",
+            "id": "538",
             "type": "people"
           }
         ]
@@ -74,7 +74,7 @@
       "submitter": {
         "data": [
           {
-            "id": "718",
+            "id": "537",
             "type": "people"
           }
         ]
@@ -82,11 +82,11 @@
       "people": {
         "data": [
           {
-            "id": "718",
+            "id": "537",
             "type": "people"
           },
           {
-            "id": "719",
+            "id": "538",
             "type": "people"
           }
         ]
@@ -94,7 +94,7 @@
       "projects": {
         "data": [
           {
-            "id": "780",
+            "id": "555",
             "type": "projects"
           }
         ]
@@ -102,7 +102,7 @@
       "investigations": {
         "data": [
           {
-            "id": "154",
+            "id": "69",
             "type": "investigations"
           }
         ]
@@ -110,7 +110,7 @@
       "studies": {
         "data": [
           {
-            "id": "135",
+            "id": "65",
             "type": "studies"
           }
         ]
@@ -118,7 +118,7 @@
       "assays": {
         "data": [
           {
-            "id": "114",
+            "id": "61",
             "type": "assays"
           }
         ]
@@ -126,7 +126,7 @@
       "publications": {
         "data": [
           {
-            "id": "66",
+            "id": "41",
             "type": "publications"
           }
         ]
@@ -134,7 +134,7 @@
       "events": {
         "data": [
           {
-            "id": "30",
+            "id": "37",
             "type": "events"
           }
         ]
@@ -142,7 +142,7 @@
       "workflows": {
         "data": [
           {
-            "id": "40",
+            "id": "37",
             "type": "workflows"
           }
         ]
@@ -158,11 +158,11 @@
       "self": "/data_files/52?version=1"
     },
     "meta": {
-      "created": "2022-06-07T14:14:15.000Z",
-      "modified": "2022-06-07T14:14:16.000Z",
+      "created": "2022-07-18T09:03:19.000Z",
+      "modified": "2022-07-18T09:03:19.000Z",
       "api_version": "0.3",
       "base_url": "http://localhost:3000",
-      "uuid": "09721140-c89a-013a-0f7e-0a81884ed284"
+      "uuid": "64627c50-e8a6-013a-1113-0a81884ed284"
     }
   },
   "jsonapi": {

--- a/public/api/examples/dataFilePost.json
+++ b/public/api/examples/dataFilePost.json
@@ -21,7 +21,7 @@
         "permissions": [
           {
             "resource": {
-              "id": "745",
+              "id": "520",
               "type": "projects"
             },
             "access": "edit"
@@ -33,7 +33,7 @@
       "creators": {
         "data": [
           {
-            "id": "680",
+            "id": "499",
             "type": "people"
           }
         ]
@@ -41,7 +41,7 @@
       "projects": {
         "data": [
           {
-            "id": "745",
+            "id": "520",
             "type": "projects"
           }
         ]
@@ -49,7 +49,7 @@
       "assays": {
         "data": [
           {
-            "id": "109",
+            "id": "56",
             "type": "assays"
           }
         ]
@@ -57,7 +57,7 @@
       "publications": {
         "data": [
           {
-            "id": "61",
+            "id": "36",
             "type": "publications"
           }
         ]
@@ -65,7 +65,7 @@
       "events": {
         "data": [
           {
-            "id": "25",
+            "id": "32",
             "type": "events"
           }
         ]
@@ -73,7 +73,7 @@
       "workflows": {
         "data": [
           {
-            "id": "35",
+            "id": "32",
             "type": "workflows"
           }
         ]

--- a/public/api/examples/dataFilePostResponse.json
+++ b/public/api/examples/dataFilePostResponse.json
@@ -8,7 +8,7 @@
         "permissions": [
           {
             "resource": {
-              "id": "745",
+              "id": "520",
               "type": "projects"
             },
             "access": "edit"
@@ -36,8 +36,8 @@
       ],
       "version": 1,
       "revision_comments": null,
-      "created_at": "2022-06-07T14:14:10.000Z",
-      "updated_at": "2022-06-07T14:14:10.000Z",
+      "created_at": "2022-07-18T09:03:13.000Z",
+      "updated_at": "2022-07-18T09:03:13.000Z",
       "doi": null,
       "content_blobs": [
         {
@@ -46,16 +46,16 @@
           "md5sum": null,
           "sha1sum": null,
           "content_type": "application/pdf",
-          "link": "http://localhost:3000/data_files/46/content_blobs/319",
+          "link": "http://localhost:3000/data_files/46/content_blobs/173",
           "size": null
         }
       ],
       "creators": [
         {
-          "profile": "/people/680",
+          "profile": "/people/499",
           "family_name": "Last",
-          "given_name": "Person567",
-          "affiliation": "An Institution: 690",
+          "given_name": "Person403",
+          "affiliation": "An Institution: 526",
           "orcid": null
         }
       ],
@@ -65,7 +65,7 @@
       "creators": {
         "data": [
           {
-            "id": "680",
+            "id": "499",
             "type": "people"
           }
         ]
@@ -73,7 +73,7 @@
       "submitter": {
         "data": [
           {
-            "id": "679",
+            "id": "498",
             "type": "people"
           }
         ]
@@ -81,11 +81,11 @@
       "people": {
         "data": [
           {
-            "id": "679",
+            "id": "498",
             "type": "people"
           },
           {
-            "id": "680",
+            "id": "499",
             "type": "people"
           }
         ]
@@ -93,7 +93,7 @@
       "projects": {
         "data": [
           {
-            "id": "745",
+            "id": "520",
             "type": "projects"
           }
         ]
@@ -101,7 +101,7 @@
       "investigations": {
         "data": [
           {
-            "id": "149",
+            "id": "64",
             "type": "investigations"
           }
         ]
@@ -109,7 +109,7 @@
       "studies": {
         "data": [
           {
-            "id": "130",
+            "id": "60",
             "type": "studies"
           }
         ]
@@ -117,7 +117,7 @@
       "assays": {
         "data": [
           {
-            "id": "109",
+            "id": "56",
             "type": "assays"
           }
         ]
@@ -125,7 +125,7 @@
       "publications": {
         "data": [
           {
-            "id": "61",
+            "id": "36",
             "type": "publications"
           }
         ]
@@ -133,7 +133,7 @@
       "events": {
         "data": [
           {
-            "id": "25",
+            "id": "32",
             "type": "events"
           }
         ]
@@ -141,7 +141,7 @@
       "workflows": {
         "data": [
           {
-            "id": "35",
+            "id": "32",
             "type": "workflows"
           }
         ]
@@ -157,11 +157,11 @@
       "self": "/data_files/46?version=1"
     },
     "meta": {
-      "created": "2022-06-07T14:14:10.000Z",
-      "modified": "2022-06-07T14:14:10.000Z",
+      "created": "2022-07-18T09:03:13.000Z",
+      "modified": "2022-07-18T09:03:13.000Z",
       "api_version": "0.3",
       "base_url": "http://localhost:3000",
-      "uuid": "065f3140-c89a-013a-0f7e-0a81884ed284"
+      "uuid": "609bd630-e8a6-013a-1113-0a81884ed284"
     }
   },
   "jsonapi": {

--- a/public/api/examples/dataFileResponse.json
+++ b/public/api/examples/dataFileResponse.json
@@ -11,7 +11,7 @@
       },
       "discussion_links": [
         {
-          "id": "62",
+          "id": "24",
           "label": "Slack",
           "url": "http://www.slack.com/"
         }
@@ -37,8 +37,8 @@
       ],
       "version": 1,
       "revision_comments": null,
-      "created_at": "2022-06-07T14:14:14.000Z",
-      "updated_at": "2022-06-07T14:14:14.000Z",
+      "created_at": "2022-07-18T09:03:18.000Z",
+      "updated_at": "2022-07-18T09:03:18.000Z",
       "doi": null,
       "content_blobs": [
         {
@@ -47,13 +47,13 @@
           "md5sum": "565ae8a7a743c3bfd9f15c69647f5b8b",
           "sha1sum": "b9d2148740050b7f37975edd0fb97faa508ff767",
           "content_type": "application/pdf",
-          "link": "http://localhost:3000/data_files/51/content_blobs/330",
+          "link": "http://localhost:3000/data_files/51/content_blobs/184",
           "size": 8827
         }
       ],
       "creators": [
         {
-          "profile": "/people/715",
+          "profile": "/people/534",
           "family_name": "One",
           "given_name": "Some",
           "affiliation": "University of Somewhere",
@@ -66,7 +66,7 @@
       "creators": {
         "data": [
           {
-            "id": "715",
+            "id": "534",
             "type": "people"
           }
         ]
@@ -74,7 +74,7 @@
       "submitter": {
         "data": [
           {
-            "id": "716",
+            "id": "535",
             "type": "people"
           }
         ]
@@ -82,11 +82,11 @@
       "people": {
         "data": [
           {
-            "id": "715",
+            "id": "534",
             "type": "people"
           },
           {
-            "id": "716",
+            "id": "535",
             "type": "people"
           }
         ]
@@ -94,7 +94,7 @@
       "projects": {
         "data": [
           {
-            "id": "778",
+            "id": "553",
             "type": "projects"
           }
         ]
@@ -102,7 +102,7 @@
       "investigations": {
         "data": [
           {
-            "id": "153",
+            "id": "68",
             "type": "investigations"
           }
         ]
@@ -110,7 +110,7 @@
       "studies": {
         "data": [
           {
-            "id": "134",
+            "id": "64",
             "type": "studies"
           }
         ]
@@ -118,7 +118,7 @@
       "assays": {
         "data": [
           {
-            "id": "113",
+            "id": "60",
             "type": "assays"
           }
         ]
@@ -126,7 +126,7 @@
       "publications": {
         "data": [
           {
-            "id": "65",
+            "id": "40",
             "type": "publications"
           }
         ]
@@ -134,7 +134,7 @@
       "events": {
         "data": [
           {
-            "id": "29",
+            "id": "36",
             "type": "events"
           }
         ]
@@ -142,7 +142,7 @@
       "workflows": {
         "data": [
           {
-            "id": "39",
+            "id": "36",
             "type": "workflows"
           }
         ]
@@ -158,11 +158,11 @@
       "self": "/data_files/51?version=1"
     },
     "meta": {
-      "created": "2022-06-07T14:14:14.000Z",
-      "modified": "2022-06-07T14:14:14.000Z",
+      "created": "2022-07-18T09:03:18.000Z",
+      "modified": "2022-07-18T09:03:18.000Z",
       "api_version": "0.3",
       "base_url": "http://localhost:3000",
-      "uuid": "08e45ae0-c89a-013a-0f7e-0a81884ed284"
+      "uuid": "63b51250-e8a6-013a-1113-0a81884ed284"
     }
   },
   "jsonapi": {

--- a/public/api/examples/fileTemplatePatch.json
+++ b/public/api/examples/fileTemplatePatch.json
@@ -9,13 +9,13 @@
         "tag1",
         "tag2"
       ],
-      "edam_data": [
+      "data_annotations": [
         {
           "label": "Sequence features metadata",
           "identifier": "http://edamontology.org/data_2914"
         }
       ],
-      "edam_formats": [
+      "format_annotations": [
         {
           "label": "JSON",
           "identifier": "http://edamontology.org/format_3464"

--- a/public/api/examples/fileTemplatePatchResponse.json
+++ b/public/api/examples/fileTemplatePatchResponse.json
@@ -36,8 +36,8 @@
       ],
       "version": 1,
       "revision_comments": null,
-      "created_at": "2022-07-07T14:43:07.000Z",
-      "updated_at": "2022-07-07T14:43:07.000Z",
+      "created_at": "2022-07-18T09:02:07.000Z",
+      "updated_at": "2022-07-18T09:02:07.000Z",
       "doi": null,
       "content_blobs": [
         {
@@ -60,13 +60,13 @@
         }
       ],
       "other_creators": "John Smith, Jane Smith",
-      "edam_data": [
+      "data_annotations": [
         {
           "label": "Sequence features metadata",
           "identifier": "http://edamontology.org/data_2914"
         }
       ],
-      "edam_formats": [
+      "format_annotations": [
         {
           "label": "JSON",
           "identifier": "http://edamontology.org/format_3464"
@@ -125,11 +125,11 @@
       "self": "/file_templates/41?version=1"
     },
     "meta": {
-      "created": "2022-07-07T14:43:07.000Z",
-      "modified": "2022-07-07T14:43:07.000Z",
+      "created": "2022-07-18T09:02:07.000Z",
+      "modified": "2022-07-18T09:02:07.000Z",
       "api_version": "0.3",
       "base_url": "http://localhost:3000",
-      "uuid": "0a09b6a0-e031-013a-10e0-0a81884ed284"
+      "uuid": "39475b90-e8a6-013a-1113-0a81884ed284"
     }
   },
   "jsonapi": {

--- a/public/api/examples/fileTemplatePost.json
+++ b/public/api/examples/fileTemplatePost.json
@@ -8,13 +8,13 @@
         "tag1",
         "tag2"
       ],
-      "edam_formats": [
+      "format_annotations": [
         {
           "label": "JSON",
           "identifier": "http://edamontology.org/format_3464"
         }
       ],
-      "edam_data": [
+      "data_annotations": [
         {
           "label": "Sequence features metadata",
           "identifier": "http://edamontology.org/data_2914"

--- a/public/api/examples/fileTemplatePostResponse.json
+++ b/public/api/examples/fileTemplatePostResponse.json
@@ -36,8 +36,8 @@
       ],
       "version": 1,
       "revision_comments": null,
-      "created_at": "2022-07-07T14:43:04.000Z",
-      "updated_at": "2022-07-07T14:43:04.000Z",
+      "created_at": "2022-07-18T09:02:04.000Z",
+      "updated_at": "2022-07-18T09:02:04.000Z",
       "doi": null,
       "content_blobs": [
         {
@@ -60,13 +60,13 @@
         }
       ],
       "other_creators": "John Smith, Jane Smith",
-      "edam_data": [
+      "data_annotations": [
         {
           "label": "Sequence features metadata",
           "identifier": "http://edamontology.org/data_2914"
         }
       ],
-      "edam_formats": [
+      "format_annotations": [
         {
           "label": "JSON",
           "identifier": "http://edamontology.org/format_3464"
@@ -125,11 +125,11 @@
       "self": "/file_templates/35?version=1"
     },
     "meta": {
-      "created": "2022-07-07T14:43:04.000Z",
-      "modified": "2022-07-07T14:43:04.000Z",
+      "created": "2022-07-18T09:02:04.000Z",
+      "modified": "2022-07-18T09:02:04.000Z",
       "api_version": "0.3",
       "base_url": "http://localhost:3000",
-      "uuid": "07ed35b0-e031-013a-10e0-0a81884ed284"
+      "uuid": "3761a220-e8a6-013a-1113-0a81884ed284"
     }
   },
   "jsonapi": {

--- a/public/api/examples/fileTemplateResponse.json
+++ b/public/api/examples/fileTemplateResponse.json
@@ -37,8 +37,8 @@
       ],
       "version": 1,
       "revision_comments": null,
-      "created_at": "2022-07-07T14:43:06.000Z",
-      "updated_at": "2022-07-07T14:43:06.000Z",
+      "created_at": "2022-07-18T09:02:06.000Z",
+      "updated_at": "2022-07-18T09:02:06.000Z",
       "doi": null,
       "content_blobs": [
         {
@@ -61,13 +61,13 @@
         }
       ],
       "other_creators": "Blogs, Joe",
-      "edam_data": [
+      "data_annotations": [
         {
           "label": "Sequence features metadata",
           "identifier": "http://edamontology.org/data_2914"
         }
       ],
-      "edam_formats": [
+      "format_annotations": [
         {
           "label": "JSON",
           "identifier": "http://edamontology.org/format_3464"
@@ -126,11 +126,11 @@
       "self": "/file_templates/40?version=1"
     },
     "meta": {
-      "created": "2022-07-07T14:43:06.000Z",
-      "modified": "2022-07-07T14:43:06.000Z",
+      "created": "2022-07-18T09:02:06.000Z",
+      "modified": "2022-07-18T09:02:06.000Z",
       "api_version": "0.3",
       "base_url": "http://localhost:3000",
-      "uuid": "09ac32a0-e031-013a-10e0-0a81884ed284"
+      "uuid": "38ef9590-e8a6-013a-1113-0a81884ed284"
     }
   },
   "jsonapi": {

--- a/public/api/examples/projectPatch.json
+++ b/public/api/examples/projectPatch.json
@@ -1,6 +1,6 @@
 {
   "data": {
-    "id": "1022251637",
+    "id": "389",
     "type": "projects",
     "attributes": {
       "avatar": null,
@@ -14,28 +14,28 @@
         "permissions": [
           {
             "resource": {
-              "id": "1039987395",
+              "id": "320",
               "type": "people"
             },
             "access": "manage"
           },
           {
             "resource": {
-              "id": "1022251637",
+              "id": "389",
               "type": "projects"
             },
             "access": "download"
           },
           {
             "resource": {
-              "id": "980191917",
+              "id": "347",
               "type": "institutions"
             },
             "access": "view"
           }
         ]
       },
-      "edam_topics": [
+      "topic_annotations": [
         {
           "label": "Biomedical science",
           "identifier": "http://edamontology.org/topic_3344"
@@ -50,7 +50,7 @@
       "programmes": {
         "data": [
           {
-            "id": "31",
+            "id": "29",
             "type": "programmes"
           }
         ]
@@ -58,7 +58,7 @@
       "organisms": {
         "data": [
           {
-            "id": "627234339",
+            "id": "29",
             "type": "organisms"
           }
         ]

--- a/public/api/examples/projectPatchResponse.json
+++ b/public/api/examples/projectPatchResponse.json
@@ -1,6 +1,6 @@
 {
   "data": {
-    "id": "1022251637",
+    "id": "389",
     "type": "projects",
     "attributes": {
       "discussion_links": [
@@ -19,21 +19,21 @@
         "permissions": [
           {
             "resource": {
-              "id": "1039987395",
+              "id": "320",
               "type": "people"
             },
             "access": "manage"
           },
           {
             "resource": {
-              "id": "1022251637",
+              "id": "389",
               "type": "projects"
             },
             "access": "download"
           },
           {
             "resource": {
-              "id": "980191917",
+              "id": "347",
               "type": "institutions"
             },
             "access": "view"
@@ -44,7 +44,7 @@
 
       ],
       "use_default_policy": false,
-      "edam_topics": [
+      "topic_annotations": [
         {
           "label": "Biomedical science",
           "identifier": "http://edamontology.org/topic_3344"
@@ -79,7 +79,7 @@
       "organisms": {
         "data": [
           {
-            "id": "627234339",
+            "id": "29",
             "type": "organisms"
           }
         ]
@@ -102,7 +102,7 @@
       "programmes": {
         "data": [
           {
-            "id": "31",
+            "id": "29",
             "type": "programmes"
           }
         ]
@@ -174,14 +174,14 @@
       }
     },
     "links": {
-      "self": "/projects/1022251637"
+      "self": "/projects/389"
     },
     "meta": {
-      "created": "2022-06-21T09:20:42.000Z",
-      "modified": "2022-06-21T09:20:43.000Z",
+      "created": "2022-07-18T09:02:41.000Z",
+      "modified": "2022-07-18T09:02:41.000Z",
       "api_version": "0.3",
       "base_url": "http://localhost:3000",
-      "uuid": "592ab3e0-d371-013a-101d-0a81884ed284"
+      "uuid": "4dd08e20-e8a6-013a-1113-0a81884ed284"
     }
   },
   "jsonapi": {

--- a/public/api/examples/projectPost.json
+++ b/public/api/examples/projectPost.json
@@ -13,28 +13,28 @@
         "permissions": [
           {
             "resource": {
-              "id": "1039987324",
+              "id": "249",
               "type": "people"
             },
             "access": "manage"
           },
           {
             "resource": {
-              "id": "1022251552",
+              "id": "304",
               "type": "projects"
             },
             "access": "download"
           },
           {
             "resource": {
-              "id": "980191843",
+              "id": "273",
               "type": "institutions"
             },
             "access": "view"
           }
         ]
       },
-      "edam_topics": [
+      "topic_annotations": [
         {
           "label": "Biomedical science",
           "identifier": "http://edamontology.org/topic_3344"
@@ -49,7 +49,7 @@
       "programmes": {
         "data": [
           {
-            "id": "26",
+            "id": "24",
             "type": "programmes"
           }
         ]
@@ -57,7 +57,7 @@
       "organisms": {
         "data": [
           {
-            "id": "627234334",
+            "id": "24",
             "type": "organisms"
           }
         ]

--- a/public/api/examples/projectPostResponse.json
+++ b/public/api/examples/projectPostResponse.json
@@ -1,6 +1,6 @@
 {
   "data": {
-    "id": "1022251554",
+    "id": "306",
     "type": "projects",
     "attributes": {
       "discussion_links": [
@@ -19,21 +19,21 @@
         "permissions": [
           {
             "resource": {
-              "id": "1039987324",
+              "id": "249",
               "type": "people"
             },
             "access": "manage"
           },
           {
             "resource": {
-              "id": "1022251552",
+              "id": "304",
               "type": "projects"
             },
             "access": "download"
           },
           {
             "resource": {
-              "id": "980191843",
+              "id": "273",
               "type": "institutions"
             },
             "access": "view"
@@ -44,7 +44,7 @@
 
       ],
       "use_default_policy": false,
-      "edam_topics": [
+      "topic_annotations": [
         {
           "label": "Biomedical science",
           "identifier": "http://edamontology.org/topic_3344"
@@ -79,7 +79,7 @@
       "organisms": {
         "data": [
           {
-            "id": "627234334",
+            "id": "24",
             "type": "organisms"
           }
         ]
@@ -102,7 +102,7 @@
       "programmes": {
         "data": [
           {
-            "id": "26",
+            "id": "24",
             "type": "programmes"
           }
         ]
@@ -174,14 +174,14 @@
       }
     },
     "links": {
-      "self": "/projects/1022251554"
+      "self": "/projects/306"
     },
     "meta": {
-      "created": "2022-06-21T09:20:32.000Z",
-      "modified": "2022-06-21T09:20:32.000Z",
+      "created": "2022-07-18T09:02:29.000Z",
+      "modified": "2022-07-18T09:02:29.000Z",
       "api_version": "0.3",
       "base_url": "http://localhost:3000",
-      "uuid": "53106880-d371-013a-101d-0a81884ed284"
+      "uuid": "468ab490-e8a6-013a-1113-0a81884ed284"
     }
   },
   "jsonapi": {

--- a/public/api/examples/projectResponse.json
+++ b/public/api/examples/projectResponse.json
@@ -1,16 +1,16 @@
 {
   "data": {
-    "id": "1022251633",
+    "id": "385",
     "type": "projects",
     "attributes": {
       "discussion_links": [
         {
-          "id": "25",
+          "id": "20",
           "label": "Slack",
           "url": "http://www.slack.com/"
         }
       ],
-      "avatar": "/projects/1022251633/avatars/4",
+      "avatar": "/projects/385/avatars/4",
       "title": "A Maximal Project",
       "description": "A Taverna project",
       "web_page": "http://www.taverna.org.uk",
@@ -26,12 +26,12 @@
       },
       "members": [
         {
-          "person_id": "1039987392",
-          "institution_id": "980191913"
+          "person_id": "317",
+          "institution_id": "343"
         }
       ],
       "use_default_policy": true,
-      "edam_topics": [
+      "topic_annotations": [
         {
           "label": "Biomedical science",
           "identifier": "http://edamontology.org/topic_3344"
@@ -76,7 +76,7 @@
       "people": {
         "data": [
           {
-            "id": "1039987392",
+            "id": "317",
             "type": "people"
           }
         ]
@@ -84,7 +84,7 @@
       "institutions": {
         "data": [
           {
-            "id": "980191913",
+            "id": "343",
             "type": "institutions"
           }
         ]
@@ -92,7 +92,7 @@
       "programmes": {
         "data": [
           {
-            "id": "30",
+            "id": "28",
             "type": "programmes"
           }
         ]
@@ -100,7 +100,7 @@
       "investigations": {
         "data": [
           {
-            "id": "973654998",
+            "id": "36",
             "type": "investigations"
           }
         ]
@@ -108,7 +108,7 @@
       "studies": {
         "data": [
           {
-            "id": "1060385051",
+            "id": "32",
             "type": "studies"
           }
         ]
@@ -116,7 +116,7 @@
       "assays": {
         "data": [
           {
-            "id": "1035386829",
+            "id": "28",
             "type": "assays"
           }
         ]
@@ -124,7 +124,7 @@
       "data_files": {
         "data": [
           {
-            "id": "883654461",
+            "id": "8",
             "type": "data_files"
           }
         ]
@@ -142,7 +142,7 @@
       "models": {
         "data": [
           {
-            "id": "1004285525",
+            "id": "32",
             "type": "models"
           }
         ]
@@ -150,7 +150,7 @@
       "sops": {
         "data": [
           {
-            "id": "1055250460",
+            "id": "8",
             "type": "sops"
           }
         ]
@@ -158,7 +158,7 @@
       "publications": {
         "data": [
           {
-            "id": "14",
+            "id": "8",
             "type": "publications"
           }
         ]
@@ -174,7 +174,7 @@
       "events": {
         "data": [
           {
-            "id": "1025618657",
+            "id": "4",
             "type": "events"
           }
         ]
@@ -182,7 +182,7 @@
       "documents": {
         "data": [
           {
-            "id": "26",
+            "id": "8",
             "type": "documents"
           }
         ]
@@ -190,21 +190,21 @@
       "workflows": {
         "data": [
           {
-            "id": "23",
+            "id": "4",
             "type": "workflows"
           }
         ]
       }
     },
     "links": {
-      "self": "/projects/1022251633"
+      "self": "/projects/385"
     },
     "meta": {
-      "created": "2022-06-21T09:20:42.000Z",
-      "modified": "2022-06-21T09:20:42.000Z",
+      "created": "2022-07-18T09:02:41.000Z",
+      "modified": "2022-07-18T09:02:41.000Z",
       "api_version": "0.3",
       "base_url": "http://localhost:3000",
-      "uuid": "58e815f0-d371-013a-101d-0a81884ed284"
+      "uuid": "4d7f4ed0-e8a6-013a-1113-0a81884ed284"
     }
   },
   "jsonapi": {

--- a/public/api/examples/projectsResponse.json
+++ b/public/api/examples/projectsResponse.json
@@ -1,353 +1,353 @@
 {
   "data": [
     {
-      "id": "1022251588",
+      "id": "344",
       "type": "projects",
       "attributes": {
-        "title": "A Project: -220"
+        "title": "A Project: -336"
       },
       "links": {
-        "self": "/projects/1022251588"
+        "self": "/projects/344"
       }
     },
     {
-      "id": "1022251589",
+      "id": "345",
       "type": "projects",
       "attributes": {
-        "title": "A Project: -221"
+        "title": "A Project: -337"
       },
       "links": {
-        "self": "/projects/1022251589"
+        "self": "/projects/345"
       }
     },
     {
-      "id": "1022251590",
-      "type": "projects",
-      "attributes": {
-        "title": "A Project: -222"
-      },
-      "links": {
-        "self": "/projects/1022251590"
-      }
-    },
-    {
-      "id": "1022251591",
-      "type": "projects",
-      "attributes": {
-        "title": "A Project: -223"
-      },
-      "links": {
-        "self": "/projects/1022251591"
-      }
-    },
-    {
-      "id": "1022251592",
-      "type": "projects",
-      "attributes": {
-        "title": "A Project: -224"
-      },
-      "links": {
-        "self": "/projects/1022251592"
-      }
-    },
-    {
-      "id": "1022251593",
-      "type": "projects",
-      "attributes": {
-        "title": "A Project: -225"
-      },
-      "links": {
-        "self": "/projects/1022251593"
-      }
-    },
-    {
-      "id": "1022251594",
+      "id": "346",
       "type": "projects",
       "attributes": {
         "title": "A Maximal Project"
       },
       "links": {
-        "self": "/projects/1022251594"
+        "self": "/projects/346"
       }
     },
     {
-      "id": "1022251581",
+      "id": "337",
       "type": "projects",
       "attributes": {
-        "title": "A Project: -213"
+        "title": "A Project: -329"
       },
       "links": {
-        "self": "/projects/1022251581"
+        "self": "/projects/337"
       }
     },
     {
-      "id": "1022251582",
+      "id": "338",
       "type": "projects",
       "attributes": {
-        "title": "A Project: -214"
+        "title": "A Project: -330"
       },
       "links": {
-        "self": "/projects/1022251582"
+        "self": "/projects/338"
       }
     },
     {
-      "id": "1022251583",
+      "id": "339",
       "type": "projects",
       "attributes": {
-        "title": "A Project: -215"
+        "title": "A Project: -331"
       },
       "links": {
-        "self": "/projects/1022251583"
+        "self": "/projects/339"
       }
     },
     {
-      "id": "1022251584",
+      "id": "340",
       "type": "projects",
       "attributes": {
-        "title": "A Project: -216"
+        "title": "A Project: -332"
       },
       "links": {
-        "self": "/projects/1022251584"
+        "self": "/projects/340"
       }
     },
     {
-      "id": "1022251585",
+      "id": "341",
       "type": "projects",
       "attributes": {
-        "title": "A Project: -217"
+        "title": "A Project: -333"
       },
       "links": {
-        "self": "/projects/1022251585"
+        "self": "/projects/341"
       }
     },
     {
-      "id": "1022251586",
+      "id": "342",
       "type": "projects",
       "attributes": {
-        "title": "A Project: -218"
+        "title": "A Project: -334"
       },
       "links": {
-        "self": "/projects/1022251586"
+        "self": "/projects/342"
       }
     },
     {
-      "id": "1022251587",
+      "id": "343",
       "type": "projects",
       "attributes": {
-        "title": "A Project: -219"
+        "title": "A Project: -335"
       },
       "links": {
-        "self": "/projects/1022251587"
+        "self": "/projects/343"
       }
     },
     {
-      "id": "1022251574",
+      "id": "330",
       "type": "projects",
       "attributes": {
-        "title": "A Project: -206"
+        "title": "A Project: -322"
       },
       "links": {
-        "self": "/projects/1022251574"
+        "self": "/projects/330"
       }
     },
     {
-      "id": "1022251575",
+      "id": "331",
       "type": "projects",
       "attributes": {
-        "title": "A Project: -207"
+        "title": "A Project: -323"
       },
       "links": {
-        "self": "/projects/1022251575"
+        "self": "/projects/331"
       }
     },
     {
-      "id": "1022251576",
+      "id": "332",
       "type": "projects",
       "attributes": {
-        "title": "A Project: -208"
+        "title": "A Project: -324"
       },
       "links": {
-        "self": "/projects/1022251576"
+        "self": "/projects/332"
       }
     },
     {
-      "id": "1022251577",
+      "id": "333",
       "type": "projects",
       "attributes": {
-        "title": "A Project: -209"
+        "title": "A Project: -325"
       },
       "links": {
-        "self": "/projects/1022251577"
+        "self": "/projects/333"
       }
     },
     {
-      "id": "1022251578",
+      "id": "334",
       "type": "projects",
       "attributes": {
-        "title": "A Project: -210"
+        "title": "A Project: -326"
       },
       "links": {
-        "self": "/projects/1022251578"
+        "self": "/projects/334"
       }
     },
     {
-      "id": "1022251579",
+      "id": "335",
       "type": "projects",
       "attributes": {
-        "title": "A Project: -211"
+        "title": "A Project: -327"
       },
       "links": {
-        "self": "/projects/1022251579"
+        "self": "/projects/335"
       }
     },
     {
-      "id": "1022251580",
+      "id": "336",
       "type": "projects",
       "attributes": {
-        "title": "A Project: -212"
+        "title": "A Project: -328"
       },
       "links": {
-        "self": "/projects/1022251580"
+        "self": "/projects/336"
       }
     },
     {
-      "id": "1022251568",
+      "id": "326",
       "type": "projects",
       "attributes": {
-        "title": "A Project: -200"
+        "title": "A Project: -318"
       },
       "links": {
-        "self": "/projects/1022251568"
+        "self": "/projects/326"
       }
     },
     {
-      "id": "1022251569",
+      "id": "327",
       "type": "projects",
       "attributes": {
-        "title": "A Project: -201"
+        "title": "A Project: -319"
       },
       "links": {
-        "self": "/projects/1022251569"
+        "self": "/projects/327"
       }
     },
     {
-      "id": "1022251570",
+      "id": "328",
       "type": "projects",
       "attributes": {
-        "title": "A Project: -202"
+        "title": "A Project: -320"
       },
       "links": {
-        "self": "/projects/1022251570"
+        "self": "/projects/328"
       }
     },
     {
-      "id": "1022251571",
+      "id": "329",
       "type": "projects",
       "attributes": {
-        "title": "A Project: -203"
+        "title": "A Project: -321"
       },
       "links": {
-        "self": "/projects/1022251571"
+        "self": "/projects/329"
       }
     },
     {
-      "id": "1022251572",
+      "id": "320",
       "type": "projects",
       "attributes": {
-        "title": "A Project: -204"
+        "title": "A Project: -312"
       },
       "links": {
-        "self": "/projects/1022251572"
+        "self": "/projects/320"
       }
     },
     {
-      "id": "1022251573",
+      "id": "321",
       "type": "projects",
       "attributes": {
-        "title": "A Project: -205"
+        "title": "A Project: -313"
       },
       "links": {
-        "self": "/projects/1022251573"
+        "self": "/projects/321"
       }
     },
     {
-      "id": "1022251560",
+      "id": "322",
+      "type": "projects",
+      "attributes": {
+        "title": "A Project: -314"
+      },
+      "links": {
+        "self": "/projects/322"
+      }
+    },
+    {
+      "id": "323",
+      "type": "projects",
+      "attributes": {
+        "title": "A Project: -315"
+      },
+      "links": {
+        "self": "/projects/323"
+      }
+    },
+    {
+      "id": "324",
+      "type": "projects",
+      "attributes": {
+        "title": "A Project: -316"
+      },
+      "links": {
+        "self": "/projects/324"
+      }
+    },
+    {
+      "id": "325",
+      "type": "projects",
+      "attributes": {
+        "title": "A Project: -317"
+      },
+      "links": {
+        "self": "/projects/325"
+      }
+    },
+    {
+      "id": "312",
       "type": "projects",
       "attributes": {
         "title": "A Minimal Project"
       },
       "links": {
-        "self": "/projects/1022251560"
+        "self": "/projects/312"
       }
     },
     {
-      "id": "1022251561",
+      "id": "313",
       "type": "projects",
       "attributes": {
-        "title": "A Project: -193"
+        "title": "A Project: -305"
       },
       "links": {
-        "self": "/projects/1022251561"
+        "self": "/projects/313"
       }
     },
     {
-      "id": "1022251562",
+      "id": "314",
       "type": "projects",
       "attributes": {
-        "title": "A Project: -194"
+        "title": "A Project: -306"
       },
       "links": {
-        "self": "/projects/1022251562"
+        "self": "/projects/314"
       }
     },
     {
-      "id": "1022251563",
+      "id": "315",
       "type": "projects",
       "attributes": {
-        "title": "A Project: -195"
+        "title": "A Project: -307"
       },
       "links": {
-        "self": "/projects/1022251563"
+        "self": "/projects/315"
       }
     },
     {
-      "id": "1022251564",
+      "id": "316",
       "type": "projects",
       "attributes": {
-        "title": "A Project: -196"
+        "title": "A Project: -308"
       },
       "links": {
-        "self": "/projects/1022251564"
+        "self": "/projects/316"
       }
     },
     {
-      "id": "1022251565",
+      "id": "317",
       "type": "projects",
       "attributes": {
-        "title": "A Project: -197"
+        "title": "A Project: -309"
       },
       "links": {
-        "self": "/projects/1022251565"
+        "self": "/projects/317"
       }
     },
     {
-      "id": "1022251566",
+      "id": "318",
       "type": "projects",
       "attributes": {
-        "title": "A Project: -198"
+        "title": "A Project: -310"
       },
       "links": {
-        "self": "/projects/1022251566"
+        "self": "/projects/318"
       }
     },
     {
-      "id": "1022251567",
+      "id": "319",
       "type": "projects",
       "attributes": {
-        "title": "A Project: -199"
+        "title": "A Project: -311"
       },
       "links": {
-        "self": "/projects/1022251567"
+        "self": "/projects/319"
       }
     }
   ],

--- a/public/api/examples/workflowPatch.json
+++ b/public/api/examples/workflowPatch.json
@@ -1,7 +1,7 @@
 {
   "data": {
     "type": "workflows",
-    "id": "36",
+    "id": "73",
     "attributes": {
       "title": "A Maximally Patched Workflow",
       "description": "A workflow to do important stuff",
@@ -13,7 +13,7 @@
         "tag2",
         "tag3"
       ],
-      "edam_operations": [
+      "operation_annotations": [
         {
           "label": "Clustering",
           "identifier": "http://edamontology.org/operation_3432"
@@ -23,7 +23,7 @@
           "identifier": "http://edamontology.org/operation_3465"
         }
       ],
-      "edam_topics": [
+      "topic_annotations": [
         {
           "label": "Chemistry",
           "identifier": "http://edamontology.org/topic_3314"
@@ -40,7 +40,7 @@
         "permissions": [
           {
             "resource": {
-              "id": "248",
+              "id": "693",
               "type": "projects"
             },
             "access": "edit"
@@ -52,7 +52,7 @@
       "creators": {
         "data": [
           {
-            "id": "245",
+            "id": "674",
             "type": "people"
           }
         ]
@@ -60,7 +60,7 @@
       "projects": {
         "data": [
           {
-            "id": "248",
+            "id": "693",
             "type": "projects"
           }
         ]
@@ -68,7 +68,7 @@
       "assays": {
         "data": [
           {
-            "id": "32",
+            "id": "89",
             "type": "assays"
           }
         ]
@@ -76,7 +76,7 @@
       "publications": {
         "data": [
           {
-            "id": "28",
+            "id": "69",
             "type": "publications"
           }
         ]
@@ -84,7 +84,7 @@
       "presentations": {
         "data": [
           {
-            "id": "24",
+            "id": "28",
             "type": "presentations"
           }
         ]
@@ -92,7 +92,7 @@
       "data_files": {
         "data": [
           {
-            "id": "24",
+            "id": "76",
             "type": "data_files"
           }
         ]
@@ -100,7 +100,7 @@
       "documents": {
         "data": [
           {
-            "id": "24",
+            "id": "32",
             "type": "documents"
           }
         ]
@@ -108,7 +108,7 @@
       "sops": {
         "data": [
           {
-            "id": "24",
+            "id": "32",
             "type": "sops"
           }
         ]

--- a/public/api/examples/workflowPatchResponse.json
+++ b/public/api/examples/workflowPatchResponse.json
@@ -1,6 +1,6 @@
 {
   "data": {
-    "id": "36",
+    "id": "73",
     "type": "workflows",
     "attributes": {
       "policy": {
@@ -8,7 +8,7 @@
         "permissions": [
           {
             "resource": {
-              "id": "248",
+              "id": "693",
               "type": "projects"
             },
             "access": "edit"
@@ -31,14 +31,14 @@
         {
           "version": 1,
           "revision_comments": null,
-          "url": "http://localhost:3000/workflows/36?version=1",
+          "url": "http://localhost:3000/workflows/73?version=1",
           "doi": null
         }
       ],
       "version": 1,
       "revision_comments": null,
-      "created_at": "2022-07-07T14:43:44.000Z",
-      "updated_at": "2022-07-07T14:43:44.000Z",
+      "created_at": "2022-07-18T09:03:55.000Z",
+      "updated_at": "2022-07-18T09:03:55.000Z",
       "doi": null,
       "content_blobs": [
         {
@@ -47,16 +47,16 @@
           "md5sum": "ef2ea32522098acc937199f6c2b64f41",
           "sha1sum": "a5133ccdb0376324d039431e4eff4f7d21a751cd",
           "content_type": "application/x-yaml",
-          "link": "http://localhost:3000/workflows/36/content_blobs/185",
+          "link": "http://localhost:3000/workflows/73/content_blobs/326",
           "size": 732
         }
       ],
       "creators": [
         {
-          "profile": "/people/245",
+          "profile": "/people/674",
           "family_name": "Last",
-          "given_name": "Person186",
-          "affiliation": "An Institution: 245",
+          "given_name": "Person545",
+          "affiliation": "An Institution: 701",
           "orcid": null
         }
       ],
@@ -66,7 +66,7 @@
         "key": "cwl",
         "description": "Common Workflow Language"
       },
-      "edam_operations": [
+      "operation_annotations": [
         {
           "label": "Clustering",
           "identifier": "http://edamontology.org/operation_3432"
@@ -76,7 +76,7 @@
           "identifier": "http://edamontology.org/operation_3465"
         }
       ],
-      "edam_topics": [
+      "topic_annotations": [
         {
           "label": "Chemistry",
           "identifier": "http://edamontology.org/topic_3314"
@@ -93,7 +93,7 @@
       "creators": {
         "data": [
           {
-            "id": "245",
+            "id": "674",
             "type": "people"
           }
         ]
@@ -101,7 +101,7 @@
       "submitter": {
         "data": [
           {
-            "id": "244",
+            "id": "673",
             "type": "people"
           }
         ]
@@ -109,11 +109,11 @@
       "people": {
         "data": [
           {
-            "id": "244",
+            "id": "673",
             "type": "people"
           },
           {
-            "id": "245",
+            "id": "674",
             "type": "people"
           }
         ]
@@ -121,7 +121,7 @@
       "projects": {
         "data": [
           {
-            "id": "248",
+            "id": "693",
             "type": "projects"
           }
         ]
@@ -129,7 +129,7 @@
       "investigations": {
         "data": [
           {
-            "id": "32",
+            "id": "97",
             "type": "investigations"
           }
         ]
@@ -137,7 +137,7 @@
       "studies": {
         "data": [
           {
-            "id": "32",
+            "id": "93",
             "type": "studies"
           }
         ]
@@ -145,7 +145,7 @@
       "assays": {
         "data": [
           {
-            "id": "32",
+            "id": "89",
             "type": "assays"
           }
         ]
@@ -153,7 +153,7 @@
       "publications": {
         "data": [
           {
-            "id": "28",
+            "id": "69",
             "type": "publications"
           }
         ]
@@ -161,7 +161,7 @@
       "sops": {
         "data": [
           {
-            "id": "24",
+            "id": "32",
             "type": "sops"
           }
         ]
@@ -169,7 +169,7 @@
       "presentations": {
         "data": [
           {
-            "id": "24",
+            "id": "28",
             "type": "presentations"
           }
         ]
@@ -177,7 +177,7 @@
       "data_files": {
         "data": [
           {
-            "id": "24",
+            "id": "76",
             "type": "data_files"
           }
         ]
@@ -185,21 +185,21 @@
       "documents": {
         "data": [
           {
-            "id": "24",
+            "id": "32",
             "type": "documents"
           }
         ]
       }
     },
     "links": {
-      "self": "/workflows/36?version=1"
+      "self": "/workflows/73?version=1"
     },
     "meta": {
-      "created": "2022-07-07T14:43:44.000Z",
-      "modified": "2022-07-07T14:43:44.000Z",
+      "created": "2022-07-18T09:03:55.000Z",
+      "modified": "2022-07-18T09:03:55.000Z",
       "api_version": "0.3",
       "base_url": "http://localhost:3000",
-      "uuid": "1fdf3730-e031-013a-10e0-0a81884ed284"
+      "uuid": "79dadd40-e8a6-013a-1113-0a81884ed284"
     }
   },
   "jsonapi": {

--- a/public/api/examples/workflowPost.json
+++ b/public/api/examples/workflowPost.json
@@ -11,7 +11,7 @@
         "tag1",
         "tag2"
       ],
-      "edam_operations": [
+      "operation_annotations": [
         {
           "label": "Clustering",
           "identifier": "http://edamontology.org/operation_3432"
@@ -21,7 +21,7 @@
           "identifier": "http://edamontology.org/operation_3463"
         }
       ],
-      "edam_topics": [
+      "topic_annotations": [
         {
           "label": "Biomedical science",
           "identifier": "http://edamontology.org/topic_3344"
@@ -44,7 +44,7 @@
         "permissions": [
           {
             "resource": {
-              "id": "217",
+              "id": "662",
               "type": "projects"
             },
             "access": "edit"
@@ -56,7 +56,7 @@
       "creators": {
         "data": [
           {
-            "id": "216",
+            "id": "645",
             "type": "people"
           }
         ]
@@ -64,7 +64,7 @@
       "projects": {
         "data": [
           {
-            "id": "217",
+            "id": "662",
             "type": "projects"
           }
         ]
@@ -72,7 +72,7 @@
       "assays": {
         "data": [
           {
-            "id": "27",
+            "id": "84",
             "type": "assays"
           }
         ]
@@ -80,7 +80,7 @@
       "publications": {
         "data": [
           {
-            "id": "23",
+            "id": "64",
             "type": "publications"
           }
         ]
@@ -88,7 +88,7 @@
       "presentations": {
         "data": [
           {
-            "id": "21",
+            "id": "25",
             "type": "presentations"
           }
         ]
@@ -96,7 +96,7 @@
       "data_files": {
         "data": [
           {
-            "id": "21",
+            "id": "73",
             "type": "data_files"
           }
         ]
@@ -104,7 +104,7 @@
       "documents": {
         "data": [
           {
-            "id": "21",
+            "id": "29",
             "type": "documents"
           }
         ]
@@ -112,7 +112,7 @@
       "sops": {
         "data": [
           {
-            "id": "21",
+            "id": "29",
             "type": "sops"
           }
         ]

--- a/public/api/examples/workflowPostResponse.json
+++ b/public/api/examples/workflowPostResponse.json
@@ -1,6 +1,6 @@
 {
   "data": {
-    "id": "30",
+    "id": "67",
     "type": "workflows",
     "attributes": {
       "policy": {
@@ -8,7 +8,7 @@
         "permissions": [
           {
             "resource": {
-              "id": "217",
+              "id": "662",
               "type": "projects"
             },
             "access": "edit"
@@ -30,14 +30,14 @@
         {
           "version": 1,
           "revision_comments": null,
-          "url": "http://localhost:3000/workflows/30?version=1",
+          "url": "http://localhost:3000/workflows/67?version=1",
           "doi": null
         }
       ],
       "version": 1,
       "revision_comments": null,
-      "created_at": "2022-07-07T14:43:37.000Z",
-      "updated_at": "2022-07-07T14:43:37.000Z",
+      "created_at": "2022-07-18T09:03:49.000Z",
+      "updated_at": "2022-07-18T09:03:49.000Z",
       "doi": null,
       "content_blobs": [
         {
@@ -46,16 +46,16 @@
           "md5sum": null,
           "sha1sum": null,
           "content_type": "application/x-yaml",
-          "link": "http://localhost:3000/workflows/30/content_blobs/163",
+          "link": "http://localhost:3000/workflows/67/content_blobs/304",
           "size": null
         }
       ],
       "creators": [
         {
-          "profile": "/people/216",
+          "profile": "/people/645",
           "family_name": "Last",
-          "given_name": "Person162",
-          "affiliation": "An Institution: 216",
+          "given_name": "Person521",
+          "affiliation": "An Institution: 672",
           "orcid": null
         }
       ],
@@ -65,7 +65,7 @@
         "key": "cwl",
         "description": "Common Workflow Language"
       },
-      "edam_operations": [
+      "operation_annotations": [
         {
           "label": "Clustering",
           "identifier": "http://edamontology.org/operation_3432"
@@ -75,7 +75,7 @@
           "identifier": "http://edamontology.org/operation_3463"
         }
       ],
-      "edam_topics": [
+      "topic_annotations": [
         {
           "label": "Biomedical science",
           "identifier": "http://edamontology.org/topic_3344"
@@ -92,7 +92,7 @@
       "creators": {
         "data": [
           {
-            "id": "216",
+            "id": "645",
             "type": "people"
           }
         ]
@@ -100,7 +100,7 @@
       "submitter": {
         "data": [
           {
-            "id": "215",
+            "id": "644",
             "type": "people"
           }
         ]
@@ -108,11 +108,11 @@
       "people": {
         "data": [
           {
-            "id": "215",
+            "id": "644",
             "type": "people"
           },
           {
-            "id": "216",
+            "id": "645",
             "type": "people"
           }
         ]
@@ -120,7 +120,7 @@
       "projects": {
         "data": [
           {
-            "id": "217",
+            "id": "662",
             "type": "projects"
           }
         ]
@@ -128,7 +128,7 @@
       "investigations": {
         "data": [
           {
-            "id": "27",
+            "id": "92",
             "type": "investigations"
           }
         ]
@@ -136,7 +136,7 @@
       "studies": {
         "data": [
           {
-            "id": "27",
+            "id": "88",
             "type": "studies"
           }
         ]
@@ -144,7 +144,7 @@
       "assays": {
         "data": [
           {
-            "id": "27",
+            "id": "84",
             "type": "assays"
           }
         ]
@@ -152,7 +152,7 @@
       "publications": {
         "data": [
           {
-            "id": "23",
+            "id": "64",
             "type": "publications"
           }
         ]
@@ -160,7 +160,7 @@
       "sops": {
         "data": [
           {
-            "id": "21",
+            "id": "29",
             "type": "sops"
           }
         ]
@@ -168,7 +168,7 @@
       "presentations": {
         "data": [
           {
-            "id": "21",
+            "id": "25",
             "type": "presentations"
           }
         ]
@@ -176,7 +176,7 @@
       "data_files": {
         "data": [
           {
-            "id": "21",
+            "id": "73",
             "type": "data_files"
           }
         ]
@@ -184,21 +184,21 @@
       "documents": {
         "data": [
           {
-            "id": "21",
+            "id": "29",
             "type": "documents"
           }
         ]
       }
     },
     "links": {
-      "self": "/workflows/30?version=1"
+      "self": "/workflows/67?version=1"
     },
     "meta": {
-      "created": "2022-07-07T14:43:37.000Z",
-      "modified": "2022-07-07T14:43:37.000Z",
+      "created": "2022-07-18T09:03:49.000Z",
+      "modified": "2022-07-18T09:03:49.000Z",
       "api_version": "0.3",
       "base_url": "http://localhost:3000",
-      "uuid": "1c03ebd0-e031-013a-10e0-0a81884ed284"
+      "uuid": "760ca2e0-e8a6-013a-1113-0a81884ed284"
     }
   },
   "jsonapi": {

--- a/public/api/examples/workflowResponse.json
+++ b/public/api/examples/workflowResponse.json
@@ -1,6 +1,6 @@
 {
   "data": {
-    "id": "35",
+    "id": "72",
     "type": "workflows",
     "attributes": {
       "policy": {
@@ -11,7 +11,7 @@
       },
       "discussion_links": [
         {
-          "id": "8",
+          "id": "28",
           "label": "Slack",
           "url": "http://www.slack.com/"
         }
@@ -31,14 +31,14 @@
         {
           "version": 1,
           "revision_comments": null,
-          "url": "http://localhost:3000/workflows/35?version=1",
+          "url": "http://localhost:3000/workflows/72?version=1",
           "doi": null
         }
       ],
       "version": 1,
       "revision_comments": null,
-      "created_at": "2022-07-07T14:43:42.000Z",
-      "updated_at": "2022-07-07T14:43:42.000Z",
+      "created_at": "2022-07-18T09:03:54.000Z",
+      "updated_at": "2022-07-18T09:03:54.000Z",
       "doi": null,
       "content_blobs": [
         {
@@ -47,13 +47,13 @@
           "md5sum": "ef2ea32522098acc937199f6c2b64f41",
           "sha1sum": "a5133ccdb0376324d039431e4eff4f7d21a751cd",
           "content_type": "application/x-yaml",
-          "link": "http://localhost:3000/workflows/35/content_blobs/180",
+          "link": "http://localhost:3000/workflows/72/content_blobs/321",
           "size": 732
         }
       ],
       "creators": [
         {
-          "profile": "/people/241",
+          "profile": "/people/670",
           "family_name": "One",
           "given_name": "Some",
           "affiliation": "University of Somewhere",
@@ -66,13 +66,13 @@
         "key": "cwl",
         "description": "Common Workflow Language"
       },
-      "edam_operations": [
+      "operation_annotations": [
         {
           "label": "Clustering",
           "identifier": "http://edamontology.org/operation_3432"
         }
       ],
-      "edam_topics": [
+      "topic_annotations": [
         {
           "label": "Chemistry",
           "identifier": "http://edamontology.org/topic_3314"
@@ -85,7 +85,7 @@
       "creators": {
         "data": [
           {
-            "id": "241",
+            "id": "670",
             "type": "people"
           }
         ]
@@ -93,7 +93,7 @@
       "submitter": {
         "data": [
           {
-            "id": "242",
+            "id": "671",
             "type": "people"
           }
         ]
@@ -101,11 +101,11 @@
       "people": {
         "data": [
           {
-            "id": "241",
+            "id": "670",
             "type": "people"
           },
           {
-            "id": "242",
+            "id": "671",
             "type": "people"
           }
         ]
@@ -113,7 +113,7 @@
       "projects": {
         "data": [
           {
-            "id": "246",
+            "id": "691",
             "type": "projects"
           }
         ]
@@ -121,7 +121,7 @@
       "investigations": {
         "data": [
           {
-            "id": "31",
+            "id": "96",
             "type": "investigations"
           }
         ]
@@ -129,7 +129,7 @@
       "studies": {
         "data": [
           {
-            "id": "31",
+            "id": "92",
             "type": "studies"
           }
         ]
@@ -137,7 +137,7 @@
       "assays": {
         "data": [
           {
-            "id": "31",
+            "id": "88",
             "type": "assays"
           }
         ]
@@ -145,7 +145,7 @@
       "publications": {
         "data": [
           {
-            "id": "27",
+            "id": "68",
             "type": "publications"
           }
         ]
@@ -172,14 +172,14 @@
       }
     },
     "links": {
-      "self": "/workflows/35?version=1"
+      "self": "/workflows/72?version=1"
     },
     "meta": {
-      "created": "2022-07-07T14:43:42.000Z",
-      "modified": "2022-07-07T14:43:42.000Z",
+      "created": "2022-07-18T09:03:54.000Z",
+      "modified": "2022-07-18T09:03:54.000Z",
       "api_version": "0.3",
       "base_url": "http://localhost:3000",
-      "uuid": "1f086c50-e031-013a-10e0-0a81884ed284"
+      "uuid": "79068240-e8a6-013a-1113-0a81884ed284"
     }
   },
   "jsonapi": {

--- a/test/fixtures/json/requests/patch_max_file_template.json.erb
+++ b/test/fixtures/json/requests/patch_max_file_template.json.erb
@@ -9,13 +9,13 @@
         "tag1",
         "tag2"
       ],
-      "edam_data": [
+      "data_annotations": [
         {
           "label": "Sequence features metadata",
           "identifier": "http://edamontology.org/data_2914"
         }
       ],
-      "edam_formats": [
+      "format_annotations": [
         {
           "label": "JSON",
           "identifier": "http://edamontology.org/format_3464"

--- a/test/fixtures/json/requests/patch_max_project.json.erb
+++ b/test/fixtures/json/requests/patch_max_project.json.erb
@@ -35,7 +35,7 @@
           }
         ]
       },
-      "edam_topics": [
+      "topic_annotations": [
         {
           "label": "Biomedical science",
           "identifier": "http://edamontology.org/topic_3344"

--- a/test/fixtures/json/requests/patch_max_workflow.json.erb
+++ b/test/fixtures/json/requests/patch_max_workflow.json.erb
@@ -13,7 +13,7 @@
         "tag2",
         "tag3"
       ],
-      "edam_operations": [
+      "operation_annotations": [
         {
           "label": "Clustering",
           "identifier": "http://edamontology.org/operation_3432"
@@ -23,7 +23,7 @@
           "identifier": "http://edamontology.org/operation_3465"
         }
       ],
-      "edam_topics": [
+      "topic_annotations": [
         {
           "label": "Chemistry",
           "identifier": "http://edamontology.org/topic_3314"

--- a/test/fixtures/json/requests/post_max_file_template.json.erb
+++ b/test/fixtures/json/requests/post_max_file_template.json.erb
@@ -8,13 +8,13 @@
         "tag1",
         "tag2"
       ],
-      "edam_formats": [
+      "format_annotations": [
         {
           "label": "JSON",
           "identifier": "http://edamontology.org/format_3464"
         }
       ],
-      "edam_data": [
+      "data_annotations": [
         {
           "label": "Sequence features metadata",
           "identifier": "http://edamontology.org/data_2914"

--- a/test/fixtures/json/requests/post_max_project.json.erb
+++ b/test/fixtures/json/requests/post_max_project.json.erb
@@ -34,7 +34,7 @@
           }
         ]
       },
-      "edam_topics": [
+      "topic_annotations": [
         {
           "label": "Biomedical science",
           "identifier": "http://edamontology.org/topic_3344"

--- a/test/fixtures/json/requests/post_max_workflow.json.erb
+++ b/test/fixtures/json/requests/post_max_workflow.json.erb
@@ -11,7 +11,7 @@
         "tag1",
         "tag2"
       ],
-      "edam_operations": [
+      "operation_annotations": [
         {
           "label": "Clustering",
           "identifier": "http://edamontology.org/operation_3432"
@@ -21,7 +21,7 @@
           "identifier": "http://edamontology.org/operation_3463"
         }
       ],
-      "edam_topics": [
+      "topic_annotations": [
         {
           "label": "Biomedical science",
           "identifier": "http://edamontology.org/topic_3344"

--- a/test/fixtures/json/responses/get_max_file_template.json.erb
+++ b/test/fixtures/json/responses/get_max_file_template.json.erb
@@ -25,13 +25,13 @@
       ],
       "title": "A Maximal FileTemplate",
       "description": "The important report we did for ~important-milestone~",
-      "edam_data": [
+      "data_annotations": [
         {
           "label": "Sequence features metadata",
           "identifier": "http://edamontology.org/data_2914"
         }
       ],
-      "edam_formats": [
+      "format_annotations": [
         {
           "label": "JSON",
           "identifier": "http://edamontology.org/format_3464"

--- a/test/fixtures/json/responses/get_max_project.json.erb
+++ b/test/fixtures/json/responses/get_max_project.json.erb
@@ -25,7 +25,7 @@
           "label": "Slack"
         }
       ],
-      "edam_topics": [
+      "topic_annotations": [
         {
           "label": "Biomedical science",
           "identifier": "http://edamontology.org/topic_3344"

--- a/test/fixtures/json/responses/get_max_workflow.json.erb
+++ b/test/fixtures/json/responses/get_max_workflow.json.erb
@@ -16,13 +16,13 @@
       ],
       "title": "A Maximal Workflow",
       "description": "How to run a simulation in GROMACS",
-      "edam_operations": [
+      "operation_annotations": [
         {
           "label": "Clustering",
           "identifier": "http://edamontology.org/operation_3432"
         }
       ],
-      "edam_topics": [
+      "topic_annotations": [
         {
           "label": "Chemistry",
           "identifier": "http://edamontology.org/topic_3314"

--- a/test/unit/workflow_test.rb
+++ b/test/unit/workflow_test.rb
@@ -559,8 +559,8 @@ class WorkflowTest < ActiveSupport::TestCase
 
     assert_equal ["Workflow-tag1", "Workflow-tag2", "Workflow-tag3", "Workflow-tag4", "Workflow-tag5"], json[:tags]
 
-    assert_equal [{label:'Clustering', identifier: 'http://edamontology.org/operation_3432'}], json[:edam_operations]
-    assert_equal [{label:'Chemistry', identifier: 'http://edamontology.org/topic_3314'}], json[:edam_topics]
+    assert_equal [{label:'Clustering', identifier: 'http://edamontology.org/operation_3432'}], json[:operation_annotations]
+    assert_equal [{label:'Chemistry', identifier: 'http://edamontology.org/topic_3314'}], json[:topic_annotations]
   end
 
   test 'edam annotation properties'do


### PR DESCRIPTION
removed EDAM specific names, and made more generic. `edam_topics` becomes `topic_annotations` etc.

Part of the #1037 task 