### PR TITLE
Minor refactor of default behaviour for contributor_credited? 

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -142,6 +142,11 @@ class ApplicationRecord < ActiveRecord::Base
     false
   end
 
+  def contributor_credited?
+    return false unless respond_to?(:contributor) && respond_to?(:creators)
+    creators.empty?
+  end
+
   def cache_key_fragment
     base = "#{self.class.name.underscore}-#{id}"
     base << "-#{version}" if versioned?

--- a/lib/seek/permissions/acts_as_authorized.rb
+++ b/lib/seek/permissions/acts_as_authorized.rb
@@ -53,10 +53,6 @@ module Seek #:nodoc:
         self.class.authorization_supported?
       end
 
-      def contributor_credited?
-        false
-      end
-
       def title_is_public?
         false
       end

--- a/lib/seek/permissions/policy_based_authorization.rb
+++ b/lib/seek/permissions/policy_based_authorization.rb
@@ -261,10 +261,6 @@ module Seek
         auth_lookup.where(user_id: 0).batch_update([false, false, false, false, false]) if policy.sharing_scope == Policy::ALL_USERS
       end
 
-      def contributor_credited?
-        !respond_to?(:creators) || creators.empty?
-      end
-
       # item is accessible to members of the projects passed. Ignores additional restrictions, such as additional permissions to block particular members.
       # if items is a downloadable it needs to be ACCESSIBLE, otherwise just VISIBLE
       def projects_accessible?(projects)

--- a/test/unit/sample_type_test.rb
+++ b/test/unit/sample_type_test.rb
@@ -971,6 +971,14 @@ class SampleTypeTest < ActiveSupport::TestCase
     assert_equal 'Jane Smith, John Smith', sample_type.other_creators
   end
 
+  test 'contributor_credited?' do
+    sample_type = Factory(:simple_sample_type, contributor: @person)
+    assert sample_type.contributor_credited?
+
+    sample_type = Factory(:simple_sample_type, contributor: @person, assets_creators:[AssetsCreator.new(creator:Factory(:person))])
+    refute sample_type.contributor_credited?
+  end
+
   private
 
   # sample type with 3 samples


### PR DESCRIPTION
separated from authorization behaviour, there is no reason to being tightly coupled to this and is just dependent and having creators and contributors. Cropped up with Sample types which have contributors and creators, but not ( yet ) full authorization support