### PR TITLE
Allow users to create projects bug 583

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -839,7 +839,7 @@ class ProjectsController < ApplicationController
     if @programme.new_record?
       error_msg = "You need to be an administrator" unless User.admin_logged_in?
     else
-      error_msg = "No rights to administer #{t('programme')}" unless ( @programme.can_associate_projects? )
+      error_msg = "No rights to administer #{t('programme')}" unless @programme.can_associate_projects?
     end
 
     if error_msg

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -187,7 +187,7 @@ class ProjectsController < ApplicationController
 
       @programme = Programme.find(params[:programme_id])
       raise "no #{t('programme')} can be found" if @programme.nil?
-      if @programme.can_manage? || @programme.allows_user_projects?
+      if @programme.can_associate_projects?
         log = ProjectCreationMessageLog.log_request(sender:current_person, programme:@programme, project:@project, institution:@institution)
       elsif @programme.site_managed?
         log = ProjectCreationMessageLog.log_request(sender:current_person, programme:@programme, project:@project, institution:@institution)
@@ -217,7 +217,7 @@ class ProjectsController < ApplicationController
       flash.now[:notice]="Thank you, your request for a new #{t('project')} has been sent"
     end
 
-    if User.admin_logged_in? || (@programme && (@programme.can_manage? || @programme.allows_user_projects?))
+    if User.admin_logged_in? || @programme&.can_associate_projects?
       redirect_to administer_create_project_request_projects_path(message_log_id: log.id)
     else
       respond_to do |format|
@@ -685,7 +685,7 @@ class ProjectsController < ApplicationController
 
     if params[:project][:programme_id].present?
       prog = Programme.find_by_id(params[:project][:programme_id])
-      if prog&.can_manage? || prog&.allows_user_projects?
+      if prog&.can_associate_projects?
         permitted_params += [:programme_id]
       end
     end
@@ -839,7 +839,7 @@ class ProjectsController < ApplicationController
     if @programme.new_record?
       error_msg = "You need to be an administrator" unless User.admin_logged_in?
     else
-      error_msg = "No rights to administer #{t('programme')}" unless ( @programme.can_manage? || @programme.allows_user_projects?)
+      error_msg = "No rights to administer #{t('programme')}" unless ( @programme.can_associate_projects? )
     end
 
     if error_msg

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -582,7 +582,10 @@ class ProjectsController < ApplicationController
 
       if validate_error_msg.blank?
         @project.save!
-        @institution.save!
+
+        # they are soon to become a project administrator, with permission to create
+        disable_authorization_checks { @institution.save! }
+
         requester.add_to_project_and_institution(@project, @institution)
         requester.is_project_administrator = true,@project
         requester.is_programme_administrator = true, @programme if make_programme_admin

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -217,7 +217,7 @@ class ProjectsController < ApplicationController
       flash.now[:notice]="Thank you, your request for a new #{t('project')} has been sent"
     end
 
-    if User.admin_logged_in? || @programme&.can_associate_projects?
+    if @programme&.can_associate_projects?
       redirect_to administer_create_project_request_projects_path(message_log_id: log.id)
     else
       respond_to do |format|

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -110,7 +110,7 @@ class Programme < ApplicationRecord
   end
 
   def allows_user_projects?
-    open_for_projects? && Seek::Config.programmes_open_for_projects_enabled
+    Seek::Config.programmes_open_for_projects_enabled && open_for_projects?
   end
 
   def self.any_programmes_open_for_projects?

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -104,6 +104,11 @@ class Programme < ApplicationRecord
     user && user.is_admin? && !is_activated?
   end
 
+  # whether there is permission to associate projects
+  def can_associate_projects?(user = User.current_user)
+    can_manage?(user) || allows_user_projects?
+  end
+
   def allows_user_projects?
     open_for_projects? && Seek::Config.programmes_open_for_projects_enabled
   end

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -46,6 +46,7 @@ class Programme < ApplicationRecord
   scope :activated, -> { where(is_activated: true) }
   scope :not_activated, -> { where(is_activated: false) }
   scope :rejected, -> { where('is_activated = ? AND activation_rejection_reason IS NOT NULL', false) }
+  scope :open_for_projects, -> { where(open_for_projects: true) }
 
   has_annotation_type :funding_code
   has_many :funding_codes_as_text, through: :funding_code_annotations, source: :value, source_type: 'TextValue'
@@ -107,8 +108,15 @@ class Programme < ApplicationRecord
     open_for_projects? && Seek::Config.programmes_open_for_projects_enabled
   end
 
+  def self.any_programmes_open_for_projects?
+    return false unless Seek::Config.programmes_open_for_projects_enabled
+
+    open_for_projects.any?
+  end
+
   def self.can_create?
     return false unless Seek::Config.programmes_enabled
+
     User.admin_logged_in? || (User.logged_in_and_registered? && Seek::Config.programme_user_creation_enabled)
   end
 

--- a/app/models/project_creation_message_log.rb
+++ b/app/models/project_creation_message_log.rb
@@ -28,7 +28,7 @@ class ProjectCreationMessageLog < MessageLog
     if programme.id.nil?
       person.is_admin?
     else
-      (person.is_admin? && programme.site_managed?) || person.is_programme_administrator?(programme)
+      (person.is_admin? && programme.site_managed?) || person.is_programme_administrator?(programme) || programme.allows_user_projects?
     end
   end
 end

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -46,7 +46,7 @@
 
 <% if Seek::Config.programmes_enabled &&
     (admin_or_programme_administrator_logged_in? ||
-        (logged_in_and_registered? && Programme.any? { |p| p.allows_user_projects? }))%>
+        (logged_in_and_registered? && Programme.any_programmes_open_for_projects? ))%>
     <%= render :partial=>"projects/programme_selection", :locals=>{:f=>f} -%>
 <% end %>
 

--- a/app/views/projects/_programme_selection.html.erb
+++ b/app/views/projects/_programme_selection.html.erb
@@ -1,7 +1,8 @@
 <%
     include_blank = (admin_logged_in? && params[:programme_id].blank?) ? "No associated #{t('programme')}" : nil
-    available = User.current_user.person.administered_programmes.activated +
-        Programme.select { |p| p.allows_user_projects? }
+    available = User.current_user.person.administered_programmes.activated
+    available = available & Programme.open_for_projects if Programme.any_programmes_open_for_projects?
+
     if params[:programme_id]
       available =   available.select{|p| p.id.to_s == params[:programme_id]}
     end

--- a/app/views/projects/_programme_selection.html.erb
+++ b/app/views/projects/_programme_selection.html.erb
@@ -1,7 +1,7 @@
 <%
     include_blank = (admin_logged_in? && params[:programme_id].blank?) ? "No associated #{t('programme')}" : nil
     available = User.current_user.person.administered_programmes.activated
-    available = available & Programme.open_for_projects if Programme.any_programmes_open_for_projects?
+    available = available | Programme.open_for_projects if Programme.any_programmes_open_for_projects?
 
     if params[:programme_id]
       available =   available.select{|p| p.id.to_s == params[:programme_id]}

--- a/app/views/projects/guided_create/_programme_dropdown.html.erb
+++ b/app/views/projects/guided_create/_programme_dropdown.html.erb
@@ -8,7 +8,9 @@
 <% end %>
 
 <%
-  programmes = (User.current_user.person.administered_programmes.activated | [Programme.site_managed_programme]).compact.uniq
+  person = User.current_user.person
+  programmes = person.administered_programmes.activated.select{|prog| person.is_programme_administrator?(prog)}
+  programmes = programmes | [Programme.site_managed_programme]
   if Programme.any_programmes_open_for_projects?
     programmes = programmes | Programme.open_for_projects
   end

--- a/app/views/projects/guided_create/_programme_dropdown.html.erb
+++ b/app/views/projects/guided_create/_programme_dropdown.html.erb
@@ -10,7 +10,7 @@
 <%
   person = User.current_user.person
   programmes = person.administered_programmes.activated.select{|prog| person.is_programme_administrator?(prog)}
-  programmes = programmes | [Programme.site_managed_programme]
+  programmes = programmes | [Programme.site_managed_programme] if Programme.site_managed_programme
   if Programme.any_programmes_open_for_projects?
     programmes = programmes | Programme.open_for_projects
   end

--- a/app/views/projects/guided_create/_programme_dropdown.html.erb
+++ b/app/views/projects/guided_create/_programme_dropdown.html.erb
@@ -6,8 +6,16 @@
     You can also choose the <%= "#{Seek::Config.instance_admins_name} managed #{t('programme')}" %>, <%= link_to Programme.site_managed_programme.title, Programme.site_managed_programme %>, and if so you will need to wait for approval.
   </div>
 <% end %>
-<% programmes = (Programme.all.select{|p| User.current_user.person.is_programme_administrator?(p)} + [Programme.site_managed_programme]).compact.uniq %>
+
+<%
+  programmes = (User.current_user.person.administered_programmes.activated + [Programme.site_managed_programme]).compact.uniq
+  if Programme.any_programmes_open_for_projects?
+    programmes = programmes | Programme.open_for_projects
+  end
+%>
+
 <%= select_tag :programme_id,options_from_collection_for_select(programmes,:id, :title), class: 'form-control' %>
+
 <% if Seek::ProjectFormProgrammeOptions.creation_allowed? %>
   <div class="help-block">
     Alternatively you can choose to create a new <%= t('programme') %>, which your new <%= t('project') %> will be associated with.

--- a/app/views/projects/guided_create/_programme_dropdown.html.erb
+++ b/app/views/projects/guided_create/_programme_dropdown.html.erb
@@ -8,7 +8,7 @@
 <% end %>
 
 <%
-  programmes = (User.current_user.person.administered_programmes.activated + [Programme.site_managed_programme]).compact.uniq
+  programmes = (User.current_user.person.administered_programmes.activated | [Programme.site_managed_programme]).compact.uniq
   if Programme.any_programmes_open_for_projects?
     programmes = programmes | Programme.open_for_projects
   end

--- a/lib/seek/project_form_programme_options.rb
+++ b/lib/seek/project_form_programme_options.rb
@@ -7,6 +7,7 @@ module Seek
       def show_programme_box?
         Seek::Config.programmes_enabled && (
           programme_administrator_logged_in? ||
+            Programme.any_programmes_open_for_projects? ||
             Programme.site_managed_programme.present? ||
             Programme.can_create?
         )
@@ -14,7 +15,7 @@ module Seek
 
       # whether the programmes should be selected from a drop down box
       def programme_dropdown?
-        show_programme_box? && programme_administrator_logged_in?
+        show_programme_box? && (programme_administrator_logged_in? || Programme.any_programmes_open_for_projects?)
       end
 
       # whether there should be a checkbox to select a managed programme

--- a/test/functional/projects_controller_test.rb
+++ b/test/functional/projects_controller_test.rb
@@ -1772,12 +1772,11 @@ class ProjectsControllerTest < ActionController::TestCase
     assert_response :success
     assert_select 'input#managed_programme', count: 0
     assert_select 'select#programme_id' do
-      # as an admin, all programmes are available as an option
-      assert_select 'option', count: 4
+      assert_select 'option', count: 2
       assert_select 'option', value: managed_prog.id, text: managed_prog.title
       assert_select 'option', value: admin_prog.id, text: admin_prog.title
-      assert_select 'option', value: person_prog.id, text: person_prog.title
-      assert_select 'option', value: another_prog.id, text: another_prog.title
+      assert_select 'option', value: person_prog.id, text: person_prog.title, count: 0
+      assert_select 'option', value: another_prog.id, text: another_prog.title, count: 0
     end
   end
 

--- a/test/functional/projects_controller_test.rb
+++ b/test/functional/projects_controller_test.rb
@@ -1758,7 +1758,7 @@ class ProjectsControllerTest < ActionController::TestCase
 
   test 'guided create with administered programmes as admin' do
     person = Factory(:programme_administrator)
-    managed_prog = Factory(:programme, title:'THE MANAGED ONE')
+    managed_prog = Factory(:programme, title: 'THE MANAGED ONE')
     person_prog = person.programmes.first
     another_prog = Factory(:programme)
     admin = Factory(:admin)
@@ -1770,13 +1770,14 @@ class ProjectsControllerTest < ActionController::TestCase
       get :guided_create
     end
     assert_response :success
-    assert_select 'input#managed_programme', count:0
+    assert_select 'input#managed_programme', count: 0
     assert_select 'select#programme_id' do
-      assert_select 'option',count:2
-      assert_select 'option',value:managed_prog.id,text:managed_prog.title
-      assert_select 'option',value:admin_prog.id,text:admin_prog.title
-      assert_select 'option',value:person_prog.id,text:person_prog.title, count:0
-      assert_select 'option',value:another_prog.id,text:another_prog.title, count:0
+      # as an admin, all programmes are available as an option
+      assert_select 'option', count: 4
+      assert_select 'option', value: managed_prog.id, text: managed_prog.title
+      assert_select 'option', value: admin_prog.id, text: admin_prog.title
+      assert_select 'option', value: person_prog.id, text: person_prog.title
+      assert_select 'option', value: another_prog.id, text: another_prog.title
     end
   end
 

--- a/test/unit/message_log_test.rb
+++ b/test/unit/message_log_test.rb
@@ -327,6 +327,19 @@ class MessageLogTest < ActiveSupport::TestCase
     assert log.can_respond_project_creation_request?(admin)
     refute log.can_respond_project_creation_request?(prog_admin)
     refute log.can_respond_project_creation_request?(person)
+
+    # programme open to projects
+    programme = Factory(:programme, open_for_projects: true)
+    log = ProjectCreationMessageLog.log_request(sender: person, programme: programme,
+                                                project: project, institution: institution)
+    with_config_value(:programmes_open_for_projects_enabled, true) do
+      assert log.can_respond_project_creation_request?(person)
+    end
+
+    with_config_value(:programmes_open_for_projects_enabled, false) do
+      refute log.can_respond_project_creation_request?(person)
+    end
+
   end
 
   test 'handles legacy serialized fields' do

--- a/test/unit/programme_test.rb
+++ b/test/unit/programme_test.rb
@@ -508,4 +508,31 @@ class ProgrammeTest < ActiveSupport::TestCase
       refute prog2.allows_user_projects?
     end
   end
+
+  test 'open for projects scope' do
+    prog = Factory(:programme, open_for_projects: true)
+    prog2 = Factory(:programme, open_for_projects: false)
+    prog3 = Factory(:programme, open_for_projects: true)
+
+    assert_equal [prog, prog3].sort, Programme.open_for_projects.sort
+  end
+
+  test 'any_programmes_open_for_projects?' do
+
+    # no programmes
+    with_config_value(:programmes_open_for_projects_enabled,true) do
+      refute Programme.any_programmes_open_for_projects?
+    end
+
+    Factory(:programme, open_for_projects: true)
+    Factory(:programme, open_for_projects: false)
+
+    with_config_value(:programmes_open_for_projects_enabled, true) do
+      assert Programme.any_programmes_open_for_projects?
+    end
+    with_config_value(:programmes_open_for_projects_enabled, false) do
+      refute Programme.any_programmes_open_for_projects?
+    end
+
+  end
 end


### PR DESCRIPTION
Handle the special case of Programmes flagged as open for user projects, not requiring approval, also determined by whether the global configuration allows it.

Fixed #583 