### PR TITLE
Ansible installation - github action

### DIFF
--- a/.github/workflows/ansible-install.yml
+++ b/.github/workflows/ansible-install.yml
@@ -13,8 +13,20 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04,ubuntu-22.04,ubuntu-latest]
-    steps:
+        # The service mysql breaks on ubuntu-18.04 during the step "Install SEEK through ansible"
 
+    services:
+      mysql:
+          image: mysql:8.0.21
+          env:
+              MYSQL_ALLOW_EMPTY_PASSWORD: yes
+              MYSQL_ROOT_PASSWORD: ''
+              MYSQL_DATABASE: test
+          ports:
+            - 3306:3306
+          options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    steps:
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/ansible-install.yml
+++ b/.github/workflows/ansible-install.yml
@@ -60,3 +60,18 @@ jobs:
           sed -i 's/mysqluser/root/g' config/database.yml
           sed -i 's/mysqlpassword//g' config/database.yml
           bash -lc 'bundle exec rake db:setup'
+
+      - name: Runs seek unit tests
+        working-directory: /home/runner/work/SEEK
+        run: |
+          bash -lc 'bundle exec rails test test/unit'
+
+      - name: Runs seek integration tests
+        working-directory: /home/runner/work/SEEK
+        run: |
+          bash -lc 'bundle exec rails test test/integration'
+
+      - name: Runs seek functional tests
+        working-directory: /home/runner/work/SEEK
+        run: |
+          bash -lc 'bundle exec rails test test/functional'

--- a/.github/workflows/ansible-install.yml
+++ b/.github/workflows/ansible-install.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Configure ansible for local install
-        working-directory: /home/runner/work/SEEK/script/ansible/
+        working-directory: /home/runner/work/seek/seek/script/ansible/
         run: |
           sed -i '/vault_password_file/d' ansible.cfg
           sed -i '/ssh_connection/d' ansible.cfg
@@ -32,6 +32,6 @@ jobs:
 
 
       - name: Install SEEK through ansible
+        working-directory: /home/runner/work/seek/seek/script/ansible/
         run: |
-          cd script/ansible/
           ansible-playbook Deploy-SEEK.yml

--- a/.github/workflows/ansible-install.yml
+++ b/.github/workflows/ansible-install.yml
@@ -1,5 +1,5 @@
 name: ansible-install
-run-name: ${{ github.actor }} is testing Ansible install
+run-name: "Testing Ansible install after commit \"${{ github.event.head_commit.message }}\""
 on:
   push:
     branches:
@@ -9,6 +9,7 @@ on:
 jobs:
   install-seek-from-ansible:
     runs-on: ${{matrix.os}}
+    #continue-on-error: true
     strategy:
       matrix:
         os: [ubuntu-20.04,ubuntu-22.04,ubuntu-latest]
@@ -18,17 +19,16 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Configure ansible for local install
+        working-directory: /home/runner/work/SEEK/script/ansible/
         run: |
-          cd script/ansible/
           sed -i '/vault_password_file/d' ansible.cfg
           sed -i '/ssh_connection/d' ansible.cfg
           sed -i '/pipelining/d' ansible.cfg
           sed -i 's/\- hosts\: \[servers\]/\- hosts\: localhost/g' Deploy-SEEK.yml
           sed -i '/\- hosts\: localhost/a \ \ connection\: local' Deploy-SEEK.yml
-          sed -i 's/user_var\: francisco/user_var\: runner/' group_vars/vars.yml
-          sed -i 's/git_dest\: \/home\/francisco/git_dest\: \/home\/runner\/work\/seek/' group_vars/vars.yml
-          sed -i 's/sql_user\: francisco/sql_user\: mysqluser/' group_vars/vars.yml
-          sed -i '/sql_user\: mysqluser/a sql_password: mysqlpassword' group_vars/vars.yml
+          sed -i 's/user_var\: username/user_var\: runner/' group_vars/vars.yml
+          sed -i 's/git_dest\: \/home\/username/git_dest\: \/home\/runner\/work/' group_vars/vars.yml
+          sed -i '/sql_user\: sql_username/a sql_password: mysqlpassword' group_vars/vars.yml
 
 
       - name: Install SEEK through ansible

--- a/.github/workflows/ansible-install.yml
+++ b/.github/workflows/ansible-install.yml
@@ -30,6 +30,9 @@ jobs:
           sed -i 's/git_dest\: \/home\/username/git_dest\: \/home\/runner\/work/' group_vars/vars.yml
           sed -i '/sql_user\: sql_username/a sql_password: mysqlpassword' group_vars/vars.yml
 
+      - name: Prepares system for ansible install
+        run: |
+          sudo apt install acl -y
 
       - name: Install SEEK through ansible
         working-directory: /home/runner/work/seek/seek/script/ansible/

--- a/.github/workflows/ansible-install.yml
+++ b/.github/workflows/ansible-install.yml
@@ -49,4 +49,14 @@ jobs:
       - name: Install SEEK through ansible
         working-directory: /home/runner/work/seek/seek/script/ansible/
         run: |
-          ansible-playbook Deploy-SEEK.yml
+          ansible-playbook Deploy-SEEK.yml --skip-tags database
+
+      - name: Configures database
+        working-directory: /home/runner/work/SEEK
+        run: |
+          cp config/database.default.yml config/database.yml
+          sed -i '/password\: mysqlpassword/a \ \ port\: 3306' config/database.yml
+          sed -i '/password\: mysqlpassword/a \ \ host\: 127.0.0.1' config/database.yml
+          sed -i 's/mysqluser/root/g' config/database.yml
+          sed -i 's/mysqlpassword//g' config/database.yml
+          bash -lc 'bundle exec rake db:setup'

--- a/script/ansible/Deploy-SEEK.yml
+++ b/script/ansible/Deploy-SEEK.yml
@@ -118,8 +118,8 @@
       become_user: root
       shell: bash -lc "{{ item }}"
       with_items:
-        - wget https://www.openssl.org/source/openssl-1.1.1g.tar.gz
-        - tar zxvf openssl-1.1.1g.tar.gz
+        - wget https://www.openssl.org/source/openssl-1.1.1g.tar.gz -P '{{git_dest}}/'
+        - tar zxvf '{{git_dest}}/openssl-1.1.1g.tar.gz' -C '{{git_dest}}/'
       args:
         chdir: '{{git_dest}}'
       run_once: true
@@ -139,7 +139,7 @@
         - rm -rf '{{git_dest}}/.openssl/openssl-1.1.1g/certs'
         - ln -s /etc/ssl/certs '{{git_dest}}/.openssl/openssl-1.1.1g/certs'
       args:
-        chdir: 'openssl-1.1.1g'
+        chdir: '{{git_dest}}/openssl-1.1.1g'
       run_once: true
       when: ansible_distribution_version is version('22.04', '>=')
       tags:

--- a/script/ansible/Deploy-SEEK.yml
+++ b/script/ansible/Deploy-SEEK.yml
@@ -239,6 +239,16 @@
         - python
         - packages
 
+    - name: Install filelock and wheel (Ubuntu < 20.04)
+      shell: bash -lc "{{ item }}"
+      with_items:
+        - python3.7 -m pip install filelock
+        - python3.7 -m pip install wheel
+      args:
+        chdir: '{{git_dest}}/SEEK'
+      when: ansible_distribution_version is version('20.04', '<')
+      tags: python
+
     - name: Install SEEK's python requirements
       shell: bash -lc "{{ item }}"
       with_items:
@@ -249,15 +259,6 @@
       tags:
         - seek
         - python
-
-    - name: Install filelock (Ubuntu < 20.04)
-      shell: bash -lc "{{ item }}"
-      with_items:
-        - python3.7 -m pip install filelock
-      args:
-        chdir: '{{git_dest}}/SEEK'
-      when: ansible_distribution_version is version('20.04', '<')
-      tags: python
 
 
     ########## Configure database

--- a/script/ansible/Deploy-SEEK.yml
+++ b/script/ansible/Deploy-SEEK.yml
@@ -120,9 +120,10 @@
       with_items:
         - wget https://www.openssl.org/source/openssl-1.1.1g.tar.gz
         - tar zxvf openssl-1.1.1g.tar.gz
-      when: ansible_distribution_version is version('22.04', '>=')
       args:
         chdir: '{{git_dest}}'
+      run_once: true
+      when: ansible_distribution_version is version('22.04', '>=')
       tags:
         - openssl
         - ruby
@@ -137,9 +138,9 @@
         - make install
         - rm -rf '{{git_dest}}/.openssl/openssl-1.1.1g/certs'
         - ln -s /etc/ssl/certs '{{git_dest}}/.openssl/openssl-1.1.1g/certs'
-        #- cd '{{git_dest}}' && rm -r openssl-1.1.1g openssl-1.1.1g.tar.gz
       args:
         chdir: 'openssl-1.1.1g'
+      run_once: true
       when: ansible_distribution_version is version('22.04', '>=')
       tags:
         - openssl
@@ -148,10 +149,13 @@
     - name: Cleanup openssl for Ruby 2.7.x
       become: true
       become_user: root
-      shell: bash -lc "{{ item }}"
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
       with_items:
-        - rm -rf '{{git_dest}}/openssl-1.1.1g'
-        - rm -f '{{git_dest}}/openssl-1.1.1g.tar.gz'
+        - '{{git_dest}}/openssl-1.1.1g'
+        - '{{git_dest}}/openssl-1.1.1g.tar.gz'
+      run_once: true
       when: ansible_distribution_version is version('22.04', '>=')
       tags:
         - openssl


### PR DESCRIPTION
Updated Ansible deploy playbook and finished the github action.
Both the ansible and the github action work for Ubuntu 20.04 and 22.04.
The action does not work on Ubuntu 18.04, for some strange docker crash, but the Ansible script does work (directly on VMs).
The action is currently configured to be triggered manually (on workflow_dispatch).

Note: the database configuration had to be taken out of the ansible script and is done directly in the github action, because of how the mysql service is provided in actions. This should not be an issue for testing dependencies, but it would be wise to test the whole script outside of github actions every so often.