### PR TITLE
Improve index views on mobile

### DIFF
--- a/app/assets/javascripts/application_shared.js.erb
+++ b/app/assets/javascripts/application_shared.js.erb
@@ -352,6 +352,35 @@ $j(document).ready(function () {
             div.after(btn);
         }
     });
+
+    // Popout filter sidebar on small screens
+    var Sidebar = {
+        close: function () {
+            $j('.sidebar-backdrop').remove();
+            $j('#sidebar').removeClass('open');
+            $j('#sidebar-toggle').button('reset');
+        },
+        open: function () {
+            $j('body').append($j('<div class="sidebar-backdrop modal-backdrop fade in"></div>'));
+            $j('#sidebar').addClass('open');
+        },
+        toggle: function () {
+            var toggleButton = $j('#sidebar-toggle');
+            toggleButton.button('toggle');
+
+            if(toggleButton.hasClass('active')) {
+                Sidebar.open();
+            } else {
+                Sidebar.close();
+            }
+
+            return false;
+        }
+    };
+
+    $j('#sidebar-toggle').click(Sidebar.toggle);
+    $j('#sidebar-close').click(Sidebar.toggle);
+    $j(document).on('click', '.sidebar-backdrop', Sidebar.toggle);
 });
 
 var URL_ROOT = '<%= Rails.application.config.relative_url_root %>';

--- a/app/assets/stylesheets/indexes.scss
+++ b/app/assets/stylesheets/indexes.scss
@@ -68,11 +68,11 @@ div.list_item_avatar img {
   .rli-head {
     display: flex;
     align-items: center;
+    gap: 1em;
   }
 
   .list_item_title {
-    flex-grow: 1;
-    flex-shrink: 0;
+    flex: 1 1 66%;
 
     img {
       max-height: 34px;
@@ -100,12 +100,8 @@ div.list_item_avatar img {
   }
 
   .rli-project-list {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    flex-shrink: 1;
-    flex-grow: 0;
-    margin-left: 3em;
+    flex: 1 1 33%;
+    text-align: right;
   }
 }
 
@@ -128,6 +124,64 @@ div.index-filters {
   width: 240px;
   margin-right: 20px;
   flex-shrink: 0;
+
+  .index-filters-heading {
+    display: none;
+  }
+
+  @media (max-width: $screen-xs-max) {
+    padding: 15px;
+    width: calc(100% - 20px);
+    position: absolute;
+    background: white;
+    top: 10px;
+    left: 10px;
+    display: none;
+    z-index: $zindex-modal;
+    border-radius: $border-radius-base;
+
+    &.open {
+      display: block;
+    }
+
+    .index-filters-heading {
+      display: block;
+    }
+  }
+}
+
+@media (max-width: $screen-xs-max) {
+  div.index-filters {
+    padding: 15px;
+    width: calc(100% - 20px);
+    position: absolute;
+    background: white;
+    top: 10px;
+    left: 10px;
+    display: none;
+    z-index: $zindex-modal;
+    border-radius: $border-radius-base;
+
+    &.open {
+      display: block;
+    }
+
+    .index-filters-heading {
+      display: block;
+    }
+  }
+
+  .sidebar-backdrop {
+    display: block !important;
+  }
+
+  #sidebar-toggle {
+    display: inline-block !important;
+  }
+}
+
+.sidebar-backdrop, #sidebar-toggle {
+  display: none;
 }
 
 .filter-category {

--- a/app/views/assets/_resource_filtering.html.erb
+++ b/app/views/assets/_resource_filtering.html.erb
@@ -1,5 +1,9 @@
 <% if @available_filters&.any? %>
-  <div class="index-filters">
+  <div class="index-filters" id="sidebar">
+    <h3 class="index-filters-heading">
+      Filters
+      <button href="#" class="btn pull-right close" id="sidebar-close">&times</button>
+    </h3>
     <% @available_filters.each do |key, options| %>
       <% filter = Seek::Filterer.new(controller_model).get_filter(key) %>
       <% begin %>

--- a/app/views/assets/_resource_list_item.html.erb
+++ b/app/views/assets/_resource_list_item.html.erb
@@ -24,7 +24,7 @@
   <div class="panel-heading rli-head">
     <%= list_item_title resource, title_options %>
     <% if resource.respond_to?(:projects) && ![Event, Person, Project, Institution, Programme, Collection].include?(resource.class) %>
-        <div class="rli-project-list">
+        <div class="rli-project-list hidden-xs">
           <%= resource.projects.uniq.map {|p| link_to p.title, p }.join(', ').html_safe %>
         </div>
     <% end %>

--- a/app/views/assets/_resource_sorting.html.erb
+++ b/app/views/assets/_resource_sorting.html.erb
@@ -2,8 +2,11 @@
 <% options = [[Seek::ListSorter::ORDER_OPTIONS[:relevance][:title], :relevance], *options] if @active_filters[:query]&.present? %>
 <% url_template = url_for(page_and_sort_params.merge(page: nil, order: '_order_')) %>
 
-<form class="form-inline pull-right">
-  <div class="form-group">
+<div>
+  <button class="btn btn-default" id="sidebar-toggle" type="button" autocomplete="off">
+    <span class="glyphicon glyphicon-filter" aria-hidden="true"></span> Filters
+  </button>
+  <div class="pull-right" style="margin: 2px 0">
     <div class="input-group">
       <span class="input-group-addon"><i title="Sort by" class="glyphicon glyphicon-sort" aria-hidden="true"></i></span>
       <%= select_tag(:index_sort_order, options_for_select(options, @order.first),
@@ -13,7 +16,7 @@
       %>
     </div>
   </div>
-</form>
+</div>
 
 <script>
   $j('#index_sort_order').change(function () {

--- a/app/views/assets/_resources_numerical_paginated.html.erb
+++ b/app/views/assets/_resources_numerical_paginated.html.erb
@@ -30,7 +30,9 @@
   <%= render partial: 'general/paginate_numerical', locals: { objects: objects } if objects.respond_to?(:current_page) %>
 <% end %>
 
-<%= content_for :pagination %>
+<div class="hidden-xs">
+  <%= content_for :pagination %>
+</div>
 
 <%# If there is no param for view, try to retrieve from session information %>
 <% if !params.has_key?(:view) && session.has_key?(:view) %>

--- a/app/views/general/_index.html.erb
+++ b/app/views/general/_index.html.erb
@@ -28,9 +28,17 @@
 <div class="index-container">
   <%= render partial: 'assets/resource_filtering' if Seek::Config.filtering_enabled %>
   <div class="index-content">
-    <%= render partial: 'assets/resource_sorting', locals: { items: items } %>
-    <%= render partial: 'assets/resource_counts' %>
-    <%= render partial: 'assets/resource_active_filters' if Seek::Config.filtering_enabled %>
+    <div class="row">
+      <div class="col-sm-6">
+        <%= render partial: 'assets/resource_counts' %>
+      </div>
+      <div class="col-sm-6">
+        <%= render partial: 'assets/resource_sorting', locals: { items: items } %>
+      </div>
+      <div class="col-sm-12">
+        <%= render partial: 'assets/resource_active_filters' if Seek::Config.filtering_enabled %>
+      </div>
+    </div>
 
     <%= render partial: 'general/index_paged', locals: { items: items } %>
   </div>

--- a/app/views/general/_isa_graph.html.erb
+++ b/app/views/general/_isa_graph.html.erb
@@ -27,7 +27,7 @@
   }
 </style>
 
-<div style="float:right"><%= help_link :isa_overview, include_icon: true, link_text:'Help' %></div>
+<div style="float:right" class="hidden-xs"><%= help_link :isa_overview, include_icon: true, link_text:'Help' %></div>
 <div class="row">
   <div class="col-sm-12 hidden-xs">
     <div id="isa-graph" class="panel panel-default">


### PR DESCRIPTION
Fixes  #1409

Hides the filters on small screens and adds a button to pop up a modal where they can be set.

Also hides the top pagination bar and RLI project list on small screens.

Filter button:

![image](https://github.com/seek4science/seek/assets/503373/a908a59b-6e8b-4940-b9e4-af5e2ec13269)

Filters popup:

![image](https://github.com/seek4science/seek/assets/503373/1c3e8895-71b9-4e59-befe-3c9328fa5e88)
