### PR TITLE
Avoid constantize

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -195,7 +195,7 @@ class ApplicationController < ActionController::Base
   # handles finding an asset, and responding when it cannot be found. If it can be found the item instance is set (e.g. @project for projects_controller)
   def find_requested_item
     name = controller_name.singularize
-    object = name.camelize.constantize.find_by_id(params[:id])
+    object = controller_model.find_by_id(params[:id])
     if object.nil?
       respond_to do |format|
         flash[:error] = "The #{name.humanize} does not exist!"
@@ -573,7 +573,7 @@ class ApplicationController < ActionController::Base
     parent_id_param = request.path_parameters.keys.detect { |k| k.to_s.end_with?('_id') }
     if parent_id_param
       parent_type = parent_id_param.to_s.chomp('_id')
-      parent_class = parent_type.camelize.constantize
+      parent_class = safe_class_lookup(parent_type.camelize)
       if parent_class
         @parent_resource = parent_class.find(params[parent_id_param])
       end
@@ -670,5 +670,9 @@ class ApplicationController < ActionController::Base
     ]
   end
 
+  def safe_class_lookup(class_name, raise: true)
+    Seek::Util.lookup_class(class_name, raise: raise)
+  end
 
+  helper_method :safe_class_lookup
 end

--- a/app/controllers/content_blobs_controller.rb
+++ b/app/controllers/content_blobs_controller.rb
@@ -160,7 +160,7 @@ class ContentBlobsController < ApplicationController
     params.each do |param, value|
       if param.end_with?('_id')
         begin
-          c = param.chomp('_id').classify.constantize
+          c = safe_class_lookup(param.chomp('_id').classify)
         rescue NameError
         else
           if c.method_defined?(:content_blob) || c.method_defined?(:content_blobs)

--- a/app/controllers/custom_metadata_types_controller.rb
+++ b/app/controllers/custom_metadata_types_controller.rb
@@ -11,7 +11,7 @@ class CustomMetadataTypesController < ApplicationController
         format.html { render html: '' }
       else
         cm = CustomMetadataType.find(id)
-        resource = cm.supported_type.constantize.new
+        resource = safe_class_lookup(cm.supported_type).new
         resource.custom_metadata = CustomMetadata.new(custom_metadata_type: cm)
         format.html do
           render partial: 'custom_metadata/custom_metadata_fields',

--- a/app/controllers/favourites_controller.rb
+++ b/app/controllers/favourites_controller.rb
@@ -12,7 +12,7 @@ class FavouritesController < ApplicationController
 
       resource = saved_search if saved_search.save
     else
-      resource = params[:resource_type].constantize.find_by_id(params[:resource_id])
+      resource = safe_class_lookup(params[:resource_type]).find_by_id(params[:resource_id])
     end
 
     favourite = Favourite.new(user: current_user, resource: resource)

--- a/app/controllers/folders_controller.rb
+++ b/app/controllers/folders_controller.rb
@@ -150,7 +150,7 @@ class FoldersController < ApplicationController
   end
 
   def get_asset
-    @asset = params[:asset_type].constantize.find(params[:asset_id])
+    @asset = safe_class_lookup(params[:asset_type]).find(params[:asset_id])
     unless @asset.can_view?
       error("You cannot view the asset", "is invalid or not authorized")
     end

--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -1,30 +1,30 @@
 class PoliciesController < ApplicationController
   before_action :login_required
-  
+
   def send_policy_data
     request_type = sanitized_text(params[:policy_type])
     entity_type = sanitized_text(params[:entity_type])
     entity_id = sanitized_text(params[:entity_id])
-    
+
     # NB! default policies now are only suppoted by Projects (but not Institutions / WorkGroups) -
     # so supplying any other type apart from Project will cause the return error message
-    if request_type.downcase == "default" && entity_type == "Project" 
+    if request_type.downcase == "default" && entity_type == "Project"
       supported = true
-      
+
       # check that current user (the one sending AJAX request to get data from this handler)
       # is a member of the project for which they try to get the default policy
       authorized = current_person.projects.include? Project.find(entity_id)
     else
       supported = false
     end
-    
+
     # only fetch all the policy/permissions settings if authorized to do so & only for request types that are supported
     if supported && authorized
       begin
-        entity = entity_type.constantize.find entity_id
+        entity = safe_class_lookup(entity_type).find entity_id
         found_entity = true
         policy = nil
-        
+
         if entity.default_policy
           # associated default policy exists
           found_exact_match = true
@@ -34,19 +34,19 @@ class PoliciesController < ApplicationController
           found_exact_match = false
           policy = Policy.default()
         end
-        
+
       rescue ActiveRecord::RecordNotFound
         found_entity = false
       end
     end
-    
+
     respond_to do |format|
       format.json {
         if supported && authorized && found_entity
           policy_settings = policy.get_settings
           permission_settings = policy.get_permission_settings
-          
-          render :json => {:status => 200, :found_exact_match => found_exact_match, :policy => policy_settings, 
+
+          render :json => {:status => 200, :found_exact_match => found_exact_match, :policy => policy_settings,
                            :permission_count => permission_settings.length, :permissions => permission_settings }
         elsif supported && authorized && !found_entity
           render :json => {:status => 404, :error => "Couldn't find #{entity_type} with ID #{entity_id}."}
@@ -60,7 +60,7 @@ class PoliciesController < ApplicationController
   end
 
   def preview_permissions
-    resource_class = params[:resource_name].camelize.constantize
+    resource_class = safe_class_lookup(params[:resource_name].camelize)
     resource = nil
     resource = resource_class.find_by_id(params[:resource_id]) if params[:resource_id]
     resource ||= resource_class.new

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -597,7 +597,7 @@ class PublicationsController < ApplicationController
 
   def create_or_update_associations(asset_ids, asset_type, required_action)
     asset_ids.each do |id|
-      asset = asset_type.constantize.find_by_id(id)
+      asset = safe_class_lookup(asset_type).find_by_id(id)
       if asset && asset.send("can_#{required_action}?")
         @publication.associate(asset)
       end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -71,7 +71,7 @@ class SearchController < ApplicationController
         raise InvalidSearchException, "#{type} is not a valid search type"
       end
 
-      sources = [type_name.constantize]
+      sources = [safe_class_lookup(type_name)]
     end
     sources
   end

--- a/app/controllers/snapshots_controller.rb
+++ b/app/controllers/snapshots_controller.rb
@@ -88,7 +88,7 @@ class SnapshotsController < ApplicationController
 
   def find_resource # This is hacky :(
     resource, id = request.path.split('/')[1, 2]
-    @resource = resource.singularize.classify.constantize.find(id)
+    @resource = safe_class_lookup(resource.singularize.classify).find(id)
   end
 
   def auth_resource

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -418,24 +418,6 @@ module ApplicationHelper
     no_deletion_explanation_message(model_item.class).html_safe
   end
 
-  # returns a new instance of the string describing a resource type, or nil if it is not applicable
-  def instance_of_resource_type(resource_type)
-    resource = nil
-    begin
-      resource_class = resource_type.classify.constantize unless resource_type.nil?
-      resource = resource_class.send(:new) if !resource_class.nil? && resource_class.respond_to?(:new)
-    rescue NameError => e
-      logger.error("Unable to find constant for resource type #{resource_type}")
-    end
-    resource
-  end
-
-  # returns the class associated with the controller, e.g. DataFile for data_files
-  #
-  def klass_from_controller(c = controller_name)
-    c.singularize.camelize.constantize
-  end
-
   def cancel_button(path, html_options = {})
     html_options[:class] ||= ''
     html_options[:class] << ' btn btn-default'
@@ -472,7 +454,7 @@ module ApplicationHelper
   end
 
   def pending_project_creation_request?
-    return false unless logged_in_and_registered?   
+    return false unless logged_in_and_registered?
     ProjectCreationMessageLog.pending_requests.collect do |log|
       log.can_respond_project_creation_request?(User.current_user)
     end.any?

--- a/app/helpers/sharing_permissions_helper.rb
+++ b/app/helpers/sharing_permissions_helper.rb
@@ -109,14 +109,12 @@ module SharingPermissionsHelper
     parent_node
   end
 
-
-  def add_asset_permission_nodes (parent_node)
-
+  def add_asset_permission_nodes(parent_node)
     asset_type = parent_node["id"].split("-")[0]
     asset_id = parent_node["id"].split("-")[1].to_i
 
     # get asset instance
-    asset =  asset_type.camelize.constantize.find(asset_id)
+    asset = safe_class_lookup(asset_type.camelize).find(asset_id)
     parent_node["text"] = "#{h(asset.title)}  #{icon_link_to("", "new_window", asset , options = {target:'blank',class:'asset-icon',:onclick => 'window.open(this.href, "_blank");'})}"
 
     permissions_array = get_permission(asset)

--- a/app/models/custom_metadata_type.rb
+++ b/app/models/custom_metadata_type.rb
@@ -23,15 +23,7 @@ class CustomMetadataType < ApplicationRecord
 
   def supported_type_must_be_valid_type
     return if supported_type.blank? # already convered by presence validation
-    valid = true
-    begin
-      clz = supported_type.constantize
-      # TODO: in the future to check it is a supported active record type
-      valid = clz.ancestors.include?(ActiveRecord::Base)
-    rescue NameError
-      valid = false
-    end
-    unless valid
+    unless Seek::Util.lookup_class(supported_type, raise: false)
       errors.add(:supported_type, 'is not a type that can supported custom metadata')
     end
   end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -77,7 +77,8 @@ class Sample < ApplicationRecord
     sample_type.sample_attributes.select(&:seek_resource?).map do |sa|
       value = get_attribute_value(sa)
       type = sa.sample_attribute_type.base_type_handler.type
-      Array.wrap(value).map { |v| type.constantize.find_by_id(v['id']) if v && type }
+      return [] unless type
+      Array.wrap(value).map { |v| type.find_by_id(v['id']) if v }
     end.flatten.compact
   end
 

--- a/app/views/admin/stats/_snapshot_and_doi_stats.html.erb
+++ b/app/views/admin/stats/_snapshot_and_doi_stats.html.erb
@@ -22,7 +22,7 @@
             <td><%= snapshots.count %></td>
             <td>
               <%= resources.count %>
-              (<%= ((resources.count / type_name.constantize.count.to_f) * 100).round(4) %>%)
+              (<%= ((resources.count / safe_class_lookup(type_name).count.to_f) * 100).round(4) %>%)
             </td>
           </tr>
       <% end %>

--- a/app/views/assets/_resource_counts.html.erb
+++ b/app/views/assets/_resource_counts.html.erb
@@ -5,7 +5,7 @@
   <% if @active_filters&.any? -%>
     <%= resource_text %> matching the given criteria:
     <%= link_to("(Clear all filters)", page_and_sort_params.merge(filter: nil)) %>
-  <% elsif @total_count && klass_from_controller.authorization_supported? %>
+  <% elsif @total_count && controller_model.authorization_supported? %>
     <%= resource_text %> visible to you, out of a total of <strong><%= @total_count %></strong>
   <% else %>
     <%= resource_text %> found

--- a/app/views/assets/_resource_listing_tabbed_by_class.html.erb
+++ b/app/views/assets/_resource_listing_tabbed_by_class.html.erb
@@ -30,7 +30,7 @@
                     Showing <%= type[:items_count] %> out of a possible <%= pluralize(resource_type_total_visible_count(type),'item') %>
                   <% end %>
 
-                  <% if !type[:is_external] && type[:type].constantize.available_filters.any? %>
+                  <% if !type[:is_external] && safe_class_lookup(type[:type]).available_filters.any? %>
                     <% if query  %>
 
                       <%= link_to "Advanced #{type[:visible_resource_type]} search with filtering ...",

--- a/app/views/assets/_select_tags.html.erb
+++ b/app/views/assets/_select_tags.html.erb
@@ -1,11 +1,10 @@
 <%
    entity=controller_name.singularize
    object=instance_variable_get("@#{entity}")
-   model_class=entity.camelize.constantize
    #FIXME: this is required for some cases where the page is rendered from an error, but the @entity doesn't exist. Mainly when rendering from a caught Exception AssetsCommon.handle_data
    #the correct fix is to fix AssetsCommon.handle_data to correctly create an instance of @entity
 
-   object ||= model_class.new
+   object ||= controller_model.new
    type_name = text_for_resource(object)
 
    owned_annotations = current_user.annotations_by.collect{|a| a.value}

--- a/app/views/assets/publishing/published.html.erb
+++ b/app/views/assets/publishing/published.html.erb
@@ -5,19 +5,19 @@
   if params[:published_items]
     published_items |= params[:published_items].collect do |param|
       item_class,item_id = param.split(',')
-      item_class.constantize.find_by_id(item_id)
+      safe_class_lookup(item_class).find_by_id(item_id)
     end.compact.select(&:can_view?)
   end
   if params[:waiting_for_publish_items]
     waiting_for_publish_items |= params[:waiting_for_publish_items].collect do |param|
       item_class,item_id = param.split(',')
-      item_class.constantize.find_by_id(item_id)
+      safe_class_lookup(item_class).find_by_id(item_id)
     end.compact.select(&:can_view?)
   end
   if params[:notified_items]
     notified_items |= params[:notified_items].collect do |param|
       item_class,item_id = param.split(',')
-      item_class.constantize.find_by_id(item_id)
+      safe_class_lookup(item_class).find_by_id(item_id)
     end.compact.select(&:can_view?)
   end
 

--- a/app/views/permissions/_preview_permissions.html.erb
+++ b/app/views/permissions/_preview_permissions.html.erb
@@ -1,7 +1,7 @@
 <%
   resource_name = resource.class.name.underscore
   permissions, privileged_people = uniq_people_permissions_and_privileged_people(policy.permissions.to_a, privileged_people)
-  downloadable = resource_name.camelize.constantize.new.try(:is_downloadable?)
+  downloadable = resource.is_downloadable?
   effective_permissions = permissions.reject { |p| p.access_type <= policy.access_type }
   sorted_permissions = effective_permissions.sort_by { |p| Permission::PRECEDENCE.index(p.contributor_type) }
   grouped_contributors = group_by_access_type(sorted_permissions, privileged_people, downloadable)
@@ -42,7 +42,7 @@
             <% [Policy::MANAGING, Policy::EDITING, downloadable ? Policy::ACCESSIBLE : nil, Policy::VISIBLE].compact.each do |access_type| %>
                 <% if grouped_contributors[access_type].try(:any?) %>
                     <div class="access-type-<%= PolicyHelper::access_type_key(access_type)-%>">
-                      <p>The following can <strong><%= Policy.get_access_type_wording(access_type, resource_name.camelize.constantize.new.try(:is_downloadable?)).downcase -%></strong></p>
+                      <p>The following can <strong><%= Policy.get_access_type_wording(access_type, downloadable).downcase -%></strong></p>
                       <ul>
                         <% grouped_contributors[access_type].each do |contributor| %>
                             <li><%= permission_title(contributor, member_prefix: true, icon: true) %></li>

--- a/lib/seek/publishing/gatekeeper_publish.rb
+++ b/lib/seek/publishing/gatekeeper_publish.rb
@@ -94,7 +94,7 @@ module Seek
         return if param.nil?
 
         param.keys.each do |asset_class|
-          klass = asset_class.constantize
+          klass = safe_class_lookup(asset_class)
           param[asset_class].keys.each do |id|
             asset = klass.find_by_id(id)
             decision = param[asset_class][id]['decision']

--- a/lib/seek/publishing/publishing_common.rb
+++ b/lib/seek/publishing/publishing_common.rb
@@ -94,7 +94,7 @@ module Seek
       end
 
       def cancel_publishing_request
-        asset = params[:asset_class].classify.constantize.find(params[:asset_id])
+        asset = safe_class_lookup(params[:asset_class].classify).find(params[:asset_id])
         if asset.can_manage?
           if asset.last_publishing_log.publish_state.in?([ResourcePublishLog::WAITING_FOR_APPROVAL, ResourcePublishLog::REJECTED])
             ResourcePublishLog.add_log(ResourcePublishLog::UNPUBLISHED, asset)
@@ -241,7 +241,7 @@ module Seek
         else
           assets = []
           param.keys.each do |asset_class|
-            klass = asset_class.constantize
+            klass = safe_class_lookup(asset_class)
             param[asset_class].keys.each do |id|
               assets << klass.find_by_id(id)
             end

--- a/lib/seek/samples/attribute_type_handlers/seek_data_file_attribute_type_handler.rb
+++ b/lib/seek/samples/attribute_type_handlers/seek_data_file_attribute_type_handler.rb
@@ -3,7 +3,7 @@ module Seek
     module AttributeTypeHandlers
       class SeekDataFileAttributeTypeHandler < SeekResourceAttributeTypeHandler
         def type
-          'DataFile'
+          DataFile
         end
       end
     end

--- a/lib/seek/samples/attribute_type_handlers/seek_resource_attribute_type_handler.rb
+++ b/lib/seek/samples/attribute_type_handlers/seek_resource_attribute_type_handler.rb
@@ -3,7 +3,7 @@ module Seek
     module AttributeTypeHandlers
       class SeekResourceAttributeTypeHandler < BaseAttributeHandler
         def test_value(value)
-          raise "Not a valid SEEK #{type.humanize} ID" unless value[:id].to_i.positive?
+          raise "Not a valid SEEK #{type.name.humanize} ID" unless value[:id].to_i.positive?
         end
 
         def type
@@ -16,7 +16,7 @@ module Seek
 
         def convert(value)
           resource = find_resource(value)
-          hash = { id: resource ? resource.id : value, type: type }.with_indifferent_access
+          hash = { id: resource ? resource.id : value, type: type.name }.with_indifferent_access
           hash[:title] = resource.title if resource
           hash
         end
@@ -24,7 +24,7 @@ module Seek
         private
 
         def find_resource(value)
-          type.constantize.find_by_id(value)
+          type.find_by_id(value)
         end
       end
     end

--- a/lib/seek/samples/attribute_type_handlers/seek_sample_attribute_type_handler.rb
+++ b/lib/seek/samples/attribute_type_handlers/seek_sample_attribute_type_handler.rb
@@ -5,7 +5,7 @@ module Seek
         class MissingLinkedSampleTypeException < AttributeHandlerException; end
 
         def type
-          'Sample'
+          Sample
         end
 
         def test_value(value)

--- a/lib/seek/samples/attribute_type_handlers/seek_sample_multi_attribute_type_handler.rb
+++ b/lib/seek/samples/attribute_type_handlers/seek_sample_multi_attribute_type_handler.rb
@@ -5,7 +5,7 @@ module Seek
         class MissingLinkedSampleTypeException < AttributeHandlerException; end
 
         def type
-          'Sample'
+          Sample
         end
 
         def test_value(value)

--- a/lib/seek/samples/attribute_type_handlers/seek_strain_attribute_type_handler.rb
+++ b/lib/seek/samples/attribute_type_handlers/seek_strain_attribute_type_handler.rb
@@ -3,7 +3,7 @@ module Seek
     module AttributeTypeHandlers
       class SeekStrainAttributeTypeHandler < SeekResourceAttributeTypeHandler
         def type
-          'Strain'
+          Strain
         end
       end
     end

--- a/lib/seek/util.rb
+++ b/lib/seek/util.rb
@@ -149,6 +149,12 @@ module Seek
       "python3.9 #{cmd}"
     end
 
+    def self.lookup_class(class_name, raise: true)
+      c = Seek::Util.persistent_classes.detect { |klass| klass.name == class_name }
+      raise NameError "#{class_name} not an appropriate class" if c.nil? && raise
+      c
+    end
+
     private
 
     def self.cache(name, &block)

--- a/lib/seek/util.rb
+++ b/lib/seek/util.rb
@@ -14,7 +14,7 @@ module Seek
     end
 
     def self.clear_cached
-      @@cache = {}
+      @cache = {}
     end
 
     def self.ensure_models_loaded
@@ -150,19 +150,29 @@ module Seek
     end
 
     def self.lookup_class(class_name, raise: true)
-      c = Seek::Util.persistent_classes.detect { |klass| klass.name == class_name }
+      c = persistent_class_lookup[class_name]
       raise NameError "#{class_name} not an appropriate class" if c.nil? && raise
       c
     end
 
     private
 
+    def self.persistent_class_lookup
+      cache('persistent_class_lookup') do
+        lookup = {}
+        persistent_classes.each do |klass|
+          lookup[klass.name] = klass
+        end
+        lookup
+      end
+    end
+
     def self.cache(name, &block)
-      @@cache ||= {}
+      @cache ||= {}
       if Rails.env.development? # Don't use caching in development mode
         block.call
       else
-        @@cache[name] ||= block.call
+        @cache[name] ||= block.call
       end
     end
 

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -82,20 +82,6 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_equal 'a: b: c and d', join_with_and(%w[a b c d], ': ')
   end
 
-  test 'instance of resource_type' do
-    m = instance_of_resource_type('model')
-    assert m.is_a?(Model)
-    assert m.new_record?
-
-    p = instance_of_resource_type('Presentation')
-    assert p.is_a?(Presentation)
-    assert p.new_record?
-
-    assert_nil instance_of_resource_type(nil)
-    assert_nil instance_of_resource_type('mushypeas')
-    assert_nil instance_of_resource_type({})
-  end
-
   test 'force to treat 1 Jan as year only' do
     date = Date.new(2012, 1, 1)
     text = date_as_string(date, false, true)

--- a/test/unit/util_test.rb
+++ b/test/unit/util_test.rb
@@ -93,26 +93,31 @@ class UtilTest < ActiveSupport::TestCase
               assert Seek::Util.asset_types.include?(Workflow)
               assert Seek::Util.user_creatable_types.include?(Workflow)
               assert Seek::Util.searchable_types.include?(Workflow)
+              assert Seek::Util.lookup_class('Workflow', raise: false)
 
               assert Seek::Util.persistent_classes.include?(Event)
               assert Seek::Util.authorized_types.include?(Event)
               assert Seek::Util.user_creatable_types.include?(Event)
               assert Seek::Util.searchable_types.include?(Event)
+              assert Seek::Util.lookup_class('Event', raise: false)
 
               assert Seek::Util.persistent_classes.include?(Sample)
               assert Seek::Util.authorized_types.include?(Sample)
               assert Seek::Util.asset_types.include?(Sample)
               assert Seek::Util.user_creatable_types.include?(Sample)
               assert Seek::Util.searchable_types.include?(Sample)
+              assert Seek::Util.lookup_class('Sample', raise: false)
 
               assert Seek::Util.persistent_classes.include?(Programme)
               assert Seek::Util.searchable_types.include?(Programme)
+              assert Seek::Util.lookup_class('Programme', raise: false)
 
               assert Seek::Util.persistent_classes.include?(Publication)
               assert Seek::Util.authorized_types.include?(Publication)
               assert Seek::Util.asset_types.include?(Publication)
               assert Seek::Util.user_creatable_types.include?(Publication)
               assert Seek::Util.searchable_types.include?(Publication)
+              assert Seek::Util.lookup_class('Publication', raise: false)
 
               with_config_value :workflows_enabled, false do
                 Seek::Util.clear_cached
@@ -121,6 +126,7 @@ class UtilTest < ActiveSupport::TestCase
                 refute Seek::Util.asset_types.include?(Workflow)
                 refute Seek::Util.user_creatable_types.include?(Workflow)
                 refute Seek::Util.searchable_types.include?(Workflow)
+                assert_nil Seek::Util.lookup_class('Workflow', raise: false)
               end
 
               with_config_value :events_enabled, false do
@@ -129,6 +135,7 @@ class UtilTest < ActiveSupport::TestCase
                 refute Seek::Util.authorized_types.include?(Event)
                 refute Seek::Util.user_creatable_types.include?(Event)
                 refute Seek::Util.searchable_types.include?(Event)
+                assert_nil Seek::Util.lookup_class('Event', raise: false)
               end
 
               with_config_value :samples_enabled, false do
@@ -138,12 +145,14 @@ class UtilTest < ActiveSupport::TestCase
                 refute Seek::Util.asset_types.include?(Sample)
                 refute Seek::Util.user_creatable_types.include?(Sample)
                 refute Seek::Util.searchable_types.include?(Sample)
+                assert_nil Seek::Util.lookup_class('Sample', raise: false)
               end
 
               with_config_value :programmes_enabled, false do
                 Seek::Util.clear_cached
                 refute Seek::Util.persistent_classes.include?(Programme)
                 refute Seek::Util.searchable_types.include?(Programme)
+                assert_nil Seek::Util.lookup_class('Programme', raise: false)
               end
 
               with_config_value :publications_enabled, false do
@@ -153,6 +162,7 @@ class UtilTest < ActiveSupport::TestCase
                 refute Seek::Util.asset_types.include?(Publication)
                 refute Seek::Util.user_creatable_types.include?(Publication)
                 refute Seek::Util.searchable_types.include?(Publication)
+                assert_nil Seek::Util.lookup_class('Publication', raise: false)
               end
 
             end
@@ -160,8 +170,16 @@ class UtilTest < ActiveSupport::TestCase
         end
       end
     end
+  end
 
-
-
+  test 'lookup_class' do
+    assert Seek::Util.lookup_class('Publication', raise: false)
+    assert Seek::Util.lookup_class('Workflow', raise: false)
+    assert_nil Seek::Util.lookup_class('String', raise: false)
+    assert_nil Seek::Util.lookup_class('WorkflowInternals::Structure', raise: false)
+    assert_nil Seek::Util.lookup_class('gdfghdfhdfhdfhdfhdfh', raise: false)
+    assert_raises NameError do
+      Seek::Util.lookup_class('String')
+    end
   end
 end


### PR DESCRIPTION
Provides a safer way of retrieving the class of a SEEK resource.

Fixes CodeQL warnings.