### PR TITLE
Fix to requesting a local copy 

### DIFF
--- a/app/assets/javascripts/templates/upload/local_file.hbs
+++ b/app/assets/javascripts/templates/upload/local_file.hbs
@@ -2,4 +2,8 @@
     <span class="generic_file_icon"></span>
     {{text}}
     <a href="#" class="remove-file"><span class="remove_icon"></span></a>
+
+    {{!-- keeps in sync with remote file parameters and avoids the content blob array getting mangled when submitted --}}
+    <input type="hidden" name="content_blobs[][data_url]" />
+    <input type="hidden" name="content_blobs[][make_local_copy]" value="0" />
 </li>

--- a/app/assets/javascripts/upload.js
+++ b/app/assets/javascripts/upload.js
@@ -110,7 +110,6 @@ $j(document).ready(function () {
                 if (json.length) {
                     var info = JSON.parse($j('script', result).html());
                     checker.trigger('urlChecked', [info]);
-                    originalFilename.val(info.file_name);
                     if (info.allow_copy) {
                         copyDialog.show();
                     } else {
@@ -153,6 +152,15 @@ $j(document).ready(function () {
             debounceTimeout = setTimeout(function() {
                 submitUrl();
             }, 700);
+        });
+
+        //triggered after url check
+        checker.on('urlChecked', function (event, info) {
+            var field = checker.parents('[data-role="seek-upload-field"]');
+            var originalFilename = $j('[data-role="seek-upload-field-filename"]', field);
+            if (originalFilename) {
+                originalFilename.val(info.file_name);
+            }
         });
     });
 });

--- a/app/assets/javascripts/upload.js
+++ b/app/assets/javascripts/upload.js
@@ -92,7 +92,6 @@ $j(document).ready(function () {
         var result = field.find('[data-role="seek-url-checker-result"]');
         var copyDialog = $j('[data-role="seek-url-checker-msg-success"]', field);
         var tooBig = $j('[data-role="seek-url-checker-msg-too-big"]', field);
-        var originalFilename = $j('[data-role="seek-upload-field-filename"]', field);
 
         var submitUrl = function () {
             result.html('').spinner('add');

--- a/app/assets/javascripts/upload.js
+++ b/app/assets/javascripts/upload.js
@@ -155,7 +155,7 @@ $j(document).ready(function () {
 
         //triggered after url check
         checker.on('urlChecked', function (event, info) {
-            var field = checker.parents('[data-role="seek-upload-field"]');
+            var field = $j(this).parents('[data-role="seek-upload-field"]');
             var originalFilename = $j('[data-role="seek-upload-field-filename"]', field);
             if (originalFilename) {
                 originalFilename.val(info.file_name);

--- a/app/assets/javascripts/upload.js
+++ b/app/assets/javascripts/upload.js
@@ -45,14 +45,19 @@ $j(document).ready(function () {
         var addRemoteFile = function () {
             var urlInput = $j('[data-role="seek-url-checker"] input', field);
             var filenameInput = $j('[data-role="seek-upload-field-filename"]', field);
-            var makeLocalCopyCheckbox = $j('[data-role="seek-upload-field-make-copy"]', field)[0];
+            var makeLocalCopyCheckbox = $j('[data-role="seek-upload-field-make-copy"]', field);
 
             var remoteFile = {
                 dataURL: urlInput.val(),
-                makeALocalCopy: (makeLocalCopyCheckbox && makeLocalCopyCheckbox.checked) ? "1" : "0",
+                makeALocalCopy: (makeLocalCopyCheckbox && makeLocalCopyCheckbox.is(":checked")) ? "1" : "0",
                 originalFilename: filenameInput.val()
             };
             remoteFile.text = remoteFile.originalFilename.trim() ? remoteFile.originalFilename : remoteFile.dataURL;
+
+            // reset
+            if (makeLocalCopyCheckbox) {
+                makeLocalCopyCheckbox.prop("checked", false);
+            }
 
             var parsed = parseUri(remoteFile.dataURL);
             if (!parsed.host || parsed.host === "null") {

--- a/app/assets/javascripts/upload.js
+++ b/app/assets/javascripts/upload.js
@@ -87,6 +87,7 @@ $j(document).ready(function () {
         var result = field.find('[data-role="seek-url-checker-result"]');
         var copyDialog = $j('[data-role="seek-url-checker-msg-success"]', field);
         var tooBig = $j('[data-role="seek-url-checker-msg-too-big"]', field);
+        var originalFilename = $j('[data-role="seek-upload-field-filename"]', field);
 
         var submitUrl = function () {
             result.html('').spinner('add');
@@ -104,6 +105,7 @@ $j(document).ready(function () {
                 if (json.length) {
                     var info = JSON.parse($j('script', result).html());
                     checker.trigger('urlChecked', [info]);
+                    originalFilename.val(info.file_name);
                     if (info.allow_copy) {
                         copyDialog.show();
                     } else {

--- a/app/views/assets/_upload.html.erb
+++ b/app/views/assets/_upload.html.erb
@@ -78,7 +78,7 @@
         <div class="checkbox">
           <label>
             <%= check_box_tag "#{field_name}[make_local_copy]", "1", false, 'data-role' => 'seek-upload-field-make-copy' %>
-            <strong>Download a copy</strong>
+            <strong>Store a copy</strong>
           </label>
         </div>
       </div>

--- a/app/views/assets/_upload.html.erb
+++ b/app/views/assets/_upload.html.erb
@@ -78,7 +78,7 @@
         <div class="checkbox">
           <label>
             <%= check_box_tag "#{field_name}[make_local_copy]", "1", false, 'data-role' => 'seek-upload-field-make-copy' %>
-            <strong>Store a copy</strong>
+            <strong>Fetch a copy</strong>
           </label>
         </div>
       </div>

--- a/app/views/assets/_upload.html.erb
+++ b/app/views/assets/_upload.html.erb
@@ -78,7 +78,7 @@
         <div class="checkbox">
           <label>
             <%= check_box_tag "#{field_name}[make_local_copy]", "1", false, 'data-role' => 'seek-upload-field-make-copy' %>
-            <strong>Upload a copy</strong>
+            <strong>Download a copy</strong>
           </label>
         </div>
       </div>

--- a/app/views/content_blobs/_examine_url_result.html.erb
+++ b/app/views/content_blobs/_examine_url_result.html.erb
@@ -1,4 +1,3 @@
 <div class="remote-content-preview">
   <%= render partial: "content_blobs/examine_url/#{@type}" %>
-  <%= hidden_field_tag "content_blobs[][original_filename]", @info[:original_filename], id: 'original_filename' %>
 </div>

--- a/lib/seek/download_handling/http_handler.rb
+++ b/lib/seek/download_handling/http_handler.rb
@@ -35,7 +35,7 @@ module Seek
           rescue RestClient::UnsupportedMediaType => e
             accept_header = "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
             response = RestClient.head(url, accept: accept_header)
-            content_type = response.headers[:content_tyspe]
+            content_type = response.headers[:content_type]
             content_length = response.headers[:content_length]
             code = response.code
           rescue RestClient::Exception => e # Try a GET if HEAD isn't allowed, but don't download anything


### PR DESCRIPTION
Fix for #1322 

Avoid creating a duplicate `content_blobs[original_filename]` element, which causes the additional array element in the params (and was always set to '' anyway). Instead set with a callback, using the info from the ajax call, and more inline with how git files are handled. Also changed to Fetch a copy, which makes more sense an consistent with git Files.

Also resets the checkbox between multiple model files being added