### PR TITLE
Remove node annotations 1226

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -48,7 +48,7 @@ class TagsController < ApplicationController
 
   def find_tagged_objects
     types = tag_types_for_selection
-    @tagged_objects = @tag.annotations.with_attribute_name(types).collect(&:annotatable).uniq.select(&:can_view?)
+    @tagged_objects = @tag.annotations.with_attribute_name(types).collect(&:annotatable).uniq.compact.select(&:can_view?)
   end
 
   def tag_types_for_selection

--- a/lib/tasks/seek.rake
+++ b/lib/tasks/seek.rake
@@ -167,4 +167,41 @@ namespace :seek do
     puts "Writing API examples..."
     system("RAILS_ENV=test SEEK_WRITE_EXAMPLES=true rails test test/integration/api -n /test_write_.+_example/")
   end
+
+  task(convert_mysql_charset: [:environment]) do
+    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == 'mysql2'
+      puts "Attempting MySQL database conversion"
+      # Get charset from database.yml, then find appropriate collation from mysql
+      db = ActiveRecord::Base.connection.current_database
+      charset = ActiveRecord::Base.connection.instance_values["config"][:encoding] || 'utf8mb4'
+      collation = "#{charset}_unicode_ci" # Prefer e.g. utf8_unicode_ci over utf8_general_ci
+      collation = ActiveRecord::Base.connection.execute("SHOW COLLATION WHERE Charset = '#{charset}' AND Collation = '#{collation}';").first&.first
+      unless collation
+        # Pick default collation for given charset if above collation not available
+        collation = ActiveRecord::Base.connection.execute("SHOW COLLATION WHERE Charset = '#{charset}' `Default` = 'Yes';").first&.first
+        unless collation
+          puts "Could not find collation for charset: #{charset}, aborting"
+          return
+        end
+      end
+
+      puts "Converting database: #{db} to character set: #{charset}, collation: #{collation}"
+
+      # Set database defaults
+      puts "Setting default charset and collation"
+      ActiveRecord::Base.connection.execute("ALTER DATABASE #{db} DEFAULT CHARACTER SET #{charset} DEFAULT COLLATE #{collation};")
+
+      # Set/convert each table
+      tables = ActiveRecord::Base.connection.exec_query("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES where TABLE_SCHEMA='#{db}' AND TABLE_COLLATION != '#{collation}';").rows.flatten
+      puts "#{tables.count} tables to convert"
+      tables.each do |table|
+        puts "  Converting #{table}"
+        ActiveRecord::Base.connection.execute("ALTER TABLE #{table} CONVERT TO CHARACTER SET #{charset} COLLATE #{collation};")
+      end
+      puts "Done"
+    else
+      puts "Database adapter is: #{ActiveRecord::Base.connection.instance_values["config"][:adapter]}, doing nothing"
+    end
+  end
+
 end

--- a/lib/tasks/seek_upgrades.rake
+++ b/lib/tasks/seek_upgrades.rake
@@ -27,6 +27,8 @@ namespace :seek do
     convert_roles
     update_edam_annotation_attributes
     remove_orphaned_project_subscriptions
+    remove_node_activity_logs
+    remove_node_asset_creators
   ]
 
   # these are the tasks that are executes for each upgrade as standard, and rarely change
@@ -255,6 +257,18 @@ namespace :seek do
     disable_authorization_checks do
       ProjectSubscription.where.missing(:project).destroy_all
     end
+  end
+
+  task(remove_node_activity_logs: [:environment]) do
+    logs = ActivityLog.where(activity_loggable_type: 'Node')
+    puts "Removing #{logs.count} Node related activity logs" if logs.count > 0
+    logs.delete_all
+  end
+
+  task(remove_node_asset_creators: [:environment]) do
+    creators = AssetsCreator.where(asset_type: 'Node')
+    puts "Removing #{creators.count} Node related asset creators" if creators.count > 0
+    creators.delete_all
   end
 
 end

--- a/lib/tasks/seek_upgrades.rake
+++ b/lib/tasks/seek_upgrades.rake
@@ -118,42 +118,6 @@ namespace :seek do
     puts "... finished removing #{count} orphaned versions"
   end
 
-  task(convert_mysql_charset: [:environment]) do
-    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == 'mysql2'
-      puts "Attempting MySQL database conversion"
-      # Get charset from database.yml, then find appropriate collation from mysql
-      db = ActiveRecord::Base.connection.current_database
-      charset = ActiveRecord::Base.connection.instance_values["config"][:encoding] || 'utf8mb4'
-      collation = "#{charset}_unicode_ci" # Prefer e.g. utf8_unicode_ci over utf8_general_ci
-      collation = ActiveRecord::Base.connection.execute("SHOW COLLATION WHERE Charset = '#{charset}' AND Collation = '#{collation}';").first&.first
-      unless collation
-        # Pick default collation for given charset if above collation not available
-        collation = ActiveRecord::Base.connection.execute("SHOW COLLATION WHERE Charset = '#{charset}' `Default` = 'Yes';").first&.first
-        unless collation
-          puts "Could not find collation for charset: #{charset}, aborting"
-          return
-        end
-      end
-
-      puts "Converting database: #{db} to character set: #{charset}, collation: #{collation}"
-
-      # Set database defaults
-      puts "Setting default charset and collation"
-      ActiveRecord::Base.connection.execute("ALTER DATABASE #{db} DEFAULT CHARACTER SET #{charset} DEFAULT COLLATE #{collation};")
-
-      # Set/convert each table
-      tables = ActiveRecord::Base.connection.exec_query("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES where TABLE_SCHEMA='#{db}' AND TABLE_COLLATION != '#{collation}';").rows.flatten
-      puts "#{tables.count} tables to convert"
-      tables.each do |table|
-        puts "  Converting #{table}"
-        ActiveRecord::Base.connection.execute("ALTER TABLE #{table} CONVERT TO CHARACTER SET #{charset} COLLATE #{collation};")
-      end
-      puts "Done"
-    else
-      puts "Database adapter is: #{ActiveRecord::Base.connection.instance_values["config"][:adapter]}, doing nothing"
-    end
-  end
-
   task(remove_scale_annotations: [:environment]) do
     a = Annotation.joins(:annotation_attribute).where(annotation_attribute: { name: ['additional_scale_info', 'scale'] })
     count = a.count

--- a/lib/tasks/seek_upgrades.rake
+++ b/lib/tasks/seek_upgrades.rake
@@ -23,6 +23,7 @@ namespace :seek do
     seek:rebuild_workflow_internals
     remove_scale_annotations
     remove_spreadsheet_annotations
+    remove_node_annotations
     convert_roles
     update_edam_annotation_attributes
   ]
@@ -166,6 +167,15 @@ namespace :seek do
     annotations.destroy_all
     AnnotationAttribute.where(name:'annotation').destroy_all
     puts "Removed #{count} spreadsheet related annotations" if count > 0
+  end
+
+  task(remove_node_annotations: [:environment]) do
+    annotations = Annotation.where(annotatable_type: 'Node')
+    count = annotations.count
+    values = TextValue.joins(:annotations).where(annotations: { annotatable_type: 'Node' })
+    values.select{|v| v.annotations.count == 1}.each(&:destroy)
+    annotations.destroy_all
+    puts "Removed #{count} Node related annotations" if count > 0
   end
 
   task(convert_roles: [:environment]) do


### PR DESCRIPTION
Upgrade tasks to remove Node references from annotations, activitylogs and asset creators (very Ibisba specific). 
Also some defensive code to protect against an annotation linked to a nil item 

Moved `convert_mysql_charset` task into the general seek tasks, as it is not run as part of the upgrade.

