### PR TITLE
Biomodels search cache key error

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -341,6 +341,14 @@ class AdminController < ApplicationController
     redirect_with_status(error, 'background tasks')
   end
 
+  def clear_cache
+    Rails.cache.clear
+    flash[:notice] = "Cache cleared"
+    respond_to do |format|
+      format.html { render :index}
+    end
+  end
+
   # give it up to 5 seconds to start up, otherwise the page reloads too quickly and says it is not running
   def wait_for_delayed_job_to_start
     sleep(0.5)

--- a/app/views/admin/_restart_buttons.html.erb
+++ b/app/views/admin/_restart_buttons.html.erb
@@ -1,4 +1,18 @@
 <%= panel do %>
+  <div class="row">
+    <div class="col-sm-8">
+      <p>
+        SEEK uses a cache to store dynamically generated content, for the benefit of improving overall performance or
+        avoid excessive requests to an external service.
+        Although the cache is automatically updated when data changes, occasionally is may be necessary to force the cache
+        to be cleared entirely.
+        <%= button_to('Clear cache', clear_cache_admin_path,
+                      class: 'btn btn-danger', id: 'clear-cache',
+                      data: { confirm: 'Are you sure you want to clear the cache?', disable_with: 'Clearing...' }) %>
+      </p>
+    </div>
+  </div>
+  <% unless using_docker? %>
     <div class="row">
       <div class="col-sm-8">
         <p>
@@ -47,4 +61,5 @@
         <% end %>
       </div>
     </div>
+  <% end %>
 <% end %>

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -14,6 +14,6 @@
   <%= render partial: 'admin/admin_selection' %>
 <% end %>
 
-<%= render partial: 'admin/restart_buttons' unless using_docker? %>
+<%= render partial: 'admin/restart_buttons' %>
 
 <small><%= git_link_tag %></small>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -165,6 +165,7 @@ SEEK::Application.routes.draw do
       post :edit_tag
       post :update_imprint_setting
       post :clear_failed_jobs
+      post :clear_cache
     end
     concerns :has_dashboard, controller: :stats
   end

--- a/lib/seek/biomodels_search/search_biomodels_adaptor.rb
+++ b/lib/seek/biomodels_search/search_biomodels_adaptor.rb
@@ -6,7 +6,7 @@ module Seek
       NUMRESULTS = 25
       def perform_search(query)
         
-        json = Rails.cache.fetch("biomodels_search_json_#{CGI.escape(query)}", expires_in: 1.day) do
+        json = Rails.cache.fetch("biomodels/search/#{Digest::SHA256.hexdigest(query)}", expires_in: 1.day) do
           RestClient.get("https://www.ebi.ac.uk/biomodels/search?query=#{CGI.escape(query)}&numResults=#{NUMRESULTS}", accept: 'application/json').body
         end
 

--- a/lib/tasks/seek_upgrades.rake
+++ b/lib/tasks/seek_upgrades.rake
@@ -46,6 +46,7 @@ namespace :seek do
     puts '... migrating database ...'
     Rake::Task['db:migrate'].invoke
     Rake::Task['tmp:clear'].invoke
+    Rails.cache.clear
 
     solr = Seek::Config.solr_enabled
     Seek::Config.solr_enabled = false

--- a/test/functional/admin_controller_test.rb
+++ b/test/functional/admin_controller_test.rb
@@ -520,4 +520,26 @@ class AdminControllerTest < ActionController::TestCase
     end
   end
 
+  test 'clear cache' do
+    Rails.cache.write('test-key', 'hello')
+    assert_equal 'hello', Rails.cache.fetch('test-key')
+
+    admin = Factory(:admin)
+    person = Factory(:project_administrator)
+
+    login_as(person)
+    post :clear_cache
+    assert_redirected_to :root
+    refute_nil flash[:error]
+    assert_nil flash[:notice]
+    assert_equal 'hello', Rails.cache.fetch('test-key')
+
+    login_as(admin)
+    post :clear_cache
+    assert_response :success
+    refute_nil flash[:notice]
+    assert_nil flash[:error]
+    assert_nil Rails.cache.fetch('test-key')
+  end
+
 end


### PR DESCRIPTION
Changed how the cache key is created to avoid encoding problems.

Also added ability to clear the cache from the admin page.

fix for #1284 