### PR TITLE
Removed temporary Gem dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -153,11 +153,6 @@ gem 'remotipart', '~> 1.4.4' # Allows file upload in AJAX forms
 
 gem 'rails-static-router'
 
-# to avoid warnings after rails 6.1.7.2 update - see https://github.com/ruby/net-imap/issues/16
-gem "net-http"
-gem "net-ftp"
-gem "uri", "0.10.0.2"
-
 group :production do
   gem 'passenger'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -153,6 +153,8 @@ gem 'remotipart', '~> 1.4.4' # Allows file upload in AJAX forms
 
 gem 'rails-static-router'
 
+gem 'net-ftp'
+
 group :production do
   gem 'passenger'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -445,7 +445,6 @@ GEM
       nokogiri (~> 1)
       rake
     mini_mime (1.1.2)
-    mini_portile2 (2.8.2)
     minitest (5.18.0)
     minitest-reporters (1.5.0)
       ansi
@@ -459,6 +458,9 @@ GEM
     mysql2 (0.5.3)
     namae (1.1.1)
     nesty (1.0.2)
+    net-ftp (0.2.0)
+      net-protocol
+      time
     net-http-digest_auth (1.4.1)
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
@@ -474,8 +476,7 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.5.9)
-    nokogiri (1.14.5)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.14.5-x86_64-linux)
       racc (~> 1.4)
     nori (1.1.5)
     oauth2 (2.0.9)
@@ -855,6 +856,8 @@ GEM
     test-prof (1.0.7)
     thor (1.2.2)
     tilt (2.0.10)
+    time (0.2.2)
+      date
     timeout (0.3.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -921,7 +924,7 @@ GEM
       rubyzip (~> 2.0.0)
 
 PLATFORMS
-  ruby
+  x86_64-linux
 
 DEPENDENCIES
   RedCloth (>= 4.3.0)
@@ -989,6 +992,7 @@ DEPENDENCIES
   minitest-reporters
   my_responds_to_parent!
   mysql2
+  net-ftp
   nokogiri (~> 1.14.3)
   omniauth (~> 2.1.0)
   omniauth-github

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -445,6 +445,7 @@ GEM
       nokogiri (~> 1)
       rake
     mini_mime (1.1.2)
+    mini_portile2 (2.8.2)
     minitest (5.18.0)
     minitest-reporters (1.5.0)
       ansi
@@ -476,7 +477,8 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.5.9)
-    nokogiri (1.14.5-x86_64-linux)
+    nokogiri (1.14.5)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     nori (1.1.5)
     oauth2 (2.0.9)
@@ -924,7 +926,7 @@ GEM
       rubyzip (~> 2.0.0)
 
 PLATFORMS
-  x86_64-linux
+  ruby
 
 DEPENDENCIES
   RedCloth (>= 4.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -459,11 +459,6 @@ GEM
     mysql2 (0.5.3)
     namae (1.1.1)
     nesty (1.0.2)
-    net-ftp (0.2.0)
-      net-protocol
-      time
-    net-http (0.3.2)
-      uri
     net-http-digest_auth (1.4.1)
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
@@ -860,8 +855,6 @@ GEM
     test-prof (1.0.7)
     thor (1.2.2)
     tilt (2.0.10)
-    time (0.2.2)
-      date
     timeout (0.3.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -879,7 +872,6 @@ GEM
     unicorn-rails (2.2.1)
       rack
       unicorn
-    uri (0.10.0.2)
     uuid (2.3.9)
       macaddr (~> 1.0)
     validate_email (0.1.6)
@@ -997,8 +989,6 @@ DEPENDENCIES
   minitest-reporters
   my_responds_to_parent!
   mysql2
-  net-ftp
-  net-http
   nokogiri (~> 1.14.3)
   omniauth (~> 2.1.0)
   omniauth-github
@@ -1063,7 +1053,6 @@ DEPENDENCIES
   terser (~> 1.1, >= 1.1.1)
   test-prof
   unicorn-rails
-  uri (= 0.10.0.2)
   uuid (~> 2.3)
   validate_url
   vcr (~> 2.9)


### PR DESCRIPTION
removed net-http and the fixed version of uri, which were necessary to work around default gem clashes for ruby 2.7, but no longer needed for ruby 3.1 - relates to #1432 