### PR TITLE
Show git revision when running with Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 .git/
 Dockerfile
 filestore*
+hooks/
 coverage/
 docker/solr/
 db/*.sqlite3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.7-buster
 
 LABEL maintainer="Stuart Owen <orcid.org/0000-0003-2130-0865>, Finn Bacall"
-
+ARG SOURCE_COMMIT
 ENV APP_DIR /seek
 ENV RAILS_ENV=production
 
@@ -37,6 +37,7 @@ RUN mkdir log tmp
 COPY docker/virtuoso_settings.docker.yml config/virtuoso_settings.yml
 
 USER root
+RUN if [ -n "$SOURCE_COMMIT" ] ; then echo $SOURCE_COMMIT > config/.git-revision ; fi
 RUN chown -R www-data solr config docker public /var/www db/schema.rb
 USER www-data
 RUN touch config/using-docker #allows us to see within SEEK we are running in a container

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,9 @@ WORKDIR $APP_DIR
 # Bundle install throw errors if Gemfile has been modified since Gemfile.lock
 COPY Gemfile* ./
 RUN bundle config --local frozen 1 && \
-    bundle install --deployment --without development test
+    bundle config set deployment 'true' && \
+    bundle config set without 'development test' && \
+    bundle install
 
 # App code
 COPY . .

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -87,6 +87,10 @@ module AdminHelper
         "Git revision: #{link} (branch: #{branch})".html_safe
       rescue
       end
+    elsif Seek::Version.git_version_record_present?
+      version = Seek::Version.git_version
+      link = link_to(version[0...7], "https://github.com/seek4science/seek/commit/#{version}", target: '_blank', title: version).html_safe
+      "Git revision: #{link}".html_safe
     end
   end
 

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -79,18 +79,18 @@ module AdminHelper
   end
 
   def git_link_tag
-    if Seek::Version.git_present?
-      begin
+    begin
+      if Seek::Version.git_version_record_present?
+        version = Seek::Version.git_version
+        link = link_to(version[0...7], "https://github.com/seek4science/seek/commit/#{version}", target: '_blank', title: version).html_safe
+        "Git revision: #{link}".html_safe
+      elsif Seek::Version.git_present?
         version = Seek::Version.git_version
         branch = Seek::Version.git_branch
         link = link_to(version[0...7], "https://github.com/seek4science/seek/commit/#{version}", target: '_blank', title: version).html_safe
         "Git revision: #{link} (branch: #{branch})".html_safe
-      rescue
       end
-    elsif Seek::Version.git_version_record_present?
-      version = Seek::Version.git_version
-      link = link_to(version[0...7], "https://github.com/seek4science/seek/commit/#{version}", target: '_blank', title: version).html_safe
-      "Git revision: #{link}".html_safe
+    rescue
     end
   end
 

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,1 @@
+docker build --build-arg SOURCE_COMMIT=$SOURCE_COMMIT -f $DOCKERFILE_PATH -t $IMAGE_NAME .

--- a/hooks/build
+++ b/hooks/build
@@ -1,3 +1,4 @@
 #!/bin/sh
 
+# docker hub build hook, to pass along the source commit hash
 docker build --build-arg SOURCE_COMMIT=$SOURCE_COMMIT -f $DOCKERFILE_PATH -t $IMAGE_NAME .

--- a/hooks/build
+++ b/hooks/build
@@ -1,1 +1,3 @@
+#!/bin/sh
+
 docker build --build-arg SOURCE_COMMIT=$SOURCE_COMMIT -f $DOCKERFILE_PATH -t $IMAGE_NAME .

--- a/lib/seek/version.rb
+++ b/lib/seek/version.rb
@@ -21,8 +21,13 @@ module Seek
 
     # returns the current version hash from git
     def self.git_version
-      return '' unless git_present?
+      if git_present?
       `git rev-parse HEAD`.chomp
+      elsif git_version_record_present?
+        File.read(Rails.root.join('config','.git-revision'))
+      else
+        ''
+      end
     end
 
     # returns the current git branch
@@ -34,6 +39,10 @@ module Seek
     # is git currently present to allow access to git information
     def self.git_present?
       File.exist?(Rails.root.join('.git'))
+    end
+
+    def self.git_version_record_present?
+      File.exist?(Rails.root.join('config','.git-revision'))
     end
 
     # equality check, based on the version string

--- a/lib/seek/version.rb
+++ b/lib/seek/version.rb
@@ -4,6 +4,8 @@ module Seek
   class Version
     attr_reader :major, :minor, :patch
 
+    GIT_VERSION_RECORD_FILE_PATH = Rails.root.join('config', '.git-revision')
+
     def initialize(path)
       yml = YAML.safe_load(File.open(path))
       @major = yml['major']
@@ -19,12 +21,12 @@ module Seek
     # a stored copy of the version, which can be used to avoid repeated calls to read, and YAML loading
     APP_VERSION = read.freeze
 
-    # returns the current version hash from git
+    # returns the current version hash from git, or the file containing the record
     def self.git_version
-      if git_present?
-      `git rev-parse HEAD`.chomp
-      elsif git_version_record_present?
-        File.read(Rails.root.join('config','.git-revision'))
+      if git_version_record_present?
+        File.read(GIT_VERSION_RECORD_FILE_PATH)
+      elsif git_present?
+        `git rev-parse HEAD`.chomp
       else
         ''
       end
@@ -33,6 +35,7 @@ module Seek
     # returns the current git branch
     def self.git_branch
       return '' unless git_present?
+
       `git rev-parse --abbrev-ref HEAD`.chomp
     end
 
@@ -41,8 +44,9 @@ module Seek
       File.exist?(Rails.root.join('.git'))
     end
 
+    # is there a config/.git-revision file that contains the revision hash
     def self.git_version_record_present?
-      File.exist?(Rails.root.join('config','.git-revision'))
+      File.exist?(GIT_VERSION_RECORD_FILE_PATH)
     end
 
     # equality check, based on the version string

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -1,6 +1,11 @@
 require 'test_helper'
 
 class VersionTest < ActiveSupport::TestCase
+
+  def teardown
+    File.delete(Seek::Version::GIT_VERSION_RECORD_FILE_PATH) if File.exist?(Seek::Version::GIT_VERSION_RECORD_FILE_PATH)
+  end
+
   test 'default path' do
     str = Seek::Version.read.to_s
 
@@ -26,5 +31,18 @@ class VersionTest < ActiveSupport::TestCase
 
   test 'APP_VERSION' do
     assert_equal Seek::Version::APP_VERSION, Seek::Version.read
+  end
+
+  test 'git_version_record_present?' do
+    refute Seek::Version.git_version_record_present?
+    File.write(Seek::Version::GIT_VERSION_RECORD_FILE_PATH, 'wibble')
+    assert Seek::Version.git_version_record_present?
+  end
+
+  test 'git version' do
+    real_git = `git rev-parse HEAD`.chomp
+    assert_equal real_git, Seek::Version.git_version
+    File.write(Seek::Version::GIT_VERSION_RECORD_FILE_PATH, 'abcdefghi')
+    assert_equal 'abcdefghi', Seek::Version.git_version
   end
 end


### PR DESCRIPTION
Ability to see the last commit for the currently running container. Addresses issue #1315 

Can pass the commit hash into the Docker build which gets copied to a file, which can then be displayed if present (similar to when a .git directory is present).
A hook is added to pass this into the build for Docker Hub.

Has been tested with Docker Hub:
```
docker run -p 3000:3000 --rm fairdom/seek:git-revision-test
```