### PR TITLE
Fixes error flashing when error grouping disabled.

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -63,11 +63,13 @@ class AdminController < ApplicationController
     Seek::Config.exception_notification_recipients = params[:exception_notification_recipients] if params.key?(:exception_notification_recipients)
     Seek::Config.exception_notification_enabled = string_to_boolean params[:exception_notification_enabled] if params.key?(:exception_notification_enabled)
 
-    eg_timeout = params[:error_grouping_timeout]
-    eg_log_base = params[:error_grouping_log_base]
     Seek::Config.error_grouping_enabled = string_to_boolean params[:error_grouping_enabled] if params.key?(:error_grouping_enabled)
-    Seek::Config.error_grouping_timeout = string_to_seconds eg_timeout if string_is_duration(eg_timeout, 'error grouping timeout')
-    Seek::Config.error_grouping_log_base = eg_log_base.to_i if only_positive_integer(eg_log_base, 'error grouping log base')
+    if Seek::Config.error_grouping_enabled
+      eg_timeout = params[:error_grouping_timeout]
+      eg_log_base = params[:error_grouping_log_base]
+      Seek::Config.error_grouping_timeout = string_to_seconds eg_timeout if string_is_duration(eg_timeout, 'error grouping timeout')
+      Seek::Config.error_grouping_log_base = eg_log_base.to_i if only_positive_integer(eg_log_base, 'error grouping log base')
+    end
 
     Seek::Config.omniauth_enabled = string_to_boolean params[:omniauth_enabled]
     Seek::Config.omniauth_user_create = string_to_boolean params[:omniauth_user_create]

--- a/test/functional/admin_controller_test.rb
+++ b/test/functional/admin_controller_test.rb
@@ -282,26 +282,42 @@ class AdminControllerTest < ActionController::TestCase
   end
 
   test 'update error_grouping_timeout' do
-    with_config_value(:error_grouping_timeout, 1.minute) do
-      post :update_features_enabled, params: { error_grouping_timeout: '1' }
-      assert_equal 1.seconds, Seek::Config.error_grouping_timeout
-      post :update_features_enabled, params: { error_grouping_timeout: '10 sec' }
-      assert_equal 10.seconds, Seek::Config.error_grouping_timeout
-      post :update_features_enabled, params: { error_grouping_timeout: '2 min' }
-      assert_equal 120.seconds, Seek::Config.error_grouping_timeout
+    with_config_value(:error_grouping_enabled, true) do
+      with_config_value(:error_grouping_timeout, 1.minute) do
+        post :update_features_enabled, params: { error_grouping_timeout: '1' }
+        assert_equal 1.seconds, Seek::Config.error_grouping_timeout
+        post :update_features_enabled, params: { error_grouping_timeout: '10 sec' }
+        assert_equal 10.seconds, Seek::Config.error_grouping_timeout
+        post :update_features_enabled, params: { error_grouping_timeout: '2 min' }
+        assert_equal 120.seconds, Seek::Config.error_grouping_timeout
+      end
+    end
+    with_config_value(:error_grouping_enabled, false) do
+      with_config_value(:error_grouping_timeout, 1.minute) do
+        post :update_features_enabled, params: { error_grouping_timeout: '3' }
+        assert_equal 1.minute, Seek::Config.error_grouping_timeout
+      end
     end
   end
 
   test 'update error_grouping_log_base' do
-    with_config_value(:error_grouping_log_base, 2) do
-      post :update_features_enabled, params: { error_grouping_log_base: '3' }
-      assert_equal 3, Seek::Config.error_grouping_log_base
-      post :update_features_enabled, params: { error_grouping_log_base: '3.4' }
-      refute_nil flash[:error]
-      assert_equal 3, Seek::Config.error_grouping_log_base
-      post :update_features_enabled, params: { error_grouping_log_base: '-1' }
-      refute_nil flash[:error]
-      assert_equal 3, Seek::Config.error_grouping_log_base
+    with_config_value(:error_grouping_enabled, true) do
+      with_config_value(:error_grouping_log_base, 2) do
+        post :update_features_enabled, params: { error_grouping_log_base: '3' }
+        assert_equal 3, Seek::Config.error_grouping_log_base
+        post :update_features_enabled, params: { error_grouping_log_base: '3.4' }
+        refute_nil flash[:error]
+        assert_equal 3, Seek::Config.error_grouping_log_base
+        post :update_features_enabled, params: { error_grouping_log_base: '-1' }
+        refute_nil flash[:error]
+        assert_equal 3, Seek::Config.error_grouping_log_base
+      end
+    end
+    with_config_value(:error_grouping_enabled, false) do
+      with_config_value(:error_grouping_log_base, 2) do
+        post :update_features_enabled, params: { error_grouping_log_base: '3' }
+        assert_equal 2, Seek::Config.error_grouping_log_base
+      end
     end
   end
 


### PR DESCRIPTION
Only checks error grouping parameters when it is enabled.

Resolves #1344 