### PR TITLE
Prevented modal closure propagation that produced blank page.

### DIFF
--- a/app/views/data_files/provide_metadata.html.erb
+++ b/app/views/data_files/provide_metadata.html.erb
@@ -74,6 +74,7 @@
     //these are to prevent the entire modal being closed, when these inner modals from the permission table are closed
     $j('#add-project-permission-modal').on('click', '[data-dismiss="modal"]', function(e) { e.stopPropagation(); });
     $j('#add-person-permission-modal').on('click', '[data-dismiss="modal"]', function(e) { e.stopPropagation(); });
+    $j('#add-programme-permission-modal').on('click', '[data-dismiss="modal"]', function(e) { e.stopPropagation(); });
     $j('#modalAssociateWorkflows').on('click', '[data-dismiss="modal"]', function(e) { e.stopPropagation(); });
 
   });


### PR DESCRIPTION
Prevents modal closure propagation that produced a blank page when creating a data file and trying to add programme permission.

Resolves #1309 .