### PR TITLE
handle a message log having been deleted when trying to respond #1228

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -785,10 +785,13 @@ class ProjectsController < ApplicationController
   def validate_message_log_for_join
     @message_log = ProjectMembershipMessageLog.find_by_id(params[:message_log_id])
 
-    error_msg ||= "message log not found" unless @message_log
-    error_msg ||= ("message log doesn't match #{t('project')}" if @message_log.subject != @project)
-    error_msg ||= ("incorrect type of message log" unless @message_log.project_membership_request?)
-    error_msg ||= ("message has already been responded to" if @message_log.responded?)
+    if @message_log
+      error_msg ||= ("message log doesn't match #{t('project')}" if @message_log.subject != @project)
+      error_msg ||= ("incorrect type of message log" unless @message_log.project_membership_request?)
+      error_msg ||= ("message has already been responded to" if @message_log.responded?)
+    else
+      error_msg = "message cannot be found, it is possible it has been deleted by another administrator"
+    end
 
     if error_msg
       error(error_msg, error_msg)
@@ -798,10 +801,13 @@ class ProjectsController < ApplicationController
 
   def validate_message_log_for_create
     @message_log = ProjectCreationMessageLog.find_by_id(params[:message_log_id])
-    error_msg ||= "you do not have permission to respond to this request" unless @message_log.can_respond_project_creation_request?(current_user)
-    error_msg ||= "message log not found" unless @message_log
-    error_msg ||= ("incorrect type of message log" unless @message_log.project_creation_request?)
-    error_msg ||= ("message has already been responded to" if @message_log.responded?)
+    if @message_log
+      error_msg ||= "you do not have permission to respond to this request" unless @message_log.can_respond_project_creation_request?(current_user)
+      error_msg ||= ("incorrect type of message log" unless @message_log.project_creation_request?)
+      error_msg ||= ("message has already been responded to" if @message_log.responded?)
+    else
+      error_msg = "message cannot be found, it is possible it has been deleted by another administrator"
+    end
 
     if error_msg
       error(error_msg, error_msg)

--- a/test/functional/projects_controller_test.rb
+++ b/test/functional/projects_controller_test.rb
@@ -2074,6 +2074,18 @@ class ProjectsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test 'administer join request, message deleted' do
+    person = Factory(:project_administrator)
+    project = person.projects.first
+    login_as(person)
+
+    id = (MessageLog.last&.id || 0) + 1
+    get :administer_join_request, params:{id:project.id,message_log_id: id}
+    assert_redirected_to :root
+    refute_nil flash[:error]
+    assert_match /deleted/i, flash[:error]
+  end
+
   test 'administer join request with new institution that was since created' do
     person = Factory(:project_administrator)
     project = person.projects.first
@@ -2351,6 +2363,16 @@ class ProjectsControllerTest < ActionController::TestCase
     log = ProjectCreationMessageLog.log_request(sender:Factory(:person), programme:programme, project:project, institution:institution)
     get :administer_create_project_request, params:{message_log_id:log.id}
     assert_response :success
+  end
+
+  test 'administer create project request, message log deleted' do
+    person = Factory(:admin)
+    login_as(person)
+    id = (MessageLog.last&.id || 0) + 1
+    get :administer_create_project_request, params:{message_log_id:id}
+    assert_redirected_to :root
+    refute_nil flash[:error]
+    assert_match /deleted/i, flash[:error]
   end
 
   test 'administer create request project with institution already created' do


### PR DESCRIPTION
Gracefully handle missing message logs when trying to respond, which have most likely been deleted

relates to #1228 