### PR TITLE
Sample extraction error reporting and Background taskjob errors

### DIFF
--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -184,6 +184,22 @@ module SamplesHelper
     }
   end
 
+  def show_extract_samples_button?(asset, display_asset)
+    return false unless ( asset.can_manage? && (display_asset.version == asset.version) && asset.sample_template? && asset.extracted_samples.empty? )
+    return ! ( asset.sample_extraction_task&.in_progress? || ( asset.sample_extraction_task&.success? && Seek::Samples::Extractor.new(asset).fetch.present? ) )
+
+    rescue Seek::Samples::FetchException
+      return true # allows to try again
+
+  end
+
+  def show_sample_extraction_status?(data_file)
+    # there is permission and a task
+    return false unless data_file.can_manage? && data_file.sample_extraction_task&.persisted?
+    # persistence isn't currently running or already taken place
+    return !( data_file.sample_persistence_task&.success? || data_file.sample_persistence_task&.in_progress? )
+  end
+
   private
 
   def attribute_form_element(attribute, resource, element_name, element_class )

--- a/app/jobs/sample_data_extraction_job.rb
+++ b/app/jobs/sample_data_extraction_job.rb
@@ -1,12 +1,19 @@
 class SampleDataExtractionJob < TaskJob
   queue_as QueueNames::SAMPLES
+
+  attr_reader :extractor
   def perform(data_file, sample_type, overwrite: false)
-    extractor = Seek::Samples::Extractor.new(data_file, sample_type)
-    extractor.clear
-    extractor.extract(overwrite)
+    @extractor = Seek::Samples::Extractor.new(data_file, sample_type)
+    @extractor.clear
+    @extractor.extract(overwrite)
   end
 
   def task
     arguments[0].sample_extraction_task
+  end
+
+  def handle_error(exception)
+    super
+    @extractor.clear
   end
 end

--- a/app/jobs/sample_data_extraction_job.rb
+++ b/app/jobs/sample_data_extraction_job.rb
@@ -14,6 +14,6 @@ class SampleDataExtractionJob < TaskJob
 
   def handle_error(exception)
     super
-    @extractor.clear
+    @extractor.clear if @extractor
   end
 end

--- a/app/jobs/sample_data_persist_job.rb
+++ b/app/jobs/sample_data_persist_job.rb
@@ -1,10 +1,12 @@
 class SampleDataPersistJob < TaskJob
   queue_as QueueNames::SAMPLES
+
+  attr_accessor :extractor
+
   def perform(data_file, sample_type, assay_ids: [])
-    extractor = Seek::Samples::Extractor.new(data_file, sample_type)
-
+    @extractor = Seek::Samples::Extractor.new(data_file, sample_type)
+    raise 'wibble'
     Rails.logger.info('Starting to persist samples')
-
     time = Benchmark.measure do
       samples = extractor.persist.select(&:persisted?)
       extractor.clear
@@ -17,4 +19,10 @@ class SampleDataPersistJob < TaskJob
   def task
     arguments[0].sample_persistence_task
   end
+
+  def handle_error(exception)
+    super
+    @extractor.clear
+  end
+
 end

--- a/app/jobs/sample_data_persist_job.rb
+++ b/app/jobs/sample_data_persist_job.rb
@@ -5,7 +5,6 @@ class SampleDataPersistJob < TaskJob
 
   def perform(data_file, sample_type, assay_ids: [])
     @extractor = Seek::Samples::Extractor.new(data_file, sample_type)
-    raise 'wibble'
     Rails.logger.info('Starting to persist samples')
     time = Benchmark.measure do
       samples = extractor.persist.select(&:persisted?)

--- a/app/jobs/sample_data_persist_job.rb
+++ b/app/jobs/sample_data_persist_job.rb
@@ -21,7 +21,7 @@ class SampleDataPersistJob < TaskJob
 
   def handle_error(exception)
     super
-    @extractor.clear
+    @extractor.clear if @extractor
   end
 
 end

--- a/app/jobs/task_job.rb
+++ b/app/jobs/task_job.rb
@@ -22,5 +22,7 @@ class TaskJob < ApplicationJob
 
   def handle_error(exception)
     task.update_attribute(:status, Task::STATUS_FAILED)
+    task.update_attribute(:exception, exception.full_message)
+    report_exception(exception, "Error occurred with a Task for Job: #{self.class.name}")
   end
 end

--- a/app/jobs/task_job.rb
+++ b/app/jobs/task_job.rb
@@ -13,10 +13,14 @@ class TaskJob < ApplicationJob
   end
 
   rescue_from(StandardError) do |exception|
-    task.update_attribute(:status, Task::STATUS_FAILED)
+    handle_error(exception)
   end
 
   def task
     raise 'implement me'
+  end
+
+  def handle_error(exception)
+    task.update_attribute(:status, Task::STATUS_FAILED)
   end
 end

--- a/app/views/assets/_asset_buttons.html.erb
+++ b/app/views/assets/_asset_buttons.html.erb
@@ -22,12 +22,10 @@
     <%= button_link_to("View samples", 'view_samples', data_file_samples_path(asset)) %>
   <% end %>
 
-  <% if asset.can_manage? && (display_asset.version == asset.version) && asset.sample_template? && asset.extracted_samples.empty? %>
-    <%# the job isn't in progress or waiting for confirmation of results %>
-    <% unless asset.sample_extraction_task&.in_progress? || Seek::Samples::Extractor.new(asset).fetch %>
+  <% if show_extract_samples_button?(asset, display_asset) %>
       <%= button_link_to('Extract samples', 'extract_samples', extract_samples_data_file_path(@data_file), method: :post) %>
-    <% end %>
   <% end %>
+
 <% end %>
 
 <% if asset.is_downloadable? -%>

--- a/app/views/data_files/_sample_extraction_status.html.erb
+++ b/app/views/data_files/_sample_extraction_status.html.erb
@@ -1,13 +1,23 @@
+
+<% return unless data_file.can_manage? %>
+<% return if data_file.sample_persistence_task&.success? || data_file.sample_persistence_task&.in_progress?  %>
 <% task =  data_file.sample_extraction_task %>
 <% return unless task&.persisted? %>
 
 <% job_status ||= task.status %>
 <% in_progress = task.in_progress? %>
-<% persistence_in_progress = data_file.sample_persistence_task&.in_progress? %>
+<% failed = task.failed? %>
+<% success = task.success? && Seek::Samples::Extractor.new(data_file).fetch.present? %>
+
+<%
+  alert_style = 'alert-info'
+  alert_style = 'alert-warning' if failed
+  alert_style = 'alert-success' if success
+%>
 
 <div id="sample-extraction-status">
-  <% if data_file.can_manage? && !persistence_in_progress && (in_progress || !Seek::Samples::Extractor.new(data_file).fetch.nil?) %>
-      <div class="alert alert-info" role="alert">
+  <% if in_progress || failed || success %>
+      <div class="alert <%= alert_style %>" role="alert">
         <strong>Sample extraction:</strong>
         <% if in_progress %>
             <%= job_status.to_s.humanize %>
@@ -23,7 +33,9 @@
                 );
               }, 5000);
             </script>
-        <% else %>
+        <% elsif failed %>
+          Failed. An administrator will have been notified of the problem, but you could try again.
+        <% elsif success  %>
             Waiting for confirmation
             <p>
               Please review the extracted samples by clicking the button below, and decide whether to continue or cancel

--- a/app/views/data_files/_sample_extraction_status.html.erb
+++ b/app/views/data_files/_sample_extraction_status.html.erb
@@ -1,13 +1,17 @@
 
-<% return unless data_file.can_manage? %>
-<% return if data_file.sample_persistence_task&.success? || data_file.sample_persistence_task&.in_progress?  %>
-<% task =  data_file.sample_extraction_task %>
-<% return unless task&.persisted? %>
+<% return unless show_sample_extraction_status?(data_file) %>
 
-<% job_status ||= task.status %>
-<% in_progress = task.in_progress? %>
-<% failed = task.failed? %>
-<% success = task.success? && Seek::Samples::Extractor.new(data_file).fetch.present? %>
+<%
+  task = data_file.sample_extraction_task
+  job_status ||= task.status
+  in_progress = task.in_progress?
+  failed = task.failed?
+  begin
+    success = task.success? && Seek::Samples::Extractor.new(data_file).fetch.present?
+  rescue Seek::Samples::FetchException
+    success = false
+  end
+%>
 
 <%
   alert_style = 'alert-info'

--- a/app/views/data_files/_sample_persistence_status.html.erb
+++ b/app/views/data_files/_sample_persistence_status.html.erb
@@ -1,14 +1,22 @@
+<% return unless data_file.can_manage? %>
 <% task =  data_file.sample_persistence_task %>
 <% return unless task&.persisted? %>
 
 <% job_status ||= task.status %>
 <% previous_status ||= params[:previous_status] %>
 <% in_progress = task.in_progress? %>
-<% just_finished = task.completed? && Task.status_in_progress?(previous_status) %>
+<% just_failed = task.failed? && Task.status_in_progress?(previous_status) %>
+<% just_finished = task.completed? && task.success? && Task.status_in_progress?(previous_status) %>
+
+<%
+  alert_style = 'alert-info'
+  alert_style = 'alert-warning' if just_failed
+  alert_style = 'alert-success' if just_finished
+%>
 
 <div id="sample-persistence-status">
-  <% if data_file.can_manage? && (in_progress || just_finished) %>
-    <div class="alert alert-info" role="alert">
+  <% if (in_progress || just_finished || just_failed) %>
+    <div class="alert <%= alert_style %>" role="alert">
       <strong>Creating extracted samples:</strong>
       <% if in_progress %>
         <%= job_status.to_s.humanize %>
@@ -24,6 +32,9 @@
                 );
             }, 5000);
         </script>
+      <% end %>
+      <% if just_failed %>
+        Failed. An administrator will have been notified of the problem
       <% end %>
       <% if just_finished %>
         <% if task.success? %>

--- a/db/migrate/20221104140342_add_exception_to_task.rb
+++ b/db/migrate/20221104140342_add_exception_to_task.rb
@@ -1,0 +1,5 @@
+class AddExceptionToTask < ActiveRecord::Migration[6.1]
+  def change
+    add_column :tasks, :exception, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_21_131037) do
+ActiveRecord::Schema.define(version: 2022_11_04_140342) do
 
   create_table "activity_logs", id: :integer, force: :cascade do |t|
     t.string "action"
@@ -2083,6 +2083,7 @@ ActiveRecord::Schema.define(version: 2022_10_21_131037) do
     t.integer "attempts", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "exception"
     t.index ["resource_type", "resource_id"], name: "index_tasks_on_resource_type_and_resource_id"
   end
 

--- a/lib/seek/samples/extractor.rb
+++ b/lib/seek/samples/extractor.rb
@@ -1,5 +1,8 @@
 module Seek
   module Samples
+
+    class FetchException < StandardError; end
+
     # Class to handle the extraction and temporary storage of samples from a data file
     class Extractor
       def initialize(data_file, sample_type = nil)
@@ -51,6 +54,8 @@ module Seek
       # Return the temporarily-stored samples if they exist (nil if not)
       def fetch
         self.class.decode(cache)
+      rescue ArgumentError=>exception
+        raise FetchException.new(exception.message)
       end
 
       private

--- a/test/unit/jobs/sample_data_extraction_job_test.rb
+++ b/test/unit/jobs/sample_data_extraction_job_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class SampleDataExtractionJobTest < ActiveSupport::TestCase
+
+  def setup
+    create_sample_attribute_type
+    @person = Factory(:project_administrator)
+    User.current_user = @person.user
+
+    @data_file = Factory :data_file, content_blob: Factory(:sample_type_populated_template_content_blob),
+                         policy: Factory(:private_policy), contributor: @person
+    refute @data_file.sample_template?
+    assert_empty @data_file.possible_sample_types
+
+    @sample_type = SampleType.new title: 'from template', uploaded_template: true,
+                                  project_ids: [@person.projects.first.id], contributor: @person
+    @sample_type.content_blob = Factory(:sample_type_template_content_blob)
+    @sample_type.build_attributes_from_template
+    # this is to force the full name to be 2 words, so that one row fails
+    @sample_type.sample_attributes.first.sample_attribute_type = Factory(:full_name_sample_attribute_type)
+    @sample_type.sample_attributes[1].sample_attribute_type = Factory(:datetime_sample_attribute_type)
+    @sample_type.save!
+  end
+
+  test 'records exception' do
+    class FailingSampleDataExtractionJob < SampleDataExtractionJob
+      def perform(data_file, sample_type, assay_ids: nil)
+        raise 'critical error'
+      end
+    end
+
+    FailingSampleDataExtractionJob.perform_now(@data_file, @sample_type)
+
+    task = @data_file.sample_extraction_task
+    assert task.failed?
+    refute_nil task.exception
+
+    # contains message and backtrace
+    assert_match /critical error/, task.exception
+    assert_match /block in perform_now/, task.exception
+    assert_match /activejob/, task.exception
+
+  end
+
+end


### PR DESCRIPTION
Improvements that

- report back to users when sample extraction or persistence fails
- records and notifies of task errors
- handles error reading sample extraction cache, and stops the data file page crashing

relates to #1206 and #1207 