### PR TITLE
Issue 1394 make submitter default creator in single page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -665,12 +665,15 @@ class ApplicationController < ActionController::Base
 
   def get_creator_ids_for_isa(params)
     creator_ids = []
-    creator_keys = params[:assets_creators_attributes].keys
+    if params.respond_to? :assets_creators_attributes
+      creator_keys = params[:assets_creators_attributes].keys
 
-    creator_keys.each do |key|
-      creator_ids.append(params[:assets_creators_attributes][key][:creator_id])
+      creator_keys.each do |key|
+        creator_ids.append(params[:assets_creators_attributes][key][:creator_id])
+      end
+      creator_ids.map(&:to_i)
     end
-    creator_ids.map(&:to_i)
+    creator_ids
   end
 
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -663,4 +663,14 @@ class ApplicationController < ActionController::Base
     ]
   end
 
+  def get_creator_ids_for_isa(params)
+    creator_ids = []
+    creator_keys = params[:assets_creators_attributes].keys
+
+    creator_keys.each do |key|
+      creator_ids.append(params[:assets_creators_attributes][key][:creator_id])
+    end
+    creator_ids.map(&:to_i)
+  end
+
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -663,17 +663,5 @@ class ApplicationController < ActionController::Base
     ]
   end
 
-  def get_creator_ids_for_isa(params)
-    creator_ids = []
-    if params.respond_to? :assets_creators_attributes
-      creator_keys = params[:assets_creators_attributes].keys
-
-      creator_keys.each do |key|
-        creator_ids.append(params[:assets_creators_attributes][key][:creator_id])
-      end
-      creator_ids.map(&:to_i)
-    end
-    creator_ids
-  end
 
 end

--- a/app/controllers/isa_assays_controller.rb
+++ b/app/controllers/isa_assays_controller.rb
@@ -14,7 +14,8 @@ class IsaAssaysController < ApplicationController
     update_sharing_policies @isa_assay.assay
     @isa_assay.assay.contributor = current_person
     @isa_assay.sample_type.contributor = User.current_user.person
-
+    @isa_assay.assay.creators = get_creator_ids_for_isa_assays(params).collect{ |creator_id| Person.find(creator_id) }
+    @isa_assay.assay.other_creators = params[:assay][:other_creators]
     if @isa_assay.save
       redirect_to single_page_path(id: @isa_assay.assay.projects.first, item_type: 'assay',
                                    item_id: @isa_assay.assay, notice: 'The ISA assay was created successfully!')
@@ -56,6 +57,15 @@ class IsaAssaysController < ApplicationController
   end
 
   private
+
+  def get_creator_ids_for_isa_assays(params = {})
+    creator_ids = []
+    creator_keys = params[:assay][:assets_creators_attributes].keys
+    creator_keys.each do |key|
+      creator_ids.append(params[:assay][:assets_creators_attributes][key][:creator_id])
+    end
+    creator_ids.map(&:to_i)
+end
 
   def isa_assay_params
     # TODO: get the params from a shared module

--- a/app/controllers/isa_assays_controller.rb
+++ b/app/controllers/isa_assays_controller.rb
@@ -15,7 +15,7 @@ class IsaAssaysController < ApplicationController
     @isa_assay.assay.contributor = current_person
     @isa_assay.sample_type.contributor = User.current_user.person
     @isa_assay.assay.creators = get_creator_ids_for_isa_assays(params).collect{ |creator_id| Person.find(creator_id) }
-    @isa_assay.assay.other_creators = params[:assay][:other_creators]
+    @isa_assay.assay.other_creators = params[:assay][:other_creators] if params[:assay].respond_to? :other_creators
     if @isa_assay.save
       redirect_to single_page_path(id: @isa_assay.assay.projects.first, item_type: 'assay',
                                    item_id: @isa_assay.assay, notice: 'The ISA assay was created successfully!')

--- a/app/controllers/isa_assays_controller.rb
+++ b/app/controllers/isa_assays_controller.rb
@@ -14,8 +14,6 @@ class IsaAssaysController < ApplicationController
     update_sharing_policies @isa_assay.assay
     @isa_assay.assay.contributor = current_person
     @isa_assay.sample_type.contributor = User.current_user.person
-    @isa_assay.assay.creators = get_creator_ids_for_isa_assays(params).collect{ |creator_id| Person.find(creator_id) }
-    @isa_assay.assay.other_creators = params[:assay][:other_creators] if params[:assay].respond_to? :other_creators
     if @isa_assay.save
       redirect_to single_page_path(id: @isa_assay.assay.projects.first, item_type: 'assay',
                                    item_id: @isa_assay.assay, notice: 'The ISA assay was created successfully!')
@@ -57,10 +55,6 @@ class IsaAssaysController < ApplicationController
   end
 
   private
-
-  def get_creator_ids_for_isa_assays(params = {})
-    get_creator_ids_for_isa(params[:assay])
-  end
 
   def isa_assay_params
     # TODO: get the params from a shared module

--- a/app/controllers/isa_assays_controller.rb
+++ b/app/controllers/isa_assays_controller.rb
@@ -59,13 +59,8 @@ class IsaAssaysController < ApplicationController
   private
 
   def get_creator_ids_for_isa_assays(params = {})
-    creator_ids = []
-    creator_keys = params[:assay][:assets_creators_attributes].keys
-    creator_keys.each do |key|
-      creator_ids.append(params[:assay][:assets_creators_attributes][key][:creator_id])
-    end
-    creator_ids.map(&:to_i)
-end
+    get_creator_ids_for_isa(params[:assay])
+  end
 
   def isa_assay_params
     # TODO: get the params from a shared module

--- a/app/controllers/isa_studies_controller.rb
+++ b/app/controllers/isa_studies_controller.rb
@@ -17,8 +17,16 @@ class IsaStudiesController < ApplicationController
     @isa_study.study.sample_types = [@isa_study.source, @isa_study.sample_collection]
 
     if @isa_study.save
-      redirect_to single_page_path(id: @isa_study.study.projects.first, item_type: 'study',
-                                   item_id: @isa_study.study)
+      flash[:notice] = "The #{t('isa_study')} was succesfully created.<br/>".html_safe
+
+      respond_to do |format|
+        format.html do
+          redirect_to single_page_path(id: @isa_study.study.projects.first, item_type: 'study',
+                                       item_id: @isa_study.study)
+        end
+        format.json { render json: @isa_study, include: [params[:include]] }
+      end
+
     else
       respond_to do |format|
         format.html { render action: 'new' }

--- a/app/controllers/isa_studies_controller.rb
+++ b/app/controllers/isa_studies_controller.rb
@@ -13,7 +13,7 @@ class IsaStudiesController < ApplicationController
     @isa_study = IsaStudy.new(isa_study_params)
     update_sharing_policies @isa_study.study
     @isa_study.study.creators = get_creator_ids_for_isa_studies(params).collect{ |creator_id| Person.find(creator_id) }
-    @isa_study.study.other_creators = params[:study][:other_creators]
+    @isa_study.study.other_creators = params[:study][:other_creators] if params[:study].respond_to? :other_creators
     @isa_study.source.contributor = User.current_user.person
     @isa_study.sample_collection.contributor = User.current_user.person
     @isa_study.study.sample_types = [@isa_study.source, @isa_study.sample_collection]

--- a/app/controllers/isa_studies_controller.rb
+++ b/app/controllers/isa_studies_controller.rb
@@ -12,8 +12,6 @@ class IsaStudiesController < ApplicationController
   def create
     @isa_study = IsaStudy.new(isa_study_params)
     update_sharing_policies @isa_study.study
-    @isa_study.study.creators = get_creator_ids_for_isa_studies(params).collect{ |creator_id| Person.find(creator_id) }
-    @isa_study.study.other_creators = params[:study][:other_creators] if params[:study].respond_to? :other_creators
     @isa_study.source.contributor = User.current_user.person
     @isa_study.sample_collection.contributor = User.current_user.person
     @isa_study.study.sample_types = [@isa_study.source, @isa_study.sample_collection]
@@ -76,10 +74,6 @@ class IsaStudiesController < ApplicationController
   end
 
   private
-
-  def get_creator_ids_for_isa_studies(params = {})
-    get_creator_ids_for_isa(params[:study])
-  end
 
   def isa_study_params
     # TODO: get the params from a shared module

--- a/app/controllers/isa_studies_controller.rb
+++ b/app/controllers/isa_studies_controller.rb
@@ -78,12 +78,7 @@ class IsaStudiesController < ApplicationController
   private
 
   def get_creator_ids_for_isa_studies(params = {})
-    creator_ids = []
-    creator_keys = params[:study][:assets_creators_attributes].keys
-    creator_keys.each do |key|
-      creator_ids.append(params[:study][:assets_creators_attributes][key][:creator_id])
-    end
-    creator_ids.map(&:to_i)
+    get_creator_ids_for_isa(params[:study])
   end
 
   def isa_study_params

--- a/app/controllers/isa_studies_controller.rb
+++ b/app/controllers/isa_studies_controller.rb
@@ -12,7 +12,7 @@ class IsaStudiesController < ApplicationController
   def create
     @isa_study = IsaStudy.new(isa_study_params)
     update_sharing_policies @isa_study.study
-    @isa_study.study.creators = get_creator_ids(params).collect{ |creator_id| Person.find(creator_id) }
+    @isa_study.study.creators = get_creator_ids_for_isa_studies(params).collect{ |creator_id| Person.find(creator_id) }
     @isa_study.study.other_creators = params[:study][:other_creators]
     @isa_study.source.contributor = User.current_user.person
     @isa_study.sample_collection.contributor = User.current_user.person
@@ -77,7 +77,7 @@ class IsaStudiesController < ApplicationController
 
   private
 
-  def get_creator_ids(params = {})
+  def get_creator_ids_for_isa_studies(params = {})
     creator_ids = []
     creator_keys = params[:study][:assets_creators_attributes].keys
     creator_keys.each do |key|

--- a/app/controllers/isa_studies_controller.rb
+++ b/app/controllers/isa_studies_controller.rb
@@ -12,6 +12,8 @@ class IsaStudiesController < ApplicationController
   def create
     @isa_study = IsaStudy.new(isa_study_params)
     update_sharing_policies @isa_study.study
+    @isa_study.study.creators = get_creator_ids(params).collect{ |creator_id| Person.find(creator_id) }
+    @isa_study.study.other_creators = params[:study][:other_creators]
     @isa_study.source.contributor = User.current_user.person
     @isa_study.sample_collection.contributor = User.current_user.person
     @isa_study.study.sample_types = [@isa_study.source, @isa_study.sample_collection]
@@ -74,6 +76,15 @@ class IsaStudiesController < ApplicationController
   end
 
   private
+
+  def get_creator_ids(params = {})
+    creator_ids = []
+    creator_keys = params[:study][:assets_creators_attributes].keys
+    creator_keys.each do |key|
+      creator_ids.append(params[:study][:assets_creators_attributes][key][:creator_id])
+    end
+    creator_ids.map(&:to_i)
+  end
 
   def isa_study_params
     # TODO: get the params from a shared module

--- a/app/views/isa_assays/_form.html.erb
+++ b/app/views/isa_assays/_form.html.erb
@@ -39,7 +39,7 @@ input_sample_type_id ||=
   <%= assay_fields.hidden_field :assay_class_id -%>
 
   <% if User.current_user -%>
-    <%= render partial: 'assets/manage_specific_attributes', locals:{f:f} if show_form_manage_specific_attributes? %>
+    <%= render partial: 'assets/manage_specific_attributes', locals:{f:assay_fields} if show_form_manage_specific_attributes? %>
     <%= assay_fields.fancy_multiselect(:sops, other_projects_checkbox: true, name: "isa_assay[assay][sop_ids]") unless action == :edit %>
     <%= assay_fields.fancy_multiselect :publications, { other_projects_checkbox: true, name: "isa_assay[assay][publication_ids]" } %>
     <%= assay_fields.fancy_multiselect :documents, { other_projects_checkbox: true, name: "isa_assay[assay][document_ids]" } %>

--- a/app/views/isa_studies/_form.html.erb
+++ b/app/views/isa_studies/_form.html.erb
@@ -24,7 +24,7 @@
 
     <div id="investigation_collection" class="hidden">
       <%= render :partial=>"studies/investigation_list",:locals=>{study:@isa_study.study, :investigations=>Investigation.all.select {|i|current_user.person.member_of? i.projects}} -%>
-    </div>    
+    </div>
 
     <div class="form-group">
       <%= study_fields.label "Study position" -%><br/>
@@ -33,7 +33,7 @@
 
     <%= render partial: 'custom_metadata/custom_metadata_attribute_input', locals:{f:f,resource:@isa_study.study} %>
 
-    <%= render partial: 'assets/manage_specific_attributes', locals:{f:f} if show_form_manage_specific_attributes? %>
+    <%= render partial: 'assets/manage_specific_attributes', locals:{f:study_fields} if show_form_manage_specific_attributes? %>
 
     <%= study_fields.fancy_multiselect :publications, { other_projects_checkbox: true, name: "isa_study[study][publication_ids]" } %>
 
@@ -42,7 +42,7 @@
     <%= render partial: 'projects/implicit_project_selector', locals: { action: action,
                                                                           select_id: '#study_investigation_id',
                                                                           parents: Investigation.authorized_for('edit') } %>
-    
+
     <%= folding_panel("Define #{t(:sample_type)} for Source") do %>
       <%= render partial: 'sample_types_form', locals: {f: f, sample_type: @isa_study.source, id_suffix: "_source_sample_type", action: action } if @isa_study.source %>
     <% end %>
@@ -59,11 +59,11 @@
       <%= render partial: 'sample_types_form', locals: {f: f, sample_type: @isa_study.sample_collection, id_suffix: "_sample_collection_sample_type", action: action  } if @isa_study.sample_collection %>
     <% end %>
 
-<% end -%> 
+<% end -%>
 
 
 
- 
+
 <%= form_submit_buttons(@isa_study.study) %>
 
 <script>
@@ -75,16 +75,16 @@
       showTemplateModal()
     }
 
-    $j(document).ready(function () {   
+    $j(document).ready(function () {
       const urlSearchParams = new URLSearchParams(window.location.search);
       const params = Object.fromEntries(urlSearchParams.entries());
       const investigation_id = params["investigation_id"]
       // Prevent setting the hidden field on redirect (query string parameters are missing)
       if(investigation_id) {
-          $j("#isa_study_study_investigation_id").val(investigation_id); 
+          $j("#isa_study_study_investigation_id").val(investigation_id);
           $j("#study_investigation_id").val(investigation_id).change();
-      } 
+      }
 
-      Templates.init($j('#template-attributes'));   
-    }); 
+      Templates.init($j('#template-attributes'));
+    });
 </script>


### PR DESCRIPTION
This PR addresses the bug fix for [issue 1394](https://github.com/seek4science/seek/issues/1394):
- Adds creator field to the form when disigning an isa-study / isa-assay
- Adds creators to the `study` object when created from single page
- Adds creators to the `assay` object when created from single page
