### PR TITLE
small improvements to the docker puma config

### DIFF
--- a/docker/puma.rb
+++ b/docker/puma.rb
@@ -1,14 +1,19 @@
 require 'concurrent-ruby'
-# Change to match your CPU core count
-workers Concurrent.processor_count
+# Match your CPU core count unless specified by PUMA_WORKERS_NUM
+workers ENV.fetch('PUMA_WORKERS_NUM') { Concurrent.processor_count }
 
 worker_timeout 120
+
+# This directive tells Puma to first boot the application and load code
+# before forking the application. This takes advantage of Copy On Write
+# process behavior so workers use less memory.
+preload_app!
 
 # Min and Max threads per worker
 threads 1, 1
 
 # Default to development
-rails_env = ENV['RAILS_ENV'] || "development"
+rails_env = ENV.fetch('RAILS_ENV') { "development" }
 environment rails_env
 
 stdout_redirect 'log/puma.out', 'log/puma.err'


### PR DESCRIPTION
allow the number of workers to be overriden by providing PUMA_WORKERS_NUM environment variable.

also use `preload_app!` for potentially quicker start up and memory useage

both have been tested with test container

fix for #1440 