### PR TITLE
Fix random test failure under postgres

### DIFF
--- a/lib/isa_exporter.rb
+++ b/lib/isa_exporter.rb
@@ -508,7 +508,7 @@ module IsaExporter
       sample_array = []
       while sample_list.any?
         temp = []
-        sample_list.each { |sample| temp += sample.linked_samples if sample.linked_samples.any? }
+        sample_list.each { |sample| temp += sample.linked_samples.order(:id) if sample.linked_samples.any? }
         sample_array << temp.map { |s| s.id }.uniq if !temp.blank?
         sample_list = temp
       end


### PR DESCRIPTION
e.g. https://github.com/seek4science/seek/actions/runs/5553390411/jobs/10141877763

```
 Failure:
IsaExporterTest#test_find_sample_origin [/home/runner/work/seek/seek/test/unit/isa_exporter_test.rb:66]
Minitest::Assertion: Expected: [162, 166]
  Actual: [166, 162]
```