### PR TITLE
Fixes to creating a project with no programme (programmes disabled)

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -570,7 +570,7 @@ class ProjectsController < ApplicationController
         validate_error_msg << "The #{t('institution')} is invalid, #{@institution.errors.full_messages.join(', ')}"
       end
 
-      unless @programme.allows_user_projects? || Institution.can_create?
+      unless @programme&.allows_user_projects? || Institution.can_create?
         validate_error_msg << "The #{t('institution')} cannot be created, as you do not have access rights"
       end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -217,7 +217,7 @@ class ProjectsController < ApplicationController
       flash.now[:notice]="Thank you, your request for a new #{t('project')} has been sent"
     end
 
-    if @programme&.can_associate_projects?
+    if (@programme.nil? && admin_logged_in?) || @programme&.can_associate_projects?
       redirect_to administer_create_project_request_projects_path(message_log_id: log.id)
     else
       respond_to do |format|


### PR DESCRIPTION
Avoids a nil error when checking if the programme is open to user projects. Also fixed the flow, as admin you should be taken straight to the confirmation page

relates to #1247 