### PR TITLE
gracefully handle incomplete snapshot with warning message #1299

### DIFF
--- a/app/controllers/snapshots_controller.rb
+++ b/app/controllers/snapshots_controller.rb
@@ -21,8 +21,13 @@ class SnapshotsController < ApplicationController
 
   def show
     respond_to do |format|
-      format.html # show.html.erb
-      format.json { render json: @snapshot, include: [params[:include]] }
+      if @snapshot.content_blob.present?
+        format.html
+        format.json { render json: @snapshot, include: [params[:include]] }
+      else
+        format.html {  render "show_no_content_blob" }
+        format.json { render json: { errors: [{ title: 'Incomplete snapshot', details: 'Snapshot has no content. It may still be being generated' }] }, status: :unprocessable_entity }
+      end
     end
   end
 

--- a/app/models/snapshot.rb
+++ b/app/models/snapshot.rb
@@ -34,7 +34,11 @@ class Snapshot < ApplicationRecord
   end
 
   def title
-    metadata['title']
+    if content_blob.present?
+      metadata['title']
+    else
+      'incomplete snapshot'
+    end
   end
 
   def description

--- a/app/views/snapshots/show_no_content_blob.html.erb
+++ b/app/views/snapshots/show_no_content_blob.html.erb
@@ -1,0 +1,8 @@
+<div class='alert alert-warning'>
+  <p>
+    The Snapshot <%= @snapshot.snapshot_number %> for <%= link_to @snapshot.resource.title, @snapshot.resource %> cannot currently be displayed as it is incomplete.
+  </p>
+  <p>
+    It is likely that the Snapshot is still being generated, so please try again later.
+  </p>
+</div>


### PR DESCRIPTION
give a warning that it is probably still being generated. Also do so for JSON response