### PR TITLE
Update CVList to use object_input and the typeahead component

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -611,6 +611,7 @@ class ApplicationController < ActionController::Base
         metadata_type.custom_metadata_attributes.each do |attr|
           if attr.sample_attribute_type.base_type == Seek::Samples::BaseType::CV_LIST
             cma << {attr.title=>[]}
+            cma << attr.title.to_s
           else
             cma << attr.title.to_s
           end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -266,6 +266,7 @@ class SamplesController < ApplicationController
       sample_type.sample_attributes.each do |attr|
         if attr.sample_attribute_type.base_type == Seek::Samples::BaseType::CV_LIST
           sample_type_param_keys << { attr.title=>[]}
+          sample_type_param_keys << attr.title.to_sym
           else
             sample_type_param_keys << attr.title.to_sym
         end

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -91,7 +91,7 @@ module SamplesHelper
       when Seek::Samples::BaseType::CV
         seek_cv_attribute_display(value, attribute)
       when Seek::Samples::BaseType::CV_LIST
-        value.join(", ")
+        value.each{|v| seek_cv_attribute_display(v, attribute) }.join(', ')
       else
         default_attribute_display(attribute, options, sample, value)
       end

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -30,21 +30,17 @@ module SamplesHelper
     end
   end
 
-  def list_select_form_field(attribute,element_name, values)
+  def controlled_vocab_list_form_field(sample_controlled_vocab, element_name, values)
 
-    sample_controlled_vocab =  attribute.sample_controlled_vocab
-
-    options = options_from_collection_for_select(
-        sample_controlled_vocab.sample_controlled_vocab_terms.sort_by(&:label),
-        :label, :label,
-        values
-      )
-      select_tag element_name,
-                 options,
-                 class: "form-control cv_list_attribute",
-                 include_blank: "",
-                 name: "#{element_name}[]",
-                 multiple: "multiple"
+    scv_id = sample_controlled_vocab.id
+    is_ontology = sample_controlled_vocab.source_ontology.present?
+    existing_objects = Array(values).collect do |value|
+      Struct.new(:id, :name).new(value, value)
+    end
+    objects_input(element_name, existing_objects,
+                  typeahead: { query_url: typeahead_sample_controlled_vocabs_path + "?query=%QUERY&scv_id=#{scv_id}",
+                               handlebars_template: 'typeahead/controlled_vocab_term' }, ontology: is_ontology
+    )
   end
 
   def sample_multi_form_field(attribute, element_name, value)  
@@ -261,7 +257,7 @@ module SamplesHelper
     when Seek::Samples::BaseType::CV
       controlled_vocab_form_field attribute.sample_controlled_vocab, element_name, value
     when Seek::Samples::BaseType::CV_LIST
-      list_select_form_field attribute, element_name, value
+      controlled_vocab_list_form_field attribute.sample_controlled_vocab, element_name, value
     when Seek::Samples::BaseType::SEEK_SAMPLE
       terms = attribute.linked_sample_type.samples.authorized_for('view').to_a
       options = options_from_collection_for_select(terms, :id, :title, value.try(:[], 'id'))

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -20,8 +20,9 @@ module SamplesHelper
     else
       scv_id = sample_controlled_vocab.id
       is_ontology = sample_controlled_vocab.source_ontology.present?
+      object_struct = Struct.new(:id, :name)
       existing_objects = Array(values).collect do |value|
-        Struct.new(:id, :name).new(value, value)
+        object_struct.new(value, value)
       end
       objects_input(element_name, existing_objects,
                     typeahead: { query_url: typeahead_sample_controlled_vocabs_path + "?query=%QUERY&scv_id=#{scv_id}", 
@@ -34,8 +35,9 @@ module SamplesHelper
 
     scv_id = sample_controlled_vocab.id
     is_ontology = sample_controlled_vocab.source_ontology.present?
+    object_struct = Struct.new(:id, :name)
     existing_objects = Array(values).collect do |value|
-      Struct.new(:id, :name).new(value, value)
+      object_struct.new(value, value)
     end
     objects_input(element_name, existing_objects,
                   typeahead: { query_url: typeahead_sample_controlled_vocabs_path + "?query=%QUERY&scv_id=#{scv_id}",

--- a/lib/seek/samples/attribute_type_handlers/base_attribute_handler.rb
+++ b/lib/seek/samples/attribute_type_handlers/base_attribute_handler.rb
@@ -29,10 +29,6 @@ module Seek
 
         private
 
-        def convert_value(value)
-          value
-        end
-
         attr_accessor :additional_options
       end
     end

--- a/lib/seek/samples/attribute_type_handlers/cv_list_attribute_type_handler.rb
+++ b/lib/seek/samples/attribute_type_handlers/cv_list_attribute_type_handler.rb
@@ -9,6 +9,12 @@ module Seek
             end
         end
 
+
+        def convert(value)
+          return value if value.is_a?(Array)
+          value.split(',').collect{|v| v.strip}
+        end
+
       end
     end
   end

--- a/test/functional/samples_controller_test.rb
+++ b/test/functional/samples_controller_test.rb
@@ -196,11 +196,36 @@ class SamplesControllerTest < ActionController::TestCase
     type = Factory(:apples_list_controlled_vocab_sample_type)
     assert_difference('Sample.count') do
       post :create, params: { sample: { sample_type_id: type.id,
-                                        data: { apples: ['Granny Smith'] },
+                                        data: { apples: ['Granny Smith', 'Bramley'] },
                                         project_ids: [person.projects.first.id] } }
     end
     assert_not_nil sample = assigns(:sample)
-    assert_equal ['Granny Smith'], sample.get_attribute_value(:apples)
+    assert_equal ['Granny Smith', 'Bramley'], sample.get_attribute_value(:apples)
+
+    # cv list type data must be an array
+    assert_no_difference('Sample.count') do
+      put :update, params: { id: sample.id, sample: { data: { apples: 'Granny Smith' } } }
+    end
+
+    # the required attribute must be filled in
+    assert_no_difference('Sample.count') do
+      put :update, params: { id: sample.id, sample: { data: { apples: nil } } }
+    end
+
+  end
+
+  test 'create and update with cv list comma seperated' do
+    person = Factory(:person)
+    login_as(person)
+
+    type = Factory(:apples_list_controlled_vocab_sample_type)
+    assert_difference('Sample.count') do
+      post :create, params: { sample: { sample_type_id: type.id,
+                                        data: { apples: 'Granny Smith, Bramley' },
+                                        project_ids: [person.projects.first.id] } }
+    end
+    assert_not_nil sample = assigns(:sample)
+    assert_equal ['Granny Smith', 'Bramley'], sample.get_attribute_value(:apples)
 
     # cv list type data must be an array
     assert_no_difference('Sample.count') do


### PR DESCRIPTION
Intermediate step before addressing #1371, so there is a releasable version of #1334 whilst that is addressed and ties it down to the `object_input` helper.

Temporarily requires the values to be passed and handled as a comma separated list, but this will be resolved when switched back to `select2` .