### PR TITLE
Workflow error handling improvements

### DIFF
--- a/app/controllers/concerns/legacy/workflow_support.rb
+++ b/app/controllers/concerns/legacy/workflow_support.rb
@@ -103,9 +103,7 @@ module Legacy
         # unlink any existing content_blob, which breaks things when creating a new version:
         extractor = Workflow.new(content_blob: content_blob, workflow_class: @workflow.workflow_class).extractor
         @metadata = extractor.metadata
-        @warnings ||= @metadata.delete(:warnings) || []
-        @errors ||= @metadata.delete(:errors) || []
-        @workflow.assign_attributes(@metadata)
+        @workflow.provide_metadata(@metadata)
       rescue StandardError => e
         raise e unless Rails.env.production?
         Seek::Errors::ExceptionForwarder.send_notification(e, data: {

--- a/app/controllers/concerns/legacy/workflow_support.rb
+++ b/app/controllers/concerns/legacy/workflow_support.rb
@@ -3,7 +3,7 @@ module Legacy
     extend ActiveSupport::Concern
 
     included do
-      before_action :login_required, only: [:create_content_blob, :create_ro_crate]
+      before_action :legacy_login_required, only: [:create_content_blob, :create_ro_crate]
       before_action :legacy_set_workflow, only: [:create_content_blob, :create_ro_crate]
     end
 
@@ -57,6 +57,12 @@ module Legacy
       else
         @workflow = Workflow.new(workflow_class_id: params[:workflow_class_id])
       end
+    end
+
+    # This is deliberately named differently from `login_required`, or it will overwrite the
+    # `before_action :login_required, only: [...]` in WorkflowsController.
+    def legacy_login_required
+      login_required
     end
 
     def legacy_handle_ro_crate_post(new_version = false)

--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -22,12 +22,25 @@ class WorkflowsController < ApplicationController
 
   rescue_from ROCrate::ReadException do |e|
     logger.error("Error whilst attempting to read RO-Crate metadata for #{@workflow&.id}.")
+    message = "Couldn't read RO-Crate metadata. Check the file is valid."
     respond_to do |format|
       format.html do
-        flash[:error] = "Couldn't read RO-Crate metadata. Check the file is valid."
+        flash[:error] = message
         redirect_to workflow_path(@workflow)
       end
-      format.json { render json: { title: 'RO-Crate Read Error', detail: e.message }, status: :internal_server_error }
+      format.json { render json: { title: 'RO-Crate Read Error', detail: message }, status: :internal_server_error }
+    end
+  end
+
+  rescue_from ROCrate::WriteException do |e|
+    exception_notification(500, e) unless Rails.application.config.consider_all_requests_local
+    message = "Couldn't generate RO-Crate. Check the ro-crate-metadata.json file is valid."
+    respond_to do |format|
+      format.html do
+        flash[:error] = message
+        redirect_to workflow_path(@workflow)
+      end
+      format.json { render json: { title: 'RO-Crate Write Error', detail: message }, status: :internal_server_error }
     end
   end
 

--- a/app/models/concerns/workflow_extraction.rb
+++ b/app/models/concerns/workflow_extraction.rb
@@ -210,13 +210,17 @@ module WorkflowExtraction
   end
 
   def ro_crate_zip
-    ro_crate do |crate|
-      path = ro_crate_path
-      File.delete(path) if File.exist?(path)
-      ROCrate::Writer.new(crate).write_zip(path)
-    end
+    begin
+      ro_crate do |crate|
+        path = ro_crate_path
+        File.delete(path) if File.exist?(path)
+        ROCrate::Writer.new(crate).write_zip(path)
+      end
 
-    ro_crate_path
+      ro_crate_path
+    rescue StandardError => e
+      raise ::ROCrate::WriteException.new("Couldn't generate RO-Crate metadata.", e)
+    end
   end
 
   def ro_crate_identifier

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -30,6 +30,12 @@ class Workflow < ApplicationRecord
 
   accepts_nested_attributes_for :workflow_data_files
 
+  def initialize(*args)
+    @extraction_errors = []
+    @extraction_warnings = []
+    super(*args)
+  end
+
   git_versioning(sync_ignore_columns: ['test_status']) do
     include WorkflowExtraction
 
@@ -156,8 +162,8 @@ class Workflow < ApplicationRecord
   attr_reader :extraction_errors
 
   def provide_metadata(metadata)
-    @extraction_warnings = metadata.delete(:warnings)
-    @extraction_errors = metadata.delete(:errors)
+    @extraction_warnings = metadata.delete(:warnings) || []
+    @extraction_errors = metadata.delete(:errors) || []
     @extracted_metadata = metadata
     assign_attributes(@extracted_metadata)
   end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -152,9 +152,14 @@ class Workflow < ApplicationRecord
   end
 
   attr_reader :extracted_metadata
+  attr_reader :extraction_warnings
+  attr_reader :extraction_errors
+
   def provide_metadata(metadata)
+    @extraction_warnings = metadata.delete(:warnings)
+    @extraction_errors = metadata.delete(:errors)
     @extracted_metadata = metadata
-    assign_attributes(metadata)
+    assign_attributes(@extracted_metadata)
   end
 
   def workflow_data_files_attributes=(attributes)

--- a/app/views/workflows/_upload_form.html.erb
+++ b/app/views/workflows/_upload_form.html.erb
@@ -28,7 +28,7 @@
           <%= error_messages_for :workflow -%>
           <%= error_messages_for :crate_builder, header_message: "Could not build Workflow RO-Crate" -%>
 
-          <%= panel do %>
+          <%= panel(nil, id: 'main-workflow-panel') do %>
             <div class="form-group">
               <label class="required">Workflow</label>
               <p class="help-block">The main executable workflow.</p>
@@ -43,8 +43,8 @@
             <script>
                 // Auto-select workflow class based on file extension.
                 $j(document).ready(function () {
-                    $j('#ro_crate_main_workflow_data').change(function () {
-                        var parts = $j(this).val().split('.');
+                    var selectWorkflowClass = function (filename) {
+                        var parts = filename.split('.');
                         var ext = parts[parts.length - 1];
                         $j('#workflow_class_id option').each(function () {
                             var o = $j(this);
@@ -52,6 +52,14 @@
                                 $j('#workflow_class_id').val(o.val());
                             }
                         });
+                    }
+                    $j('#main-workflow-panel [data-role="seek-url-checker"]').on('urlChecked', function () {
+                        setTimeout(function () {
+                            selectWorkflowClass($j('#ro_crate_main_workflow_original_filename').val());
+                        }, 100);
+                    });
+                    $j('#ro_crate_main_workflow_data').change(function () {
+                        selectWorkflowClass($j(this).val());
                     });
                 });
             </script>

--- a/app/views/workflows/provide_metadata.html.erb
+++ b/app/views/workflows/provide_metadata.html.erb
@@ -7,22 +7,22 @@
   <%= hidden_field_tag 'revision_comments', params[:revision_comments] %>
 
   <div class="asset_form">
-    <% if @errors && @errors.any? %>
-      <div class="alert alert-danger">
+    <% if @workflow.extraction_errors.present? %>
+      <div class="alert alert-danger" id="extraction-errors">
         <strong>Extraction errors:</strong>
         <ul>
-          <% @errors.each do |error| %>
+          <% @workflow.extraction_errors.each do |error| %>
             <li><%= error %></li>
           <% end %>
         </ul>
       </div>
     <% end %>
 
-    <% if @warnings && @warnings.any? %>
-      <div class="alert alert-warning">
+    <% if @workflow.extraction_warnings.present? %>
+      <div class="alert alert-warning" id="extraction-warnings">
         <strong>Extraction warnings:</strong>
         <ul>
-          <% @warnings.each do |warning| %>
+          <% @workflow.extraction_warnings.each do |warning| %>
             <li><%= warning %></li>
           <% end %>
         </ul>

--- a/lib/ro_crate/exception.rb
+++ b/lib/ro_crate/exception.rb
@@ -1,0 +1,11 @@
+module ROCrate
+  class Exception < RuntimeError
+    attr_reader :cause
+
+    def initialize(message, original_exception)
+      @cause = original_exception
+      super("#{self.class.name} - #{message}\n#{@cause.class.name} - #{@cause.message}")
+      set_backtrace(@cause.backtrace)
+    end
+  end
+end

--- a/lib/ro_crate/read_exception.rb
+++ b/lib/ro_crate/read_exception.rb
@@ -1,3 +1,3 @@
 module ROCrate
-  class ReadException < RuntimeError; end
+  class ReadException < ROCrate::Exception; end
 end

--- a/lib/ro_crate/write_exception.rb
+++ b/lib/ro_crate/write_exception.rb
@@ -1,0 +1,3 @@
+module ROCrate
+  class WriteException < ROCrate::Exception; end
+end

--- a/lib/seek/workflow_extractors/git_repo.rb
+++ b/lib/seek/workflow_extractors/git_repo.rb
@@ -35,11 +35,22 @@ module Seek
       def metadata
         # Use CWL description
         m = if @git_version.path_for_key(:abstract_cwl).present?
-              abstract_cwl_extractor.metadata
+              begin
+                abstract_cwl_extractor.metadata
+              rescue StandardError => e
+                Rails.logger.error('Error extracting abstract CWL:')
+                Rails.logger.error(e)
+                { errors: ["Couldn't parse abstract CWL"] }
+              end
             else
-              main_workflow_extractor.metadata
+              begin
+                main_workflow_extractor.metadata
+              rescue StandardError => e
+                Rails.logger.error('Error extracting workflow:')
+                Rails.logger.error(e)
+                { errors: ["Couldn't parse main workflow"] }
+              end
             end
-
 
         if @git_version.file_exists?('README.md')
           m[:description] ||= @git_version.file_contents('README.md').force_encoding('utf-8')

--- a/lib/seek/workflow_extractors/ro_crate.rb
+++ b/lib/seek/workflow_extractors/ro_crate.rb
@@ -13,12 +13,16 @@ module Seek
         open_crate do |crate|
           crate.test_suites.any?
         end
+      rescue ::ROCrate::ReadException => e
+        false
       end
 
       def can_render_diagram?
         open_crate do |crate|
           crate.main_workflow_diagram.present? || main_workflow_extractor(crate)&.can_render_diagram? || abstract_cwl_extractor(crate)&.can_render_diagram?
         end
+      rescue ::ROCrate::ReadException => e
+        false
       end
 
       def generate_diagram
@@ -33,6 +37,8 @@ module Seek
 
           return nil
         end
+      rescue ::ROCrate::ReadException => e
+        nil
       end
 
       def metadata
@@ -133,8 +139,8 @@ module Seek
         @opened_crate = nil
 
         v
-      rescue RuntimeError
-        raise ::ROCrate::ReadException.new("Couldn't read RO-Crate metadata.")
+      rescue StandardError => e
+        raise ::ROCrate::ReadException.new("Couldn't read RO-Crate metadata.", e)
       end
 
       def diagram_extension

--- a/test/functional/workflows_controller_test.rb
+++ b/test/functional/workflows_controller_test.rb
@@ -637,6 +637,34 @@ class WorkflowsControllerTest < ActionController::TestCase
     end
   end
 
+  test 'downloads RO-Crate for git-versioned workflow' do
+    workflow = Factory(:remote_git_workflow, policy: Factory(:public_policy))
+
+    get :ro_crate, params: { id: workflow.id }
+
+    assert_response :success
+    assert @response.header['Content-Length'].present?
+    assert @response.header['Content-Length'].to_i > 5000 # Length is variable because the crate contains variable data
+    Dir.mktmpdir do |dir|
+      crate = ROCrate::WorkflowCrateReader.read_zip(response.stream.to_path, target_dir: dir)
+      assert crate.main_workflow
+    end
+  end
+
+  test 'handles error when generating RO-Crate' do
+    workflow = Factory(:local_git_workflow, policy: Factory(:public_policy))
+    gv = workflow.latest_git_version
+    disable_authorization_checks do
+      gv.add_file('ro-crate-metadata.json', StringIO.new('{}'))
+      gv.save!
+    end
+
+    get :ro_crate, params: { id: workflow.id }
+
+    assert_redirected_to workflow
+    assert flash[:error].include?("Couldn't generate RO-Crate")
+  end
+
   test 'create RO-Crate even with with duplicated filenames' do
     cwl = Factory(:cwl_workflow_class)
     person = Factory(:person)

--- a/test/integration/workflow_versioning_test.rb
+++ b/test/integration/workflow_versioning_test.rb
@@ -176,7 +176,7 @@ class WorkflowVersioningTest < ActionDispatch::IntegrationTest
     metadata[:internals] = metadata[:internals].to_json
 
     assert_response :success
-    assert_empty assigns(:errors)
+    assert_empty assigns(:workflow).extraction_errors
     assert_equal 'galaxy', assigns(:workflow).workflow_class.key
     assert_select 'form[action=?]', create_version_metadata_workflow_path(workflow_id)
     assert_select '#workflow_submit_btn[value=?]', 'Update'


### PR DESCRIPTION
- Catches and reports errors reading/writing RO-Crates.
- Fixes issue where workflow extraction errors/warnings were not being displayed to the user.
- Fixes issue where user authentication was not being checked properly when creating workflows.
- Auto selects workflow type based on file extension when registering a remote file as a workflow (was only doing it for local files before).

Fixes #768
