### PR TITLE
Fix broken workflow creation with remote files

### DIFF
--- a/app/models/git/version.rb
+++ b/app/models/git/version.rb
@@ -8,7 +8,7 @@ module Git
     belongs_to :contributor, class_name: 'Person'
     belongs_to :git_repository, class_name: 'Git::Repository'
     has_many :git_annotations, inverse_of: :git_version, dependent: :destroy, class_name: 'Git::Annotation', foreign_key: :git_version_id
-    has_many :remote_source_annotations, -> { where(key: 'remote_source') },
+    has_many :remote_source_annotations, -> { where(key: 'remote_source') }, autosave: true,
              inverse_of: :git_version, dependent: :destroy, class_name: 'Git::Annotation', foreign_key: :git_version_id
 
     before_create :set_version

--- a/app/models/git/version.rb
+++ b/app/models/git/version.rb
@@ -8,6 +8,8 @@ module Git
     belongs_to :contributor, class_name: 'Person'
     belongs_to :git_repository, class_name: 'Git::Repository'
     has_many :git_annotations, inverse_of: :git_version, dependent: :destroy, class_name: 'Git::Annotation', foreign_key: :git_version_id
+    has_many :remote_source_annotations, -> { where(key: 'remote_source') },
+             inverse_of: :git_version, dependent: :destroy, class_name: 'Git::Annotation', foreign_key: :git_version_id
 
     before_create :set_version
     before_validation :set_git_info, on: :create
@@ -198,23 +200,20 @@ module Git
 
     def remote_sources= hash
       to_keep = []
-      to_update = []
-      existing = find_git_annotations('remote_source').to_a
+      existing = remote_source_annotations.to_a
 
       hash.each do |path, url|
         annotation = existing.detect { |a| a.path == path }
         if annotation.nil? || annotation.value != url
-          annotation ||= git_annotations.build(key: 'remote_source', path: path)
+          annotation ||= remote_source_annotations.build(path: path)
           annotation.value = url
-          to_update << annotation
         end
 
         to_keep << annotation
       end
 
       to_destroy = existing - to_keep
-      to_destroy.each(&:destroy)
-      to_update.each(&:save)
+      to_destroy.each(&:mark_for_destruction)
 
       hash
     end
@@ -222,7 +221,7 @@ module Git
     def remote_sources
       h = {}
 
-      find_git_annotations('remote_source').each do |ann|
+      remote_source_annotations.each do |ann|
         h[ann.path] = ann.value
       end
 

--- a/app/models/workflow_repository_builder.rb
+++ b/app/models/workflow_repository_builder.rb
@@ -43,7 +43,7 @@ class WorkflowRepositoryBuilder
 
       gv.add_files(files)
       files.each do |path, _, url|
-        gv.git_annotations.build(path: path, key: 'remote_source', value: url) if url
+        gv.remote_source_annotations.build(path: path, value: url) if url
       end
 
       extractor = @workflow.extractor

--- a/test/integration/git_workflow_creation_test.rb
+++ b/test/integration/git_workflow_creation_test.rb
@@ -241,7 +241,7 @@ class GitWorkflowCreationTest < ActionDispatch::IntegrationTest
     repo = assigns(:workflow).git_version.git_repository
     assert_select 'input[name="workflow[title]"]', count: 1
     a = assigns(:workflow).git_version.remote_source_annotations
-    assert_equal 1, length
+    assert_equal 1, a.length
     assert_equal 'http://workflow.com/rp2.cwl', a.first.value
     assert_equal  'rp2.cwl', a.first.path
 

--- a/test/integration/git_workflow_creation_test.rb
+++ b/test/integration/git_workflow_creation_test.rb
@@ -209,6 +209,86 @@ class GitWorkflowCreationTest < ActionDispatch::IntegrationTest
     assert_equal annotation_count + 1, Git::Annotation.count
   end
 
+  test 'can upload local files and link to remote ones to create a local git repository for a workflow' do
+    mock_remote_file "#{Rails.root}/test/fixtures/files/workflows/rp2-to-rp2path-packed.cwl", 'http://workflow.com/rp2.cwl'
+
+    repo_count = Git::Repository.count
+    workflow_count = Workflow.count
+    version_count = Git::Version.count
+    annotation_count = Git::Annotation.count
+
+    person = Factory(:person)
+    cwl = WorkflowClass.find_by_key('cwl') || Factory(:cwl_workflow_class)
+    login_as(person.user)
+
+    get new_workflow_path
+
+    assert_enqueued_jobs(0) do
+      assert_difference('Git::Repository.count', 1) do
+        assert_no_difference('Task.count') do
+          post create_from_files_workflows_path, params: {
+            ro_crate: {
+              main_workflow: { data: fixture_file_upload('workflows/rp2-to-rp2path-packed.cwl', 'text/plain') },
+              abstract_cwl: { data_url: 'http://workflow.com/rp2.cwl', original_filename: 'rp2.cwl' },
+              diagram: { data: fixture_file_upload('file_picture.png', 'image/png') }
+            },
+            workflow_class_id: cwl.id
+          } # Should go to metadata page...
+        end
+      end
+    end
+
+    repo = assigns(:workflow).git_version.git_repository
+    assert_select 'input[name="workflow[title]"]', count: 1
+    a = assigns(:workflow).git_version.remote_source_annotations
+    assert_equal 1, length
+    assert_equal 'http://workflow.com/rp2.cwl', a.first.value
+    assert_equal  'rp2.cwl', a.first.path
+
+    assert_difference('Workflow.count', 1) do
+      assert_difference('Git::Version.count', 1) do
+        # 4 annotations = Main WF path, Abstract CWL path, diagram path, 1x remote source
+        assert_difference('Git::Annotation.count', 4) do
+          post create_metadata_workflows_path, params: {
+            workflow: {
+              workflow_class_id: cwl.id,
+              title: 'blabla',
+              project_ids: [person.projects.first.id],
+              git_version_attributes: {
+                root_path: '/',
+                git_repository_id: repo.id,
+                ref: 'refs/heads/master',
+                main_workflow_path: 'rp2-to-rp2path-packed.cwl',
+                diagram_path: 'file_picture.png',
+                abstract_cwl_path: 'rp2.cwl',
+                remote_sources: {
+                  'rp2.cwl' => 'http://workflow.com/rp2.cwl'
+                }
+              }
+            }
+          } # Should go to workflow page...
+        end
+      end
+    end
+
+    assert_redirected_to workflow_path(assigns(:workflow))
+
+    assert assigns(:workflow).latest_git_version.commit.present?
+    assert_equal 'refs/heads/master', assigns(:workflow).latest_git_version.ref
+    refute assigns(:workflow).latest_git_version.git_repository.remote?
+    assert_equal assigns(:workflow), assigns(:workflow).latest_git_version.git_repository.resource
+    refute assigns(:workflow).latest_git_version.get_blob('rp2-to-rp2path-packed.cwl').remote?
+    refute assigns(:workflow).latest_git_version.get_blob('file_picture.png').remote?
+    assert assigns(:workflow).latest_git_version.get_blob('rp2.cwl').remote?
+    assert_equal({ 'rp2.cwl' => 'http://workflow.com/rp2.cwl' }, assigns(:workflow).latest_git_version.remote_sources)
+
+    # Check there wasn't anything extra created in the whole flow...
+    assert_equal repo_count + 1, Git::Repository.count
+    assert_equal workflow_count + 1, Workflow.count
+    assert_equal version_count + 1, Git::Version.count
+    assert_equal annotation_count + 4, Git::Annotation.count
+  end
+
   private
 
   def login_as(user)

--- a/test/integration/workflow_ro_crate_test.rb
+++ b/test/integration/workflow_ro_crate_test.rb
@@ -41,6 +41,7 @@ class WorkflowRoCrateTest < ActionDispatch::IntegrationTest
       assert_enqueued_jobs(1, only: RemoteGitContentFetchingJob) do
         v.add_remote_file('blah.txt', 'http://internet.internet/file')
         v.add_remote_file('blah2.txt', 'http://internet.internet/another_file', fetch: false)
+        disable_authorization_checks { v.save! }
       end
     end
 

--- a/test/unit/git/git_version_test.rb
+++ b/test/unit/git/git_version_test.rb
@@ -356,6 +356,7 @@ class GitVersionTest < ActiveSupport::TestCase
     assert_difference('Git::Annotation.count', 1) do
       assert_enqueued_jobs(1, only: RemoteGitContentFetchingJob) do
         v.add_remote_file('blah.txt', 'http://internet.internet/file')
+        disable_authorization_checks { v.save! }
       end
     end
 
@@ -388,6 +389,7 @@ class GitVersionTest < ActiveSupport::TestCase
     assert_difference('Git::Annotation.count', 1) do
       assert_no_enqueued_jobs(only: RemoteGitContentFetchingJob) do
         v.add_remote_file('blah.txt', 'http://internet.internet/file', fetch: false)
+        disable_authorization_checks { v.save! }
       end
     end
 


### PR DESCRIPTION
Fixes #1361 

Error was:
```
Git::Version#can_edit? delegated to parent.can_edit?, but parent is nil
```