### PR TITLE
Bump `resource_attributes` column length in `git_versions`

### DIFF
--- a/db/migrate/20230606102509_increase_git_version_resource_attributes_length.rb
+++ b/db/migrate/20230606102509_increase_git_version_resource_attributes_length.rb
@@ -1,0 +1,5 @@
+class IncreaseGitVersionResourceAttributesLength < ActiveRecord::Migration[6.1]
+  def change
+    change_column :git_versions, :resource_attributes, :text, limit: 16.megabytes - 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_16_123819) do
+ActiveRecord::Schema.define(version: 2023_06_06_102509) do
 
   create_table "activity_logs", id: :integer, force: :cascade do |t|
     t.string "action"
@@ -815,7 +815,7 @@ ActiveRecord::Schema.define(version: 2023_05_16_123819) do
     t.text "root_path"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "resource_attributes"
+    t.text "resource_attributes", size: :medium
     t.bigint "git_repository_id"
     t.integer "visibility"
     t.string "doi"


### PR DESCRIPTION
The default size (`65536`?) was overflowing for long workflow descriptions.