### PR TITLE
Clarify empty Linked Sample Type error message

### DIFF
--- a/lib/seek/json_metadata/attribute.rb
+++ b/lib/seek/json_metadata/attribute.rb
@@ -63,8 +63,10 @@ module Seek
         if sample_attribute_type && linked_sample_type && !seek_sample? && !seek_sample_multi?
           errors.add(:sample_attribute_type, 'Attribute type must be SeekSample if linked sample type set')
         end
-        if (seek_sample? || seek_sample_multi?) && linked_sample_type.nil?
-          errors.add(:sample_controlled_vocab, 'Linked Sample Type must be set if attribute type is SeekSample')
+        if seek_sample? && linked_sample_type.nil?
+          errors.add(:seek_sample, 'Linked Sample Type must be set if attribute type is SeekSample')
+        elsif seek_sample_multi? && linked_sample_type.nil? 
+          errors.add(:seek_sample_multi, 'Linked Sample Type must be set if attribute type is SeekSampleMulti')
         end
       end
     end


### PR DESCRIPTION
The issue with the empty Linked Sample Type error message is fixed but, the format of Seek error message hasn't changed.