### PR TITLE
Fix naming consistency in single page

### DIFF
--- a/app/views/investigations/_buttons.html.erb
+++ b/app/views/investigations/_buttons.html.erb
@@ -1,35 +1,37 @@
-<%= render :partial => "subscriptions/subscribe", :locals => {:object => item} %>
+<%= render :partial => "subscriptions/subscribe", :locals => { :object => item } %>
 <% if logged_in_and_member? %>
-    <%= button_link_to("New #{t('investigation')} based on this one", 'new', new_object_based_on_existing_one_investigation_path(item,:controller_name=>"investigations")) %>
-<!--    <%= button_link_to("Export ISATab JSON", 'publish', export_isatab_json_investigation_path(item)) %> -->
+  <% unless displaying_single_page? %>
+		<%= button_link_to("New #{t('investigation')} based on this one", 'new', new_object_based_on_existing_one_investigation_path(item, :controller_name => "investigations")) %>
+  <% end %>
+  <!--    <%= button_link_to("Export ISATab JSON", 'publish', export_isatab_json_investigation_path(item)) %> -->
 <% end %>
 
 <% if item.can_edit? -%>
   <% if displaying_single_page? %>
     <%= button_link_to("Design #{t('study')}", 'new', new_isa_study_path(investigation_id: item, single_page: params[:single_page])) %>
     <% if Seek::Config.project_single_page_advanced_enabled %>
-			<%= button_link_to("Export ISA", 'download', export_isa_single_page_path(id: params[:single_page] , investigation_id: item)) %>
-		<% end -%>
-	<% else -%>
-    <%= add_new_item_to_dropdown(item) %> 
+      <%= button_link_to("Export ISA", 'download', export_isa_single_page_path(id: params[:single_page], investigation_id: item)) %>
+    <% end -%>
+  <% else -%>
+    <%= add_new_item_to_dropdown(item) %>
   <% end -%>
 <% end -%>
 
 <%= item_actions_dropdown do %>
-    <% if item.can_edit? %>
-      <li><%= image_tag_for_key('edit', edit_investigation_path(item), "Edit #{t('investigation')}", nil, "Edit #{t('investigation')}") -%></li>
-    <% end %>
+  <% if item.can_edit? %>
+    <li><%= image_tag_for_key('edit', edit_investigation_path(item), "Edit #{t('investigation')}", nil, "Edit #{t('investigation')}") -%></li>
+  <% end %>
 
-    <% if item.can_manage? -%>
-        <li><%= image_tag_for_key('manage', manage_investigation_path(item), "Manage #{t('investigation')}", nil, "Manage #{t('investigation')}") -%></li>
-        <%= render :partial => 'snapshots/new_snapshot_link', :locals => { :item => item } %>
-    <% end -%>
+  <% if item.can_manage? -%>
+    <li><%= image_tag_for_key('manage', manage_investigation_path(item), "Manage #{t('investigation')}", nil, "Manage #{t('investigation')}") -%></li>
+    <%= render :partial => 'snapshots/new_snapshot_link', :locals => { :item => item } %>
+  <% end -%>
 
-    <% if (item.can_publish? || item.contains_publishable_items?) && item.can_manage? -%>
-        <li><%= image_tag_for_key('publish', polymorphic_path(item, :action => :check_related_items), nil, {:method=>:post}, "Publish full #{t('investigation')}") -%></li>
-    <% end -%>
+  <% if (item.can_publish? || item.contains_publishable_items?) && item.can_manage? -%>
+    <li><%= image_tag_for_key('publish', polymorphic_path(item, :action => :check_related_items), nil, { :method => :post }, "Publish full #{t('investigation')}") -%></li>
+  <% end -%>
 
-    <%= order_icon(item,current_user, order_studies_investigation_path(item), item.studies, 'study') -%>
+  <%= order_icon(item, current_user, order_studies_investigation_path(item), item.studies, 'study') -%>
 
-    <%= delete_icon item,current_user -%>
+  <%= delete_icon item, current_user -%>
 <% end -%>

--- a/app/views/investigations/new.html.erb
+++ b/app/views/investigations/new.html.erb
@@ -1,7 +1,11 @@
-<h1>New <%= t('investigation') %></h1>
+<% if displaying_single_page? %>
+  <h1>New ISA <%= t('investigation') %></h1>
+<% else %>
+  <h1>New <%= t('investigation') %></h1>
+<% end %>
 
 <%= index_and_new_help_icon controller_name %>
 
 <%= form_for @investigation do |f| %>
-    <%= render :partial => "form", :locals => { :f => f, :action=>:new } -%>
+  <%= render :partial => "form", :locals => { :f => f, :action => :new } -%>
 <% end -%>

--- a/app/views/projects/_buttons.html.erb
+++ b/app/views/projects/_buttons.html.erb
@@ -33,9 +33,9 @@
 
 <% if item.can_edit? -%>
   <% if displaying_single_page? %>
-    <%= button_link_to("Create #{t('investigation')}", 'new', new_investigation_path("investigation[project_id]": item.id, single_page: params[:id])) %> 
+    <%= button_link_to("Design #{t('investigation')}", 'new', new_investigation_path("investigation[project_id]": item.id, single_page: params[:id])) %>
   <% else -%>
-    <%= add_new_item_to_dropdown(item) %> 
+    <%= add_new_item_to_dropdown(item) %>
   <% end -%>
 <% end -%>
 

--- a/app/views/studies/_buttons.html.erb
+++ b/app/views/studies/_buttons.html.erb
@@ -1,26 +1,28 @@
-<%= render :partial => "subscriptions/subscribe", :locals => {:object => item} %>
+<%= render :partial => "subscriptions/subscribe", :locals => { :object => item } %>
 
 <% if logged_in_and_member? %>
-    <%= button_link_to("New #{t('study')} based on this one", 'new', new_object_based_on_existing_one_study_path(item,:controller_name=>"studies")) %>
+  <% unless displaying_single_page?%>
+		<%= button_link_to("New #{t('study')} based on this one", 'new', new_object_based_on_existing_one_study_path(item, :controller_name => "studies")) %>
+  <% end %>
 <% end %>
 
 <% if item.can_edit? -%>
   <% if displaying_single_page? %>
-		<% if item&.sample_types.present? %>
-    	<%= button_link_to("Design #{t('assay')}", 'new', new_isa_assay_path(study_id: item.id, single_page: params[:single_page], is_source: true)) %>
-		<% end -%>
-	<% else -%>
-    <%= add_new_item_to_dropdown(item) %> 
+    <% if item&.sample_types.present? %>
+      <%= button_link_to("Design #{t('assay')}", 'new', new_isa_assay_path(study_id: item.id, single_page: params[:single_page], is_source: true)) %>
+    <% end -%>
+  <% else -%>
+    <%= add_new_item_to_dropdown(item) %>
   <% end -%>
 <% end -%>
 
 <%= item_actions_dropdown do %>
   <% if item.can_edit? %>
-		<% if displaying_single_page? %>
-			<li><%= image_tag_for_key('edit', edit_isa_study_path(item, single_page: params[:single_page]), "Edit #{t('isa_study')}", nil, "Edit #{t('isa_study')}") -%></li>
-		<% else %>
-			<li><%= image_tag_for_key('edit', edit_study_path(item), "Edit #{t('study')}", nil, "Edit #{t('study')}") -%></li>
-		<% end %>
+    <% if displaying_single_page? %>
+      <li><%= image_tag_for_key('edit', edit_isa_study_path(item, single_page: params[:single_page]), "Edit #{t('isa_study')}", nil, "Edit #{t('isa_study')}") -%></li>
+    <% else %>
+      <li><%= image_tag_for_key('edit', edit_study_path(item), "Edit #{t('study')}", nil, "Edit #{t('study')}") -%></li>
+    <% end %>
   <% end %>
 
   <% if item.can_manage? -%>
@@ -28,7 +30,7 @@
     <%= render :partial => 'snapshots/new_snapshot_link', :locals => { :item => item } %>
   <% end -%>
 
-    <%= order_icon(item,current_user, order_assays_study_path(item), item.assays, 'assay') -%>
- 
-  <%= delete_icon item,current_user -%>
+  <%= order_icon(item, current_user, order_assays_study_path(item), item.assays, 'assay') -%>
+
+  <%= delete_icon item, current_user -%>
 <% end -%>


### PR DESCRIPTION
- Changed 'create new investigation' button to 'Design new investigation' in single page.
- Hidden the buttons 'new <x> based on this one' in single page.
- Changed the title of the new ISA investigation