### PR TITLE
allow admin to edit system CV's

### DIFF
--- a/app/models/sample_controlled_vocab.rb
+++ b/app/models/sample_controlled_vocab.rb
@@ -36,7 +36,11 @@ class SampleControlledVocab < ApplicationRecord
   end
 
   def can_edit?(user = User.current_user)
-    !system_vocab? && samples.empty? && user && (!Seek::Config.project_admin_sample_type_restriction || user.is_admin_or_project_administrator?) && Seek::Config.samples_enabled
+    return false unless Seek::Config.samples_enabled
+    return false unless user
+    return true if user.is_admin?
+
+    !system_vocab? && samples.empty? && (!Seek::Config.project_admin_sample_type_restriction || user.is_admin_or_project_administrator?)
   end
 
   # a vocabulary that is built in and seeded, and that other parts are dependent upon


### PR DESCRIPTION
small change, to allow admins to edit builtin system controlled vocabs and also those with samples. related to #1037