### PR TITLE
Remove redundant `provider` property from RO-Crate metadata

### DIFF
--- a/app/models/concerns/workflow_extraction.rb
+++ b/app/models/concerns/workflow_extraction.rb
@@ -133,7 +133,6 @@ module WorkflowExtraction
     others = other_creators&.split(',')&.collect(&:strip)&.compact || []
     authors += others.map.with_index { |name, i| crate.add_person("creator-#{i + 1}", name: name) }
     crate.author = authors
-    crate['provider'] = projects.map { |project| crate.add_organization(nil, project.ro_crate_metadata).reference }
     crate.license = license
     crate.identifier = ro_crate_identifier
     crate.url = ro_crate_url('ro_crate')

--- a/test/unit/workflow_repository_builder_test.rb
+++ b/test/unit/workflow_repository_builder_test.rb
@@ -91,7 +91,7 @@ class WorkflowRepositoryBuilderTest < ActiveSupport::TestCase
     disable_authorization_checks { workflow.save }
     crate = workflow.ro_crate
 
-    assert_equal 20, crate.entities.count # TODO: Change me to 19 when #960 resolved
+    assert_equal 19, crate.entities.count
     assert crate.get("ro-crate-metadata.json").is_a?(ROCrate::Metadata)
     assert crate.get("ro-crate-preview.html").is_a?(ROCrate::Preview)
     assert crate.get("./").is_a?(ROCrate::WorkflowCrate)


### PR DESCRIPTION
Fixes #960 