### PR TITLE
Download content blob file if available, provide the content-length for streams, and include Content-MD5 header

### DIFF
--- a/lib/seek/content_blob_common.rb
+++ b/lib/seek/content_blob_common.rb
@@ -122,7 +122,8 @@ module Seek
     end
 
     def handle_download(disposition = 'attachment', image_size = nil)
-      if @content_blob.file_exists?
+      jerm_generated = @asset_version && @asset_version.contributor.nil?
+      if @content_blob.file_exists? && !jerm_generated # JERM will try to download first
         if image_size && @content_blob.is_image_convertable?
           @content_blob.resize_image(image_size)
           filepath = @content_blob.full_cache_path(image_size)
@@ -136,7 +137,7 @@ module Seek
         send_file filepath, filename: @content_blob.original_filename, type: @content_blob.content_type || 'application/octet-stream', disposition: disposition
       elsif @content_blob.url.present?
         begin
-          if @asset_version.contributor.nil? # A jerm generated resource
+          if jerm_generated
             download_jerm_asset
           else
             case URI(@content_blob.url).scheme

--- a/lib/seek/content_blob_common.rb
+++ b/lib/seek/content_blob_common.rb
@@ -131,6 +131,7 @@ module Seek
           filepath = @content_blob.filepath
           # added for the benefit of the tests after rails3 upgrade - but doubt it is required
           headers['Content-Length'] = @content_blob.file_size.to_s
+          headers['Content-MD5'] = @content_blob.md5sum if @content_blob.md5sum
         end
         send_file filepath, filename: @content_blob.original_filename, type: @content_blob.content_type || 'application/octet-stream', disposition: disposition
       elsif @content_blob.url.present?

--- a/lib/seek/content_blob_common.rb
+++ b/lib/seek/content_blob_common.rb
@@ -182,7 +182,7 @@ module Seek
       info = Seek::DownloadHandling::HTTPHandler.new(@content_blob.url).info
       case info[:code]
       when 200
-        stream_with(Seek::DownloadHandling::HTTPStreamer.new(@content_blob.url))
+        stream_with(Seek::DownloadHandling::HTTPStreamer.new(@content_blob.url), info)
       when 401, 403
         # Try redirecting the user to the URL if SEEK cannot access it
         redirect_to @content_blob.url
@@ -201,8 +201,9 @@ module Seek
       stream_with(Seek::DownloadHandling::FTPStreamer.new(@content_blob.url))
     end
 
-    def stream_with(streamer)
+    def stream_with(streamer, info={})
       response.headers['Content-Type'] = @content_blob.content_type
+      response.headers['Content-Length'] = info[:file_size].to_s if info[:file_size]
       response.headers['Content-Disposition'] = "attachment; filename=#{@content_blob.original_filename}"
       response.headers['Last-Modified'] = Time.now.ctime.to_s
 

--- a/test/functional/content_blobs_controller_test.rb
+++ b/test/functional/content_blobs_controller_test.rb
@@ -568,6 +568,18 @@ class ContentBlobsControllerTest < ActionController::TestCase
     assert_equal '7168', @response.header['Content-Length']
   end
 
+  test 'download should provide the content length if file exists but has a url' do
+    df = Factory :small_test_spreadsheet_datafile, policy: Factory(:public_policy), contributor: User.current_user.person
+    blob = df.content_blob
+    blob.update_column(:url, 'http://website.com/somefile.txt')
+    get :download, params: { data_file_id: df, id: df.content_blob }
+    assert_response :success
+    assert_equal "attachment; filename=\"small-test-spreadsheet.xls\"; filename*=UTF-8''small-test-spreadsheet.xls", @response.header['Content-Disposition']
+    assert_equal 'application/vnd.ms-excel', @response.header['Content-Type']
+    assert_equal '7168', @response.header['Content-Length']
+  end
+
+
   test 'should not log download for inline view intent' do
     df = Factory :small_test_spreadsheet_datafile, policy: Factory(:public_policy), contributor: User.current_user.person
     assert_no_difference('ActivityLog.count') do

--- a/test/functional/content_blobs_controller_test.rb
+++ b/test/functional/content_blobs_controller_test.rb
@@ -568,6 +568,7 @@ class ContentBlobsControllerTest < ActionController::TestCase
     assert_equal "attachment; filename=\"small-test-spreadsheet.xls\"; filename*=UTF-8''small-test-spreadsheet.xls", @response.header['Content-Disposition']
     assert_equal 'application/vnd.ms-excel', @response.header['Content-Type']
     assert_equal '7168', @response.header['Content-Length']
+    assert_equal '86f7a87eb0b1c30b172037d69628f279', @response.header['Content-MD5']
   end
 
   test 'download should provide the content length if file exists but has a url' do
@@ -579,6 +580,7 @@ class ContentBlobsControllerTest < ActionController::TestCase
     assert_equal "attachment; filename=\"small-test-spreadsheet.xls\"; filename*=UTF-8''small-test-spreadsheet.xls", @response.header['Content-Disposition']
     assert_equal 'application/vnd.ms-excel', @response.header['Content-Type']
     assert_equal '7168', @response.header['Content-Length']
+    assert_equal '86f7a87eb0b1c30b172037d69628f279', @response.header['Content-MD5']
   end
 
   test 'download via streaming should provide the content length' do

--- a/test/functional/content_blobs_controller_test.rb
+++ b/test/functional/content_blobs_controller_test.rb
@@ -368,6 +368,8 @@ class ContentBlobsControllerTest < ActionController::TestCase
     assert File.exist?(doc_sop.content_blob.filepath('pdf')), 'the generated PDF file should remain'
   end
 
+
+
   test 'should gracefully handle view_pdf for non existing asset' do
     stub_request(:head, 'http://somewhere.com/piccy.doc').to_return(status: 404)
     sop = Factory(:sop,
@@ -577,6 +579,23 @@ class ContentBlobsControllerTest < ActionController::TestCase
     assert_equal "attachment; filename=\"small-test-spreadsheet.xls\"; filename*=UTF-8''small-test-spreadsheet.xls", @response.header['Content-Disposition']
     assert_equal 'application/vnd.ms-excel', @response.header['Content-Type']
     assert_equal '7168', @response.header['Content-Length']
+  end
+
+  test 'download via streaming should provide the content length' do
+    mock_remote_file "#{Rails.root}/test/fixtures/files/ms_word_test.doc",
+                     'http://somewhere.com/piccy.doc',
+                     'Content-Length':'500'
+    doc_sop = Factory(:sop,
+                      policy: Factory(:public_policy),
+                      contributor: User.current_user.person,
+                      content_blob: Factory(:doc_content_blob,
+                                            data: nil,
+                                            url: 'http://somewhere.com/piccy.doc',
+                                            uuid: UUID.generate))
+    get :download, params: { sop_id: doc_sop, id: doc_sop.content_blob }
+    assert_response :success
+
+    assert_equal '500', @response.header['Content-Length']
   end
 
 


### PR DESCRIPTION
related to #1391 and #1392 

related to a problem reported with large files registered via a URL. Now will always download the copied file if available, rather than reverting to streaming from the URL and include the content-length for both cases. There are broader problems to be addressed as part of issue #1396 and this is a quick fix to get close to the desired behaviour for being able to handle large files.

Also include the md5sum header if available