### PR TITLE
Error grouping log base flashed with email disabled

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -166,9 +166,12 @@ class AdminController < ApplicationController
 
     Seek::Config.bio_tools_enabled = string_to_boolean(params[:bio_tools_enabled])
 
-    time_lock_doi_for = params[:time_lock_doi_for]
-    time_lock_is_integer = only_integer time_lock_doi_for, 'time lock doi for'
-    Seek::Config.time_lock_doi_for = time_lock_doi_for.to_i if time_lock_is_integer
+    time_lock_is_integer = true
+    if params.key?(:time_lock_doi_for)
+      time_lock_doi_for = params[:time_lock_doi_for]
+      time_lock_is_integer = only_integer time_lock_doi_for, 'time lock doi for'
+      Seek::Config.time_lock_doi_for = time_lock_doi_for.to_i if time_lock_is_integer
+    end
 
     Seek::Util.clear_cached
 

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -64,11 +64,15 @@ class AdminController < ApplicationController
     Seek::Config.exception_notification_enabled = string_to_boolean params[:exception_notification_enabled] if params.key?(:exception_notification_enabled)
 
     Seek::Config.error_grouping_enabled = string_to_boolean params[:error_grouping_enabled] if params.key?(:error_grouping_enabled)
-    if Seek::Config.error_grouping_enabled
+    if params.key?(:error_grouping_timeout)
       eg_timeout = params[:error_grouping_timeout]
-      eg_log_base = params[:error_grouping_log_base]
       Seek::Config.error_grouping_timeout = string_to_seconds eg_timeout if string_is_duration(eg_timeout, 'error grouping timeout')
-      Seek::Config.error_grouping_log_base = eg_log_base.to_i if only_positive_integer(eg_log_base, 'error grouping log base')
+    end
+    eg_log_base_is_pos_int = true
+    if params.key?(:error_grouping_log_base)
+      eg_log_base = params[:error_grouping_log_base]
+      eg_log_base_is_pos_int = only_positive_integer(eg_log_base, 'error grouping log base')
+      Seek::Config.error_grouping_log_base = eg_log_base.to_i if eg_log_base_is_pos_int
     end
 
     Seek::Config.omniauth_enabled = string_to_boolean params[:omniauth_enabled]
@@ -168,7 +172,7 @@ class AdminController < ApplicationController
 
     Seek::Util.clear_cached
 
-    validation_flag = time_lock_is_integer && port_is_integer
+    validation_flag = time_lock_is_integer && port_is_integer && eg_log_base_is_pos_int
     update_redirect_to validation_flag, 'features_enabled'
   end
 

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -63,11 +63,13 @@ class AdminController < ApplicationController
     Seek::Config.exception_notification_recipients = params[:exception_notification_recipients] if params.key?(:exception_notification_recipients)
     Seek::Config.exception_notification_enabled = string_to_boolean params[:exception_notification_enabled] if params.key?(:exception_notification_enabled)
 
-    eg_timeout = params[:error_grouping_timeout]
-    eg_log_base = params[:error_grouping_log_base]
     Seek::Config.error_grouping_enabled = string_to_boolean params[:error_grouping_enabled] if params.key?(:error_grouping_enabled)
-    Seek::Config.error_grouping_timeout = string_to_seconds eg_timeout if string_is_duration(eg_timeout, 'error grouping timeout')
-    Seek::Config.error_grouping_log_base = eg_log_base.to_i if only_positive_integer(eg_log_base, 'error grouping log base')
+    if Seek::Config.error_grouping_enabled
+      eg_timeout = params[:error_grouping_timeout]
+      eg_log_base = params[:error_grouping_log_base]
+      Seek::Config.error_grouping_timeout = string_to_seconds eg_timeout if string_is_duration(eg_timeout, 'error grouping timeout')
+      Seek::Config.error_grouping_log_base = eg_log_base.to_i if only_positive_integer(eg_log_base, 'error grouping log base')
+    end
 
     Seek::Config.omniauth_enabled = string_to_boolean params[:omniauth_enabled]
     Seek::Config.omniauth_user_create = string_to_boolean params[:omniauth_user_create]

--- a/test/functional/admin_controller_test.rb
+++ b/test/functional/admin_controller_test.rb
@@ -282,42 +282,44 @@ class AdminControllerTest < ActionController::TestCase
   end
 
   test 'update error_grouping_timeout' do
-    with_config_value(:error_grouping_enabled, true) do
-      with_config_value(:error_grouping_timeout, 1.minute) do
-        post :update_features_enabled, params: { error_grouping_timeout: '1' }
-        assert_equal 1.seconds, Seek::Config.error_grouping_timeout
-        post :update_features_enabled, params: { error_grouping_timeout: '10 sec' }
-        assert_equal 10.seconds, Seek::Config.error_grouping_timeout
-        post :update_features_enabled, params: { error_grouping_timeout: '2 min' }
-        assert_equal 120.seconds, Seek::Config.error_grouping_timeout
-      end
+    # Checks for warnings when not setting error_grouping_timeout
+    with_config_value(:filtering_enabled, 'True') do
+      post :update_features_enabled, params: { filtering_enabled: 'False' }
+      assert_nil flash[:error]
     end
-    with_config_value(:error_grouping_enabled, false) do
-      with_config_value(:error_grouping_timeout, 1.minute) do
-        post :update_features_enabled, params: { error_grouping_timeout: '3' }
-        assert_equal 1.minute, Seek::Config.error_grouping_timeout
-      end
+    # Checks setting error_grouping_timeout
+    with_config_value(:error_grouping_timeout, 1.minute) do
+      post :update_features_enabled, params: { error_grouping_timeout: '1' }
+      assert_nil flash[:error]
+      assert_equal 1.seconds, Seek::Config.error_grouping_timeout
+      post :update_features_enabled, params: { error_grouping_timeout: '10 sec' }
+      assert_nil flash[:error]
+      assert_equal 10.seconds, Seek::Config.error_grouping_timeout
+      post :update_features_enabled, params: { error_grouping_timeout: '2 min' }
+      assert_nil flash[:error]
+      assert_equal 120.seconds, Seek::Config.error_grouping_timeout
+      post :update_features_enabled, params: { error_grouping_timeout: 'x' }
+      assert_equal 'Please enter a valid time for the error grouping timeout.', flash[:error]
     end
   end
 
   test 'update error_grouping_log_base' do
-    with_config_value(:error_grouping_enabled, true) do
-      with_config_value(:error_grouping_log_base, 2) do
-        post :update_features_enabled, params: { error_grouping_log_base: '3' }
-        assert_equal 3, Seek::Config.error_grouping_log_base
-        post :update_features_enabled, params: { error_grouping_log_base: '3.4' }
-        refute_nil flash[:error]
-        assert_equal 3, Seek::Config.error_grouping_log_base
-        post :update_features_enabled, params: { error_grouping_log_base: '-1' }
-        refute_nil flash[:error]
-        assert_equal 3, Seek::Config.error_grouping_log_base
-      end
+    # Checks for warnings when not setting error_grouping_log_base
+    with_config_value(:filtering_enabled, 'True') do
+      post :update_features_enabled, params: { filtering_enabled: 'False' }
+      assert_nil flash[:error]
     end
-    with_config_value(:error_grouping_enabled, false) do
-      with_config_value(:error_grouping_log_base, 2) do
-        post :update_features_enabled, params: { error_grouping_log_base: '3' }
-        assert_equal 2, Seek::Config.error_grouping_log_base
-      end
+    # Checks setting error_grouping_log_base
+    with_config_value(:error_grouping_log_base, 2) do
+      post :update_features_enabled, params: { error_grouping_log_base: '3' }
+      assert_nil flash[:error]
+      assert_equal 3, Seek::Config.error_grouping_log_base
+      post :update_features_enabled, params: { error_grouping_log_base: '3.4' }
+      assert_equal 'Please enter a valid positive number for the error grouping log base', flash[:error]
+      assert_equal 3, Seek::Config.error_grouping_log_base
+      post :update_features_enabled, params: { error_grouping_log_base: '-1' }
+      assert_equal 'Please enter a valid positive number for the error grouping log base', flash[:error]
+      assert_equal 3, Seek::Config.error_grouping_log_base
     end
   end
 

--- a/test/functional/admin_controller_test.rb
+++ b/test/functional/admin_controller_test.rb
@@ -282,26 +282,42 @@ class AdminControllerTest < ActionController::TestCase
   end
 
   test 'update error_grouping_timeout' do
-    with_config_value(:error_grouping_timeout, 1.minute) do
-      post :update_features_enabled, params: { error_grouping_timeout: '1' }
-      assert_equal 1.seconds, Seek::Config.error_grouping_timeout
-      post :update_features_enabled, params: { error_grouping_timeout: '10 sec' }
-      assert_equal 10.seconds, Seek::Config.error_grouping_timeout
-      post :update_features_enabled, params: { error_grouping_timeout: '2 min' }
-      assert_equal 120.seconds, Seek::Config.error_grouping_timeout
+    with_config_value(:error_grouping_enabled, true) do
+      with_config_value(:error_grouping_timeout, 1.minute) do
+        post :update_features_enabled, params: { error_grouping_timeout: '1' }
+        assert_equal 1.seconds, Seek::Config.error_grouping_timeout
+        post :update_features_enabled, params: { error_grouping_timeout: '10 sec' }
+        assert_equal 10.seconds, Seek::Config.error_grouping_timeout
+        post :update_features_enabled, params: { error_grouping_timeout: '2 min' }
+        assert_equal 120.seconds, Seek::Config.error_grouping_timeout
+      end
+    end
+    with_config_value(:error_grouping_enabled, false) do
+      with_config_value(:error_grouping_timeout, 1.minute) do
+        post :update_features_enabled, params: { error_grouping_timeout: '3' }
+        assert_equal 1.minute, Seek::Config.error_grouping_timeout
+      end
     end
   end
 
   test 'update error_grouping_log_base' do
-    with_config_value(:error_grouping_log_base, 2) do
-      post :update_features_enabled, params: { error_grouping_log_base: '3' }
-      assert_equal 3, Seek::Config.error_grouping_log_base
-      post :update_features_enabled, params: { error_grouping_log_base: '3.4' }
-      refute_nil flash[:error]
-      assert_equal 3, Seek::Config.error_grouping_log_base
-      post :update_features_enabled, params: { error_grouping_log_base: '-1' }
-      refute_nil flash[:error]
-      assert_equal 3, Seek::Config.error_grouping_log_base
+    with_config_value(:error_grouping_enabled, true) do
+      with_config_value(:error_grouping_log_base, 2) do
+        post :update_features_enabled, params: { error_grouping_log_base: '3' }
+        assert_equal 3, Seek::Config.error_grouping_log_base
+        post :update_features_enabled, params: { error_grouping_log_base: '3.4' }
+        refute_nil flash[:error]
+        assert_equal 3, Seek::Config.error_grouping_log_base
+        post :update_features_enabled, params: { error_grouping_log_base: '-1' }
+        refute_nil flash[:error]
+        assert_equal 3, Seek::Config.error_grouping_log_base
+      end
+    end
+    with_config_value(:error_grouping_enabled, false) do
+      with_config_value(:error_grouping_log_base, 2) do
+        post :update_features_enabled, params: { error_grouping_log_base: '3' }
+        assert_equal 2, Seek::Config.error_grouping_log_base
+      end
     end
   end
 


### PR DESCRIPTION
Parameter keys checked before updating error grouping parameters.

Implemented tests to make sure it does not sneak back in.

Resolves #1344 .