### PR TITLE
Minor LifeMonitor fixes

### DIFF
--- a/app/models/git/version.rb
+++ b/app/models/git/version.rb
@@ -78,7 +78,6 @@ module Git
         return false
       end
 
-      self.set_resource_attributes(resource.attributes)
       self.mutable = false
       self.ref = git_base.tags.create(unique_git_tag, commit).canonical_name
       save!

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -63,6 +63,7 @@ class Workflow < ApplicationRecord
     end
 
     def test_status= stat
+      @only_test_status_changed = changed.empty?
       resource_attributes['test_status'] = (Workflow::TEST_STATUS_INV[stat&.to_sym])
     end
 
@@ -76,7 +77,7 @@ class Workflow < ApplicationRecord
 
     def should_submit_to_life_monitor?
       Seek::Config.life_monitor_enabled &&
-        (previous_changes.keys - ['updated_at', 'test_status']).any? &&
+        !@only_test_status_changed &&
         extractor.has_tests? &&
         parent.can_download?(nil)
     end

--- a/config/initializers/seek_configuration.rb
+++ b/config/initializers/seek_configuration.rb
@@ -251,6 +251,7 @@ def load_seek_config_defaults!
   Seek::Config.default :sorting, {}
 
   Seek::Config.default :life_monitor_enabled, false
+  Seek::Config.default :life_monitor_url, 'https://api.lifemonitor.eu/'
   Seek::Config.default :git_support_enabled, false
   Seek::Config.default :bio_tools_enabled, false
 

--- a/lib/life_monitor/oauth2/client.rb
+++ b/lib/life_monitor/oauth2/client.rb
@@ -18,12 +18,17 @@ module LifeMonitor
       #  user.profile
       #  user.workflow.read
 
+      SCOPES = %w[registry.info registry.user registry.workflow.read registry.workflow.write
+                  registry.user.workflow.read registry.user.workflow.write workflow.read workflow.write
+                  testingService.read testingService.write user.profile user.workflow.read]
+
       attr_accessor :verify_ssl
 
-      def initialize(client_id = nil, client_secret = nil, base = nil)
+      def initialize(client_id = nil, client_secret = nil, base = nil, scopes = SCOPES)
         @base = base || Seek::Config.life_monitor_url
         @client_id = client_id || Seek::Config.life_monitor_client_id
         @client_secret = client_secret || Seek::Config.life_monitor_client_secret
+        @scopes = scopes
         @verify_ssl = Rails.env.production? || !@base.start_with?('https://localhost')
       end
 
@@ -34,13 +39,10 @@ module LifeMonitor
             client_id: @client_id,
             client_secret: @client_secret,
             grant_type: 'client_credentials',
-            scope: %w[registry.info registry.user registry.workflow.read registry.workflow.write registry.user.workflow.read registry.user.workflow.write workflow.read workflow.write testingService.read user.profile user.workflow.read user.workflow.write].join(' '),
+            scope: @scopes.join(' ')
         }
 
-        res = RestClient::Request.execute(method: :post,
-                                          url: url.to_s,
-                                          payload: body,
-                                          verify_ssl: @verify_ssl)
+        res = RestClient::Request.execute(method: :post, url: url.to_s, payload: body, verify_ssl: @verify_ssl)
         JSON.parse(res)['access_token']
       end
     end

--- a/test/factories/workflows.rb
+++ b/test/factories/workflows.rb
@@ -259,6 +259,21 @@ Factory.define(:local_ro_crate_git_workflow, class: Workflow) do |f|
   end
 end
 
+Factory.define(:local_ro_crate_git_workflow_with_tests, class: Workflow) do |f|
+  f.title 'Sort and change case'
+  f.with_project_contributor
+  f.workflow_class { WorkflowClass.find_by_key('galaxy') || Factory(:galaxy_workflow_class) }
+  f.git_version_attributes do
+    repo = Factory(:workflow_ro_crate_repository)
+    { git_repository_id: repo.id,
+      ref: 'refs/heads/tests',
+      commit: '612f7f7',
+      main_workflow_path: 'sort-and-change-case.ga',
+      mutable: false
+    }
+  end
+end
+
 Factory.define(:nfcore_git_workflow, class: Workflow) do |f|
   f.title 'nf-core/ampliseq'
   f.with_project_contributor

--- a/test/unit/git/git_version_test.rb
+++ b/test/unit/git/git_version_test.rb
@@ -23,8 +23,9 @@ class GitVersionTest < ActiveSupport::TestCase
     repo = Factory(:local_repository)
     workflow = repo.resource
 
-    v = disable_authorization_checks { workflow.git_versions.create!(name: 'version 1.0.0', ref: 'refs/heads/master', mutable: true) }
-    assert_empty v.resource_attributes
+    v = disable_authorization_checks do
+      workflow.save_as_new_git_version(name: 'version 1.0.0', ref: 'refs/heads/master', mutable: true)
+    end
     assert_equal 'This Workflow', v.title
     refute v.git_base.tags['version-1.0.0']
     assert v.mutable?

--- a/test/unit/jobs/life_monitor_status_job_test.rb
+++ b/test/unit/jobs/life_monitor_status_job_test.rb
@@ -40,7 +40,7 @@ class LifeMonitorStatusJobTest < ActiveSupport::TestCase
     VCR.use_cassette('life_monitor/get_token') do
       VCR.use_cassette('life_monitor/list_workflows') do
         workflow = Factory(:ro_crate_git_workflow_with_tests, uuid: '1493b330-d44b-013a-df8a-000c29a94011', title: 'sort-and-change-case', policy: Factory(:public_policy))
-        all_failing = Factory(:local_ro_crate_git_workflow, uuid: '86da0a30-d2cd-013a-a07d-000c29a94011', title: 'Concat two files', policy: Factory(:public_policy))
+        all_failing = Factory(:local_ro_crate_git_workflow_with_tests, uuid: '86da0a30-d2cd-013a-a07d-000c29a94011', title: 'Concat two files', policy: Factory(:public_policy))
         disable_authorization_checks do
           workflow.save_as_new_git_version
         end

--- a/test/unit/life_monitor_rest_client_test.rb
+++ b/test/unit/life_monitor_rest_client_test.rb
@@ -57,4 +57,21 @@ class LifeMonitorRestClientTest < ActiveSupport::TestCase
       refute @client.exists?(@workflow.latest_version)
     end
   end
+
+  test 'list workflows' do
+    VCR.use_cassette('life_monitor/list_workflows') do
+      response = @client.list_workflows
+      assert_equal 2, response['items'].count
+
+      name = 'Concat two files'
+      wf = response['items'].detect { |i| i['name'] == name }
+      assert wf, "Couldn't find '#{name}' workflow in response"
+      assert_equal 'all_failing', wf.dig('status', 'aggregate_test_status')
+
+      name = 'sort-and-change-case'
+      wf = response['items'].detect { |i| i['name'] == name }
+      assert wf, "Couldn't find '#{name}' workflow in response"
+      assert_equal 'all_passing', wf.dig('status', 'aggregate_test_status')
+    end
+  end
 end

--- a/test/unit/workflow_test.rb
+++ b/test/unit/workflow_test.rb
@@ -432,6 +432,28 @@ class WorkflowTest < ActiveSupport::TestCase
     end
   end
 
+  test 'updating test status does not trigger life monitor submission job for git workflow' do
+    workflow = Factory(:local_ro_crate_git_workflow_with_tests, policy: Factory(:public_policy), test_status: nil)
+    assert_nil workflow.reload.test_status
+    assert_nil workflow.latest_version.reload.test_status
+    with_config_value(:life_monitor_enabled, true) do
+      assert_no_enqueued_jobs(only: LifeMonitorSubmissionJob) do
+        disable_authorization_checks { workflow.update_test_status(:all_failing) }
+      end
+    end
+  end
+
+  test 'updating other workflow fields does trigger life monitor submission job for git workflow' do
+    workflow = Factory(:local_ro_crate_git_workflow_with_tests, policy: Factory(:public_policy), test_status: nil)
+    assert_nil workflow.reload.test_status
+    assert_nil workflow.latest_version.reload.test_status
+    with_config_value(:life_monitor_enabled, true) do
+      assert_enqueued_jobs(1, only: LifeMonitorSubmissionJob) do
+        disable_authorization_checks { workflow.update!(title: 'something') }
+      end
+    end
+  end
+
   test 'changing main workflow path refreshes internals structure' do
     workflow = Factory(:local_git_workflow)
     v = workflow.git_version


### PR DESCRIPTION
Stops some submission jobs being created when the daily test status checker job is run.

Also makes `scopes` configurable in the client.