### PR TITLE
Versioning fixes

### DIFF
--- a/app/models/data_file.rb
+++ b/app/models/data_file.rb
@@ -7,7 +7,7 @@ class DataFile < ApplicationRecord
 
   acts_as_asset
 
-  acts_as_doi_parent(child_accessor: :versions)
+  acts_as_doi_parent
 
   has_controlled_vocab_annotations :data_types, :data_formats
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -7,7 +7,7 @@ class Document < ApplicationRecord
 
   validates :projects, presence: true, projects: { self: true }
 
-  acts_as_doi_parent(child_accessor: :versions)
+  acts_as_doi_parent
 
   #don't add a dependent=>:destroy, as the content_blob needs to remain to detect future duplicates
   has_one :content_blob, -> (r) { where('content_blobs.asset_version = ?', r.version) }, :as => :asset, :foreign_key => :asset_id

--- a/app/models/file_template.rb
+++ b/app/models/file_template.rb
@@ -12,7 +12,7 @@ class FileTemplate < ApplicationRecord
 
   validates :projects, presence: true, projects: { self: true }
 
-  acts_as_doi_parent(child_accessor: :versions)
+  acts_as_doi_parent
 
   has_controlled_vocab_annotations :data_types, :data_formats
 

--- a/app/models/ga4gh/trs/v2/tool.rb
+++ b/app/models/ga4gh/trs/v2/tool.rb
@@ -22,9 +22,8 @@ module Ga4gh
           projects.map(&:title).sort.join(', ')
         end
 
-        alias_method :orig_versions, :versions
         def versions
-          orig_versions.map { |v| ToolVersion.new(self, v) }
+          @workflow.versions.map { |v| ToolVersion.new(self, v) }
         end
 
         def toolclass

--- a/app/models/ga4gh/trs/v2/tool.rb
+++ b/app/models/ga4gh/trs/v2/tool.rb
@@ -22,8 +22,9 @@ module Ga4gh
           projects.map(&:title).sort.join(', ')
         end
 
+        alias_method :orig_versions, :versions
         def versions
-          all_versions.map { |v| ToolVersion.new(self, v) }
+          orig_versions.map { |v| ToolVersion.new(self, v) }
         end
 
         def toolclass

--- a/app/models/git/version.rb
+++ b/app/models/git/version.rb
@@ -11,7 +11,7 @@ module Git
     has_many :remote_source_annotations, -> { where(key: 'remote_source') }, autosave: true,
              inverse_of: :git_version, dependent: :destroy, class_name: 'Git::Annotation', foreign_key: :git_version_id
 
-    before_create :set_version
+    before_validation :set_version, on: :create
     before_validation :set_git_info, on: :create
     before_validation :set_default_visibility, on: :create
     before_validation :assign_contributor, on: :create
@@ -22,6 +22,7 @@ module Git
     accepts_nested_attributes_for :git_annotations
 
     store :resource_attributes, coder: JSON
+    validates :name, length: { minimum: 1 }
     validates :git_repository, presence: true
     validate :git_repository_linkable
 

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -20,7 +20,7 @@ class Model < ApplicationRecord
 
   validates :projects, presence: true, projects: { self: true }
 
-  acts_as_doi_parent(child_accessor: :versions)
+  acts_as_doi_parent
 
   include Seek::Models::ModelExtraction
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -280,9 +280,10 @@ class Person < ApplicationRecord
 
   # all items, assets, ISA, samples and events that are linked to this person as a contributor
   def contributed_items
-    [Assay, Study, Investigation, DataFile, Document, Sop, Presentation, Model, Sample, Strain, Publication, Event, SampleType].collect do |type|
-      type.where(contributor_id:id)
-    end.flatten.uniq.compact
+    RELATED_RESOURCE_TYPES.flat_map do |type|
+      plural = type.tableize
+      send("contributed_#{plural}")
+    end
   end
 
   def me?

--- a/app/models/sop.rb
+++ b/app/models/sop.rb
@@ -6,7 +6,7 @@ class Sop < ApplicationRecord
 
   acts_as_asset
 
-  acts_as_doi_parent(child_accessor: :versions)
+  acts_as_doi_parent
 
   validates :projects, presence: true, projects: { self: true }
 

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -12,7 +12,7 @@ class Workflow < ApplicationRecord
 
   acts_as_asset
 
-  acts_as_doi_parent(child_accessor: :versions)
+  acts_as_doi_parent(child_accessor: :all_versions)
 
   has_controlled_vocab_annotations :topics, :operations
 

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -12,7 +12,7 @@ class Workflow < ApplicationRecord
 
   acts_as_asset
 
-  acts_as_doi_parent(child_accessor: :all_versions)
+  acts_as_doi_parent
 
   has_controlled_vocab_annotations :topics, :operations
 

--- a/app/views/assets/_edit_version_form.erb
+++ b/app/views/assets/_edit_version_form.erb
@@ -12,10 +12,6 @@
       </div>
     <% end %>
 
-    <%= submit_tag 'Update', id: "edit_comment_submit_btn", class: 'btn btn-primary'-%>
+    <%= submit_tag 'Update', class: 'btn btn-primary'-%>
   <% end %>
 <% end %>
-
-
-
-

--- a/app/views/assets/_resource_git_version_list_item.html.erb
+++ b/app/views/assets/_resource_git_version_list_item.html.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-sm-8">
       <h4 class="list-group-item-heading">
-        <%= link_to "#{version.name} #{resource.describe_version(version.version)}", {:version => version.version} %>
+        <%= link_to "#{version.name} #{resource.describe_version(version.version)}", { version: version.version } %>
         <small>
           Created <%= date_as_string(version.created_at,true) %>
           by <%= contributor version.contributor %>
@@ -34,11 +34,6 @@
       <% if resource.can_manage? %>
         <%= button_link_to('Edit', 'edit', '#', onclick:"$j('#edit_git_version_form_#{version.version}').fadeToggle(); return false;") -%>
       <%end %>
-      <% if Seek::Config.delete_asset_version_enabled && resource.can_edit?(User.current_user) && visible_versions.length > 1 %>
-        <% path = polymorphic_path(resource, :version => version.version, :action => :destroy_version) %>
-        <%= button_link_to("Delete", 'destroy', path,
-                           { data: { confirm: "This deletes version #{version.version.to_s} of the #{text_for_resource resource}. Are you sure?" }, :method => :delete}) -%>
-      <% end -%>
     </div>
   </div>
 </div>

--- a/app/views/assets/_resource_git_version_list_item.html.erb
+++ b/app/views/assets/_resource_git_version_list_item.html.erb
@@ -18,13 +18,27 @@
       <% unless version.ref.blank? %>
         <code><%= git_target_icon(version.ref) %><%= version.ref.split('/').last %></code>
       <% end %>
-       <code><%= version.commit&.first(7) %></code>
+      <code><%= version.commit&.first(7) %></code>
       <% unless version.visibility == :public %>
-        <div class="subtle">
+        <span class="subtle">
           <span class="glyphicon glyphicon-eye-close" aria-hidden="true"></span>
           <%= VersionHelper::VISIBILITY_LABELS[version.visibility] %>
-        </div>
+        </span>
       <% end %>
+
+      <% if resource.can_manage? %>
+        <%= render partial: 'git/edit_git_version_form', locals: { resource: resource, version: version } %>
+      <% end %>
+    </div>
+    <div class="col-sm-4 text-right">
+      <% if resource.can_manage? %>
+        <%= button_link_to('Edit', 'edit', '#', onclick:"$j('#edit_git_version_form_#{version.version}').fadeToggle(); return false;") -%>
+      <%end %>
+      <% if Seek::Config.delete_asset_version_enabled && resource.can_edit?(User.current_user) && visible_versions.length > 1 %>
+        <% path = polymorphic_path(resource, :version => version.version, :action => :destroy_version) %>
+        <%= button_link_to("Delete", 'destroy', path,
+                           { data: { confirm: "This deletes version #{version.version.to_s} of the #{text_for_resource resource}. Are you sure?" }, :method => :delete}) -%>
+      <% end -%>
     </div>
   </div>
 </div>

--- a/app/views/assets/_resource_version_list_item.html.erb
+++ b/app/views/assets/_resource_version_list_item.html.erb
@@ -36,10 +36,10 @@
       <% if resource.can_manage? %>
         <%= button_link_to('Edit', 'edit', '#', onclick:"$j('#edit_version_form_#{version.version}').fadeToggle(); return false;") -%>
       <%end %>
-      <% if Seek::Config.delete_asset_version_enabled && resource.can_edit?(User.current_user) && visible_versions.length > 1 %>
-        <% path = polymorphic_path(resource, :version => version.version, :action => :destroy_version) %>
+      <% if Seek::Config.delete_asset_version_enabled && resource.can_edit? && visible_versions.length > 1 %>
+        <% path = polymorphic_path(resource, version: version.version, action: :destroy_version) %>
         <%= button_link_to("Delete", 'destroy', path,
-                           { data: { confirm: "This deletes version #{version.version.to_s} of the #{text_for_resource resource}. Are you sure?" }, :method => :delete}) -%>
+                           { data: { confirm: "This deletes version #{version.version.to_s} of the #{text_for_resource resource}. Are you sure?" }, method: :delete}) -%>
       <% end -%>
     </div>
   </div>

--- a/app/views/git/_edit_git_version_form.html.erb
+++ b/app/views/git/_edit_git_version_form.html.erb
@@ -1,0 +1,22 @@
+<%= panel('Edit version', id: 'edit_git_version_form_'+"#{version.version}", style: 'margin-top: 1em; display: none') do %>
+  <%= form_for(version, as: :git_version, url: polymorphic_path([resource, :git_update_version], version: version.version), method: :patch) do |f| %>
+    <div class="form-group">
+      <label>Name</label>
+      <%= f.text_field(:name, class: 'form-control') %>
+    </div>
+
+    <div class="form-group">
+      <label>Comment</label>
+      <%= f.text_area(:comment, class: 'form-control') %>
+    </div>
+
+    <% if version.can_change_visibility? %>
+      <div class="form-group">
+        <label>Visibility</label>
+        <%= f.select :visibility, version_visibility_options(version.visibility), {}, class: 'form-control' -%>
+      </div>
+    <% end %>
+
+    <%= submit_tag 'Update', class: 'btn btn-primary'-%>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -131,6 +131,8 @@ SEEK::Application.routes.draw do
         patch 'blob/*path' => 'git#move_file', as: :git_move_file
         get 'freeze' => 'git#freeze_preview', as: :git_freeze_preview
         post 'freeze' => 'git#freeze', as: :git_freeze
+        patch '' => 'git#update', as: :git_update_version
+        #delete '' => 'git#destroy', as: :git_destroy_version
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -132,7 +132,6 @@ SEEK::Application.routes.draw do
         get 'freeze' => 'git#freeze_preview', as: :git_freeze_preview
         post 'freeze' => 'git#freeze', as: :git_freeze
         patch '' => 'git#update', as: :git_update_version
-        #delete '' => 'git#destroy', as: :git_destroy_version
       end
     end
   end

--- a/lib/git/converter.rb
+++ b/lib/git/converter.rb
@@ -14,7 +14,7 @@ module Git
       else
         repo = asset.local_git_repository || asset.create_local_git_repository
       end
-      asset.versions.order(:version).each do |version|
+      asset.standard_versions.order(:version).each do |version|
         convert_version(repo, version, unzip: unzip)
       end
 

--- a/lib/git/versioning.rb
+++ b/lib/git/versioning.rb
@@ -23,7 +23,7 @@ module Git
           after_update :sync_resource_attributes
 
           def is_git_versioned?
-            git_versions.any? || !@git_version_attributes.blank?
+            git_versions.any? || @git_version_attributes.present?
           end
 
           def is_git_versioned=(truth)
@@ -45,6 +45,10 @@ module Git
 
           def latest_git_version
             git_versions.last
+          end
+
+          def previous_git_version(base = latest_git_version.version)
+            git_versions.where('version < ?', base).last
           end
 
           def save_git_version_on_create

--- a/lib/git/versioning_compatibility.rb
+++ b/lib/git/versioning_compatibility.rb
@@ -2,15 +2,19 @@
 module Git
   module VersioningCompatibility
     def latest_version
-      is_git_versioned? ? latest_git_version : super
+      is_git_versioned? ? latest_git_version : latest_standard_version
+    end
+
+    def previous_version(base = version)
+      is_git_versioned? ? previous_git_version(base) : previous_standard_version(base)
     end
 
     def visible_versions(user = User.current_user)
-      is_git_versioned? ? visible_git_versions(user) : super
+      is_git_versioned? ? visible_git_versions(user) : visible_standard_versions(user)
     end
 
     def find_version(version)
-      is_git_versioned? ? find_git_version(version) : super
+      is_git_versioned? ? find_git_version(version) : find_standard_version(version)
     end
 
     def describe_version(version_number)

--- a/lib/git/versioning_compatibility.rb
+++ b/lib/git/versioning_compatibility.rb
@@ -14,15 +14,15 @@ module Git
     end
 
     def describe_version(version_number)
-      vs = all_versions
+      vs = versions
 
       return '(earliest)' if version_number == vs.first.version
       return '(latest)' if version_number == vs.last.version
       ''
     end
 
-    def all_versions
-      is_git_versioned? ? git_versions : versions
+    def versions
+      is_git_versioned? ? git_versions : standard_versions
     end
   end
 end

--- a/lib/seek/assets_standard_controller_actions.rb
+++ b/lib/seek/assets_standard_controller_actions.rb
@@ -152,7 +152,7 @@ module Seek
 
     def edit_version
       item = class_for_controller_name.find(params[:id])
-      version = item.versions.find_by(version: params[:version])
+      version = item.standard_versions.find_by(version: params[:version])
 
       if version&.update(edit_version_params(version))
         flash[:notice] = "Version #{params[:version]} was successfully updated."

--- a/lib/seek/explicit_versioning.rb
+++ b/lib/seek/explicit_versioning.rb
@@ -44,7 +44,7 @@ module Seek
         class_eval do
           order_opts = version_association_options.delete(:order) || ''
           condition_ops = version_association_options.delete(:conditions) || ''
-          has_many :versions, -> { order(order_opts).where(condition_ops) }, **version_association_options
+          has_many :standard_versions, -> { order(order_opts).where(condition_ops) }, **version_association_options
 
           before_create :set_new_version
           after_create :save_version_on_create
@@ -71,7 +71,7 @@ module Seek
           end
 
           def versions
-            parent.versions
+            parent.standard_versions
           end
 
           def latest_version?

--- a/lib/seek/permissions/policy_based_authorization.rb
+++ b/lib/seek/permissions/policy_based_authorization.rb
@@ -339,7 +339,7 @@ module Seek
 
       def contributor_ids
         ids = [contributor_id]
-        ids += versions.pluck(:contributor_id) if self.respond_to?(:versions)
+        ids += versions.pluck(:contributor_id) if respond_to?(:versions)
         ids.uniq
       end
 

--- a/lib/tasks/seek.rake
+++ b/lib/tasks/seek.rake
@@ -143,7 +143,7 @@ namespace :seek do
     count = 0
     disable_authorization_checks do
       Workflow.includes(:git_versions, :versions).find_each do |workflow|
-        ([workflow] + workflow.versions.to_a + workflow.git_versions.to_a).each do |wf|
+        ([workflow] + workflow.standard_versions.to_a + workflow.git_versions.to_a).each do |wf|
           begin
             wf.refresh_internals
             if wf.save(touch: false)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ galaxy2cwl==0.1.4
 gxformat2==0.15.0
 nbconvert==6.5.1
 ipython==7.33.0
+filelock>=3.8.0

--- a/test/unit/person_test.rb
+++ b/test/unit/person_test.rb
@@ -185,8 +185,7 @@ class PersonTest < ActiveSupport::TestCase
     strain = FactoryBot.create(:strain,contributor:person)
     sample = FactoryBot.create(:sample,contributor:person)
 
-
-    items = person.contributed_items
+    items = person.reload.contributed_items
 
     assert_equal 6, items.count
     assert_includes items, df
@@ -199,14 +198,14 @@ class PersonTest < ActiveSupport::TestCase
     person = FactoryBot.create(:person_in_project)
     assert_nil person.user
 
-    assert_empty person.contributed_items
+    assert_empty person.reload.contributed_items
 
     df = FactoryBot.create(:data_file, contributor: person)
     inv = FactoryBot.create(:investigation, contributor:person)
     study = FactoryBot.create(:study, contributor: person,investigation:inv)
     as = FactoryBot.create(:assay, contributor: person,study:study)
 
-    items = person.contributed_items
+    items = person.reload.contributed_items
 
     assert_equal 4, items.count
     assert_includes items, df

--- a/test/unit/versioning_compatibility_test.rb
+++ b/test/unit/versioning_compatibility_test.rb
@@ -1,0 +1,144 @@
+require 'test_helper'
+
+class VersioningCompatibilityTest < ActiveSupport::TestCase
+  setup do
+    @standard_workflow = FactoryBot.create(:workflow)
+    disable_authorization_checks do
+      @standard_workflow.save_as_new_version('new version')
+      FactoryBot.create(:cwl_content_blob, asset: @standard_workflow, asset_version: 2)
+    end
+
+    @git_workflow = FactoryBot.create(:local_git_workflow)
+    disable_authorization_checks do
+      @git_workflow.latest_git_version.next_version.save!
+    end
+
+    @converted_workflow = FactoryBot.create(:workflow)
+    disable_authorization_checks do
+      @converted_workflow.save_as_new_version('new version')
+      FactoryBot.create(:cwl_content_blob, asset: @converted_workflow, asset_version: 2)
+      Git::Converter.new(@converted_workflow.reload).convert(unzip: true)
+      @converted_workflow.latest_git_version.next_version.save! # v3
+    end
+  end
+
+  test 'is_git_versioned?' do
+    refute @standard_workflow.is_git_versioned?
+
+    assert @git_workflow.is_git_versioned?
+
+    assert @converted_workflow.is_git_versioned?
+  end
+
+  test 'latest_version' do
+    latest_standard_workflow = @standard_workflow.latest_version
+    assert_equal 'Workflow::Version', latest_standard_workflow.class.name
+    assert_equal 2, latest_standard_workflow.version
+    assert_equal latest_standard_workflow, @standard_workflow.latest_standard_version
+
+    latest_git_workflow = @git_workflow.latest_version
+    assert_equal 'Workflow::Git::Version', latest_git_workflow.class.name
+    assert_equal 2, latest_git_workflow.version
+    assert_equal latest_git_workflow, @git_workflow.latest_git_version
+
+    latest_converted_workflow = @converted_workflow.latest_version
+    assert_equal 'Workflow::Git::Version', latest_converted_workflow.class.name
+    assert_equal 3, latest_converted_workflow.version
+    assert_equal latest_converted_workflow, @converted_workflow.latest_git_version
+    latest_converted_workflow_std = @converted_workflow.latest_standard_version
+    assert_equal 'Workflow::Version', latest_converted_workflow_std.class.name
+    assert_equal 2, latest_converted_workflow_std.version
+  end
+
+  test 'previous_version' do
+    previous_standard_workflow = @standard_workflow.previous_version
+    assert_equal 'Workflow::Version', previous_standard_workflow.class.name
+    assert_equal 1, previous_standard_workflow.version
+    assert_equal previous_standard_workflow, @standard_workflow.previous_standard_version
+
+    previous_git_workflow = @git_workflow.previous_version
+    assert_equal 'Workflow::Git::Version', previous_git_workflow.class.name
+    assert_equal 1, previous_git_workflow.version
+    assert_equal previous_git_workflow, @git_workflow.previous_git_version
+
+    previous_converted_workflow = @converted_workflow.previous_version
+    assert_equal 'Workflow::Git::Version', previous_converted_workflow.class.name
+    assert_equal 2, previous_converted_workflow.version
+    assert_equal previous_converted_workflow, @converted_workflow.previous_git_version
+    previous_converted_workflow_std = @converted_workflow.previous_standard_version
+    assert_equal 'Workflow::Version', previous_converted_workflow_std.class.name
+    assert_equal 1, previous_converted_workflow_std.version
+  end
+
+  test 'version' do
+    assert_equal 2, @standard_workflow.version
+    assert_equal 2, @standard_workflow.latest_version.version
+
+    assert_equal 2, @git_workflow.version
+    assert_equal 2, @git_workflow.latest_version.version
+
+    assert_equal 3, @converted_workflow.version
+    assert_equal 3, @converted_workflow.latest_version.version
+    assert_equal 2, @converted_workflow.latest_standard_version.version
+  end
+
+  test 'versions' do
+    assert @standard_workflow.versions.all? { |v| v.is_a?(Workflow::Version) }
+
+    assert @git_workflow.versions.all? { |v| v.is_a?(Workflow::Git::Version) }
+
+    assert @converted_workflow.versions.all? { |v| v.is_a?(Workflow::Git::Version) }
+  end
+
+  test 'visible_versions' do
+    assert @standard_workflow.visible_versions.all? { |v| v.is_a?(Workflow::Version) }
+
+    assert @git_workflow.visible_versions.all? { |v| v.is_a?(Workflow::Git::Version) }
+
+    assert @converted_workflow.visible_versions.all? { |v| v.is_a?(Workflow::Git::Version) }
+
+    assert_equal 2, @converted_workflow.visible_standard_versions.length
+    assert_equal 3, @converted_workflow.visible_git_versions.length
+
+    disable_authorization_checks do
+      @converted_workflow.find_standard_version(1).update!(visibility: :private)
+    end
+
+    assert_equal 1, @converted_workflow.visible_standard_versions.length
+    assert_equal 3, @converted_workflow.visible_git_versions.length
+  end
+
+  test 'find_version' do
+    assert_equal 'Workflow::Version', @standard_workflow.find_version(1).class.name
+    assert_equal 'Workflow::Version', @standard_workflow.find_version(2).class.name
+    assert_nil @standard_workflow.find_version(3)
+
+    assert_equal 'Workflow::Git::Version', @git_workflow.find_version(1).class.name
+    assert_equal 'Workflow::Git::Version', @git_workflow.find_version(2).class.name
+    assert_nil @git_workflow.find_version(3)
+
+    assert_equal 'Workflow::Git::Version', @converted_workflow.find_version(1).class.name
+    assert_equal 'Workflow::Git::Version', @converted_workflow.find_version(3).class.name
+    assert_nil @converted_workflow.find_version(4)
+  end
+
+  test 'update_version only affects standard versions' do
+    disable_authorization_checks do
+      @converted_workflow.update_version(1, { title: 'hello world' })
+    end
+
+    assert_equal 'hello world', @converted_workflow.find_standard_version(1).title
+    assert_not_equal 'hello world', @converted_workflow.find_git_version(1).title
+  end
+
+  test 'destroy_version only affects standard versions' do
+    with_config_value(:delete_asset_version_enabled, true) do
+      disable_authorization_checks do
+        assert @converted_workflow.destroy_version(1)
+      end
+    end
+
+    assert_nil @converted_workflow.find_standard_version(1)
+    refute_nil @converted_workflow.find_git_version(1)
+  end
+end

--- a/test/unit/workflow_test.rb
+++ b/test/unit/workflow_test.rb
@@ -786,7 +786,7 @@ class WorkflowTest < ActiveSupport::TestCase
   test 'sets deleted_contributor after contributor deleted' do
     workflow = FactoryBot.create(:local_git_workflow)
     assert_nil workflow.deleted_contributor
-    refute item.has_deleted_contributor?
+    refute workflow.has_deleted_contributor?
 
     disable_authorization_checks do
       workflow.contributor.destroy!
@@ -794,6 +794,6 @@ class WorkflowTest < ActiveSupport::TestCase
 
     workflow.reload
     assert workflow.deleted_contributor
-    assert item.has_deleted_contributor?
+    assert workflow.has_deleted_contributor?
   end
 end

--- a/test/unit/workflow_test.rb
+++ b/test/unit/workflow_test.rb
@@ -782,4 +782,18 @@ class WorkflowTest < ActiveSupport::TestCase
       refute workflow.can_delete?
     end
   end
+
+  test 'sets deleted_contributor after contributor deleted' do
+    workflow = FactoryBot.create(:local_git_workflow)
+    assert_nil workflow.deleted_contributor
+    refute item.has_deleted_contributor?
+
+    disable_authorization_checks do
+      workflow.contributor.destroy!
+    end
+
+    workflow.reload
+    assert workflow.deleted_contributor
+    assert item.has_deleted_contributor?
+  end
 end

--- a/test/unit/workflow_test.rb
+++ b/test/unit/workflow_test.rb
@@ -754,4 +754,32 @@ class WorkflowTest < ActiveSupport::TestCase
                    wf.bio_tools_links.pluck(:bio_tools_id).sort
     end
   end
+
+  test 'cannot delete workflow with doi' do
+    workflow = FactoryBot.create(:workflow)
+    v = workflow.latest_version
+    User.with_current_user(workflow.contributor.user) do
+      assert workflow.state_allows_delete?
+      assert workflow.can_delete?
+
+      assert v.update(doi: '10.81082/dev-workflowhub.workflow.136.1')
+
+      refute workflow.state_allows_delete?
+      refute workflow.can_delete?
+    end
+  end
+
+  test 'cannot delete git workflow with doi' do
+    workflow = FactoryBot.create(:local_git_workflow)
+    v = workflow.git_version
+    User.with_current_user(workflow.contributor.user) do
+      assert workflow.state_allows_delete?
+      assert workflow.can_delete?
+
+      assert v.update(doi: '10.81082/dev-workflowhub.workflow.136.1')
+
+      refute workflow.state_allows_delete?
+      refute workflow.can_delete?
+    end
+  end
 end


### PR DESCRIPTION
Some method renaming in versioning systems to prevent confusion.

- Methods prefixed with `standard_` always refer to `ExplicitVersioning` versions.
- Methods prefixed with `git_` always refer to git versions.
- Non-prefixed methods will switch between the 2 systems: https://github.com/seek4science/seek/blob/fix-versioning-ambiguity/lib/git/versioning_compatibility.rb
 
Fixes #1229 and #1470

Also fixes some types missing from `Person#contributed_items`.