### PR TITLE
Update linking samples on sample change #1240

### DIFF
--- a/app/jobs/linking_samples_update_job.rb
+++ b/app/jobs/linking_samples_update_job.rb
@@ -1,0 +1,11 @@
+# Job responsible for updating the title of sample in the linking samples
+class LinkingSamplesUpdateJob < ApplicationJob
+  queue_as QueueNames::SAMPLES
+  queue_with_priority 1
+
+  def perform(sample)
+    disable_authorization_checks do
+      sample.refresh_linking_samples
+    end
+  end
+end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -40,9 +40,10 @@ class Sample < ApplicationRecord
 
   before_save :update_sample_resource_links
   after_save :queue_sample_type_update_job
+  after_save :queue_linking_samples_update_job
   after_destroy :queue_sample_type_update_job
 
-
+  
   has_filter :sample_type
 
   def sample_type=(type)
@@ -76,7 +77,7 @@ class Sample < ApplicationRecord
     sample_type.sample_attributes.select(&:seek_resource?).map do |sa|
       value = get_attribute_value(sa)
       type = sa.sample_attribute_type.base_type_handler.type
-      Array.wrap(value).map {|v| type.constantize.find_by_id(v['id']) if v && type} 
+      Array.wrap(value).map { |v| type.constantize.find_by_id(v['id']) if v && type }
     end.flatten.compact
   end
 
@@ -133,9 +134,27 @@ class Sample < ApplicationRecord
     organism_ids | ncbi_linked_organisms.map(&:id)
   end
 
-  #overides default to include sample_type key at the start
+  # overides default to include sample_type key at the start
   def list_item_title_cache_key_prefix
     "#{sample_type.list_item_title_cache_key_prefix}/#{cache_key}"
+  end
+
+  def refresh_linking_samples
+    sample_type_hash = {}
+    linking_samples.each do |s|
+      sample_type_hash = update_sample_type_hash(sample_type_hash, s.sample_type)
+      positions = sample_type_hash[s.sample_type.id]
+      metadata = s.data
+      positions.each do |p|
+        item_linked_samples = Array(metadata.values[p - 1])
+        item_linked_samples.each do |sample|
+          sample['title'] = title if sample['id'] == id
+        end
+        metadata.values[p - 1] = item_linked_samples
+        s.json_metadata = metadata.to_json
+        s.save
+      end
+    end
   end
 
   private
@@ -143,19 +162,20 @@ class Sample < ApplicationRecord
   # organisms linked through an NCBI attribute type
   def ncbi_linked_organisms
     return [] unless sample_type
+
     Rails.cache.fetch("sample-organisms-#{cache_key}-#{Organism.order('updated_at DESC').first.try(:cache_key)}") do
       sample_type.sample_attributes.collect do |attribute|
         next unless attribute.sample_attribute_type.title == 'NCBI ID'
+
         value = get_attribute_value(attribute)
-        if value
-          Organism.all.select { |o| o.ncbi_id && o.ncbi_id.to_s == value }
-        end
+        Organism.all.select { |o| o.ncbi_id && o.ncbi_id.to_s == value } if value
       end.flatten.compact.uniq
     end
   end
 
   def samples_this_links_to
     return [] unless sample_type
+
     seek_sample_attributes = sample_type.sample_attributes.select { |attr| attr.sample_attribute_type.seek_sample? }
     seek_sample_attributes.map do |attr|
       value = get_attribute_value(attr)
@@ -174,11 +194,16 @@ class Sample < ApplicationRecord
   # the designated title attribute
   def title_attribute
     return nil unless sample_type && sample_type.sample_attributes.title_attributes.any?
+
     sample_type.sample_attributes.title_attributes.first
   end
 
   def queue_sample_type_update_job
     SampleTypeUpdateJob.new(sample_type, false).queue_job
+  end
+
+  def queue_linking_samples_update_job
+    LinkingSamplesUpdateJob.new(self).queue_job
   end
 
   def update_sample_resource_links
@@ -190,4 +215,13 @@ class Sample < ApplicationRecord
     SampleAttribute
   end
 
+  def update_sample_type_hash(sample_type_hash, sample_type)
+    if sample_type_hash[sample_type.id].nil?
+      # Select all attributes of type seek_sample_multi or seek_sample
+      sample_type_hash[sample_type.id] = sample_type.sample_attributes.select do |sa|
+        sa.seek_sample_multi? || sa.seek_sample?
+      end.map(&:pos)
+    end
+    sample_type_hash
+  end
 end

--- a/test/unit/jobs/linking_samples_update_job_test.rb
+++ b/test/unit/jobs/linking_samples_update_job_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+
+class LinkingSamplesUpdateJobTest < ActiveSupport::TestCase
+  def setup
+    create_linked_samples
+  end
+
+  test 'perform' do
+    sample = Sample.first
+    sample.set_attribute_value(:full_name, 'Ali Mohammadi')
+    disable_authorization_checks { sample.save! }
+
+    LinkingSamplesUpdateJob.perform_now(sample)
+
+    sample.linking_samples.each do |s|
+      assert_equal 'Ali Mohammadi', s.get_attribute_value(:patient)[0][:title]
+    end
+  end
+
+  def create_linked_samples
+    person = Factory(:person)
+    project = person.projects.first
+
+    main_sample = Factory(:max_sample)
+    sample_type = main_sample.sample_type
+
+    another_sample_type = Factory(:multi_linked_sample_type, project_ids: [project.id])
+    another_sample_type.sample_attributes.last.linked_sample_type = sample_type
+    another_sample_type.save!
+
+    linked_sample1 = Sample.new(sample_type: another_sample_type, project_ids: [project.id])
+    linked_sample1.set_attribute_value(:title, 'linked_sample1')
+    linked_sample1.set_attribute_value(:patient, [main_sample.id])
+    disable_authorization_checks { linked_sample1.save! }
+
+    linked_sample2 = Sample.new(sample_type: another_sample_type, project_ids: [project.id])
+    linked_sample2.set_attribute_value(:title, 'linked_sample2')
+    linked_sample2.set_attribute_value(:patient, [main_sample.id])
+    disable_authorization_checks { linked_sample2.save! }
+  end
+end


### PR DESCRIPTION
Updating a sample triggers a job to check any linking samples and to refresh the title of the Sample that is being linked in the `json_matadata`