### PR TITLE
Git/RO-Crate download fixes

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -777,3 +777,7 @@ div#super_tag_cloud {
 .workflow-class-logo-sm {
   max-width: 36px;
 }
+
+.disabled[data-tooltip] {
+  pointer-events: inherit;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -381,9 +381,10 @@ class ApplicationController < ActionController::Base
         action = 'create' if action == 'create_metadata' || action == 'create_from_template'
         action = 'update' if action == 'create_version'
         action = 'inline_view' if action == 'explore'
+        action = 'download' if action == 'ro_crate'
         if %w(show create update destroy download inline_view).include?(action)
           check_log_exists(action, controller_name, object)
-            ActivityLog.create(action: action,
+          ActivityLog.create(action: action,
                              culprit: current_user,
                              referenced: object.projects.first,
                              controller_name: controller_name,

--- a/app/controllers/ga4gh/trs/v2/tool_versions_controller.rb
+++ b/app/controllers/ga4gh/trs/v2/tool_versions_controller.rb
@@ -4,6 +4,7 @@ module Ga4gh
       class ToolVersionsController < TrsBaseController
         before_action :get_tool
         before_action :get_version, only: [:show, :descriptor, :tests, :files, :containerfile]
+        before_action :check_downloadable, only: [:descriptor, :tests, :files, :containerfile]
         before_action :check_type, only: [:descriptor, :tests, :files]
         include ::RoCrateHandling
 
@@ -73,6 +74,11 @@ module Ga4gh
         end
 
         private
+
+        def check_downloadable
+          # TRS 2.0.1 spec currently only supports 200 and 404 responses.
+          trs_error(404, "You are not authorized to access this tool's content.") unless @tool.can_download?
+        end
 
         def get_version
           workflow_version = @tool.find_version(params[:version_id])

--- a/app/controllers/git_controller.rb
+++ b/app/controllers/git_controller.rb
@@ -187,7 +187,10 @@ class GitController < ApplicationController
   end
 
   def authorize_parent
-    render_git_error('Not authorized', status: 403, redirect: :root) unless @parent_resource.can_download?
+    unless @parent_resource.can_download?
+      target = @parent_resource.can_view? ? @parent_resource : :root
+      render_git_error('Not authorized', status: 403, redirect: target)
+    end
   end
 
   def authorized_to_edit

--- a/app/helpers/bootstrap_helper.rb
+++ b/app/helpers/bootstrap_helper.rb
@@ -212,7 +212,7 @@ module BootstrapHelper
       if block_given?
         content_tag(:a, **link_options, &block)
       else
-        content_tag(:a, title, **a_options, role: 'tab')
+        content_tag(:a, title, **link_options, role: 'tab')
       end
     end
   end

--- a/app/helpers/bootstrap_helper.rb
+++ b/app/helpers/bootstrap_helper.rb
@@ -181,7 +181,7 @@ module BootstrapHelper
     end
   end
 
-  def tab(*args, &block)
+  def tab(*args, disabled_reason: nil, &block)
     if block_given?
       tab_id, selected = *args
       title = nil
@@ -191,11 +191,28 @@ module BootstrapHelper
 
     selected = show_page_tab == tab_id if selected.nil?
 
-    content_tag(:li, class: selected ? 'active' : '') do
+    tab_options = {}
+    link_options = {
+      data: { target: "##{tab_id}",
+              toggle: 'tab' },
+      aria: { controls: tab_id },
+      role: 'tab'
+    }
+
+    if disabled_reason
+      tab_options[:class] = 'disabled'
+      tab_options['data-tooltip'] = disabled_reason
+      tab_options[:onclick] = "alert('#{disabled_reason}');";
+      link_options = {}
+    elsif selected
+      tab_options[:class] = 'active'
+    end
+
+    content_tag(:li, **tab_options) do
       if block_given?
-        content_tag(:a, data: { target: "##{tab_id}", toggle: 'tab' }, aria: { controls: tab_id }, role: 'tab', &block)
+        content_tag(:a, **link_options, &block)
       else
-        content_tag(:a, title, data: { target: "##{tab_id}", toggle: 'tab' }, aria: { controls: tab_id }, role: 'tab')
+        content_tag(:a, title, **a_options, role: 'tab')
       end
     end
   end

--- a/app/views/general/_show_page_tab_definitions.html.erb
+++ b/app/views/general/_show_page_tab_definitions.html.erb
@@ -8,7 +8,7 @@
   <% end %>
 
   <% if versioned_resource&.is_git_versioned? %>
-    <%= tab('files') do %>
+    <%= tab('files', disabled_reason: versioned_resource.can_download? ? nil : 'You are not authorized to access this content.') do %>
       <span class="glyphicon glyphicon-folder-close"></span> Files
     <% end %>
   <% end %>
@@ -19,7 +19,7 @@
 
 	<% if Seek::Config.project_single_page_advanced_enabled && displaying_single_page? && resource %>
 		<%= tab(resource_name&.downcase + "_design") do %>
-			<span class="glyphicon glyphicon-th-list"></span> <%=resource_name&.camelize%> design
+			<span class="glyphicon glyphicon-th-list"></span> <%= resource.model_name.human %> design
 		<% end %>
 	<% end %>
 </ul>

--- a/app/views/git/_files.html.erb
+++ b/app/views/git/_files.html.erb
@@ -23,8 +23,7 @@
 
 <strong>Total size: </strong> <%= number_to_human_size git_version.total_size -%><br/>
 <%= render partial: 'git/jstree', locals: { tree: git_version.tree, annotations: git_version.git_annotations,
-                                            opts: { id: 'git-browser-jstree',
-                                                    class: git_version.can_download? ? 'allow-blob-preview' : '' } } %>
+                                            opts: { id: 'git-browser-jstree', class: 'allow-blob-preview' } } %>
 <% if git_version.empty? %>
   <span class="none_text">Empty</span>
 <% end %>

--- a/app/views/workflows/show.html.erb
+++ b/app/views/workflows/show.html.erb
@@ -77,7 +77,7 @@
     </div>
   <% end %>
 
-  <% if @display_workflow.is_git_versioned? %>
+  <% if @display_workflow.is_git_versioned? && @display_workflow.can_download? %>
     <%= tab_pane('files') do %>
       <%= render partial: 'git/files', locals: { resource: @workflow, git_version: @display_workflow } %>
     <% end %>

--- a/test/functional/git_controller_test.rb
+++ b/test/functional/git_controller_test.rb
@@ -236,6 +236,7 @@ class GitControllerTest < ActionController::TestCase
     workflow = FactoryBot.create(:local_git_workflow, policy: FactoryBot.create(:publicly_viewable_policy))
     get :blob, params: { workflow_id: workflow.id, version: 1, path: 'diagram.png' }, format: :html
 
+    assert_redirected_to workflow
     assert flash[:error].include?('authorized')
   end
 
@@ -243,6 +244,7 @@ class GitControllerTest < ActionController::TestCase
     workflow = FactoryBot.create(:local_git_workflow, policy: FactoryBot.create(:publicly_viewable_policy))
     get :raw, params: { workflow_id: workflow.id, version: 1, path: 'diagram.png' }, format: :html
 
+    assert_redirected_to workflow
     assert flash[:error].include?('authorized')
   end
 
@@ -250,6 +252,7 @@ class GitControllerTest < ActionController::TestCase
     workflow = FactoryBot.create(:local_git_workflow, policy: FactoryBot.create(:publicly_viewable_policy))
     get :download, params: { workflow_id: workflow.id, version: 1, path: 'diagram.png' }, format: :html
 
+    assert_redirected_to workflow
     assert flash[:error].include?('authorized')
   end
 
@@ -333,6 +336,15 @@ class GitControllerTest < ActionController::TestCase
     workflow = FactoryBot.create(:local_git_workflow, policy: FactoryBot.create(:publicly_viewable_policy))
     get :tree, params: { workflow_id: workflow.id, version: 1 }
 
+    assert_redirected_to workflow
+    assert flash[:error].include?('authorized')
+  end
+
+  test 'redirects to root if no permission to view' do
+    workflow = FactoryBot.create(:local_git_workflow, policy: FactoryBot.create(:private_policy))
+    get :tree, params: { workflow_id: workflow.id, version: 1 }
+
+    assert_redirected_to root_path
     assert flash[:error].include?('authorized')
   end
 

--- a/test/functional/git_controller_test.rb
+++ b/test/functional/git_controller_test.rb
@@ -233,22 +233,22 @@ class GitControllerTest < ActionController::TestCase
   end
 
   test 'getting blob with no permissions throws error' do
-    logout
-    get :blob, params: { workflow_id: @workflow.id, version: @git_version.version, path: 'diagram.png' }, format: :html
+    workflow = FactoryBot.create(:local_git_workflow, policy: FactoryBot.create(:publicly_viewable_policy))
+    get :blob, params: { workflow_id: workflow.id, version: 1, path: 'diagram.png' }, format: :html
 
     assert flash[:error].include?('authorized')
   end
 
   test 'getting raw with no permissions throws error' do
-    logout
-    get :raw, params: { workflow_id: @workflow.id, version: @git_version.version, path: 'diagram.png' }, format: :html
+    workflow = FactoryBot.create(:local_git_workflow, policy: FactoryBot.create(:publicly_viewable_policy))
+    get :raw, params: { workflow_id: workflow.id, version: 1, path: 'diagram.png' }, format: :html
 
     assert flash[:error].include?('authorized')
   end
 
   test 'download with no permissions throws error' do
-    logout
-    get :download, params: { workflow_id: @workflow.id, version: @git_version.version, path: 'diagram.png' }, format: :html
+    workflow = FactoryBot.create(:local_git_workflow, policy: FactoryBot.create(:publicly_viewable_policy))
+    get :download, params: { workflow_id: workflow.id, version: 1, path: 'diagram.png' }, format: :html
 
     assert flash[:error].include?('authorized')
   end
@@ -330,8 +330,8 @@ class GitControllerTest < ActionController::TestCase
   end
 
   test 'cannot browse tree with no permissions' do
-    logout
-    get :tree, params: { workflow_id: @workflow.id, version: @git_version.version }
+    workflow = FactoryBot.create(:local_git_workflow, policy: FactoryBot.create(:publicly_viewable_policy))
+    get :tree, params: { workflow_id: workflow.id, version: 1 }
 
     assert flash[:error].include?('authorized')
   end

--- a/test/functional/workflows_controller_test.rb
+++ b/test/functional/workflows_controller_test.rb
@@ -1704,4 +1704,16 @@ class WorkflowsControllerTest < ActionController::TestCase
 
     assert_select 'li.disabled', text: 'Files', count: 0
   end
+
+  test 'RO-Crate downloads are logged' do
+    workflow = FactoryBot.create(:generated_galaxy_ro_crate_workflow, policy: FactoryBot.create(:public_policy))
+
+    assert_difference('workflow.download_count') do
+      get :ro_crate, params: { id: workflow.id }
+    end
+
+    assert_response :success
+    log = workflow.activity_logs.last
+    assert_equal 'download', log.action
+  end
 end

--- a/test/functional/workflows_controller_test.rb
+++ b/test/functional/workflows_controller_test.rb
@@ -1687,4 +1687,21 @@ class WorkflowsControllerTest < ActionController::TestCase
     get :index, params: { dump: true }, format: :jsonld
     assert_response :not_found
   end
+
+  test 'disables files tab if no download permission' do
+    workflow = FactoryBot.create(:local_git_workflow, policy: FactoryBot.create(:publicly_viewable_policy))
+    refute workflow.can_download?
+
+    get :show, params: { id: workflow.id }
+
+    assert_select 'li.disabled', text: 'Files'
+
+    login_as(workflow.contributor)
+
+    assert workflow.can_download?
+
+    get :show, params: { id: workflow.id }
+
+    assert_select 'li.disabled', text: 'Files', count: 0
+  end
 end


### PR DESCRIPTION
- Tweaks/tests behaviour when workflows are visible but not downloadable.
- Ensures Git/RO-Crate downloads are logged properly.


Disables the "Files" tab now:
![image](https://github.com/seek4science/seek/assets/503373/6d3b3dbf-7e73-494a-8091-f71caee9e984)