### PR TITLE
fix to allow project administrator to delete project #1288

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -14,9 +14,8 @@ class ProjectsController < ApplicationController
                                         :administer_create_project_request, :respond_create_project_request,
                                         :project_join_requests, :project_creation_requests, :typeahead]
 
-  before_action :find_requested_item, only: %i[asset_report]
-  before_action :find_and_authorize_requested_item, only: %i[show admin edit update destroy admin_members
-                                               populate populate_from_spreadsheet
+  before_action :find_requested_item, only: %i[show admin edit update destroy admin_members
+                                               asset_report populate populate_from_spreadsheet
                                                admin_member_roles update_members storage_report
                                                overview administer_join_request respond_join_request]
 
@@ -26,7 +25,7 @@ class ProjectsController < ApplicationController
   before_action :auth_to_create, only: %i[new create,:administer_create_project_request, :respond_create_project_request]
   before_action :editable_by_user, only: %i[edit update]
   before_action :check_investigations_are_for_this_project, only: %i[update]
-  before_action :administerable_by_user, only: %i[admin admin_members admin_member_roles update_members storage_report administer_join_request respond_join_request populate populate_from_spreadsheet]
+  before_action :administerable_by_user, only: %i[admin admin_members admin_member_roles destroy update_members storage_report administer_join_request respond_join_request populate populate_from_spreadsheet]
 
   before_action :member_of_this_project, only: [:asset_report], unless: :admin_logged_in?
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -14,7 +14,8 @@ class ProjectsController < ApplicationController
                                         :administer_create_project_request, :respond_create_project_request,
                                         :project_join_requests, :project_creation_requests, :typeahead]
 
-  before_action :find_requested_item, only: %i[show admin edit update destroy asset_report admin_members
+  before_action :find_requested_item, only: %i[asset_report]
+  before_action :find_and_authorize_requested_item, only: %i[show admin edit update destroy admin_members
                                                populate populate_from_spreadsheet
                                                admin_member_roles update_members storage_report
                                                overview administer_join_request respond_join_request]
@@ -23,7 +24,6 @@ class ProjectsController < ApplicationController
 
   before_action :find_assets, only: [:index]
   before_action :auth_to_create, only: %i[new create,:administer_create_project_request, :respond_create_project_request]
-  before_action :is_user_admin_auth, only: %i[destroy]
   before_action :editable_by_user, only: %i[edit update]
   before_action :check_investigations_are_for_this_project, only: %i[update]
   before_action :administerable_by_user, only: %i[admin admin_members admin_member_roles update_members storage_report administer_join_request respond_join_request populate populate_from_spreadsheet]

--- a/lib/seek/permissions/translator.rb
+++ b/lib/seek/permissions/translator.rb
@@ -29,7 +29,7 @@ module Seek
         manage: Set.new(%i[
                           manage manage_update notification read_interaction write_interaction report_problem storage_report
                           select_sample_type extraction_status persistence_status extract_samples confirm_extraction cancel_extraction
-                          upload_fulltext upload_pdf soft_delete_fulltext
+                          upload_fulltext upload_pdf soft_delete_fulltext populate_from_spreadsheet
                         ]).freeze
       }.freeze
 

--- a/lib/seek/permissions/translator.rb
+++ b/lib/seek/permissions/translator.rb
@@ -29,7 +29,7 @@ module Seek
         manage: Set.new(%i[
                           manage manage_update notification read_interaction write_interaction report_problem storage_report
                           select_sample_type extraction_status persistence_status extract_samples confirm_extraction cancel_extraction
-                          upload_fulltext upload_pdf soft_delete_fulltext populate_from_spreadsheet
+                          upload_fulltext upload_pdf soft_delete_fulltext
                         ]).freeze
       }.freeze
 

--- a/test/functional/projects_controller_test.rb
+++ b/test/functional/projects_controller_test.rb
@@ -271,7 +271,7 @@ class ProjectsControllerTest < ActionController::TestCase
       delete :destroy, params: { id: project }
     end
     refute_nil flash[:error]
-    assert_redirected_to project_path(project)
+    assert_redirected_to :root
   end
 
   test 'can destroy project if it contains people' do
@@ -845,11 +845,11 @@ class ProjectsControllerTest < ActionController::TestCase
     assert_select 'a', text: /Project administration/, count: 0
 
     get :edit, params: { id: a_project }
-    assert_redirected_to project_path(a_project)
+    assert_redirected_to :root
     assert_not_nil flash[:error]
 
     put :update, params: { id: a_project, project: { title: 'banana' } }
-    assert_redirected_to project_path(a_project)
+    assert_redirected_to :root
     assert_not_nil flash[:error]
     assert_not_equal 'banana', a_project.reload.title
   end
@@ -1509,7 +1509,7 @@ class ProjectsControllerTest < ActionController::TestCase
 
     login_as(person)
     get :storage_report, params: { id: project.id }
-    assert_redirected_to project_path(project)
+    assert_redirected_to :root
     refute_nil flash[:error]
   end
 


### PR DESCRIPTION
Fix to #1288 - incorrect filter was preventing a non-admin from deleting. Also made sure other actions were authorized correctly.