### PR TITLE
Make it clearer there are additional search results

### DIFF
--- a/app/helpers/resource_list_helper.rb
+++ b/app/helpers/resource_list_helper.rb
@@ -59,4 +59,47 @@ module ResourceListHelper
       end
     end
   end
+
+  def resource_list_advanced_search_link(list_items_details, search_query, parent_item)
+    return nil if list_items_details[:is_external]
+    return nil unless safe_class_lookup(list_items_details[:type]).available_filters.any?
+    return nil unless (search_query || parent_item)
+    right_arrow_glyph = "<span class='glyphicon glyphicon-arrow-right' aria-hidden='true'></span>"
+     if search_query
+          more_results_link_text = "Advanced #{list_items_details[:visible_resource_type]} search with filtering #{right_arrow_glyph}".html_safe
+     elsif parent_item
+          more_results_link_text = "Advanced #{list_items_details[:visible_resource_type]} list for this #{internationalized_resource_name(parent_item.model_name.to_s, false)} with search and filtering #{right_arrow_glyph}".html_safe
+     end
+
+     link_to(more_results_link_text, resource_list_more_results_path(list_items_details, search_query, parent_item), class: 'pull-right')
+  end
+
+  def resource_list_items_shown_text(list_items_details, search_query, parent_item)
+    return nil if list_items_details[:is_external] || list_items_details[:extra_count] <= 0
+
+    content_tag(:span, id: 'resource-shown-count') do
+      link = link_to(pluralize(resource_type_total_visible_count(list_items_details),list_items_details[:visible_resource_type]), resource_list_more_results_path(list_items_details, search_query, parent_item))
+      "Showing #{list_items_details[:items_count]} out of a possible #{link}".html_safe
+    end
+
+  end
+
+  def resource_list_all_results_link(list_items_details, search_query, parent_item)
+    return nil if list_items_details[:is_external] || list_items_details[:extra_count] <= 0
+    right_arrow_glyph = "<span class='glyphicon glyphicon-arrow-right' aria-hidden='true'></span>"
+    content_tag(:div, id:'more-results', class:'text-center') do
+      link_text = "View all #{pluralize(resource_type_total_visible_count(list_items_details),list_items_details[:visible_resource_type])} #{right_arrow_glyph}".html_safe
+      link_to(link_text, resource_list_more_results_path(list_items_details, search_query, parent_item))
+    end
+  end
+
+  # the path to the index view with filtering, based on whether there is a search query, or parent from a nested route
+  def resource_list_more_results_path(list_items_details, search_query, parent_item)
+    if search_query
+      polymorphic_path(list_items_details[:type].tableize.to_sym, 'filter[query]': search_query)
+    else
+      [parent_item, list_items_details[:type].tableize.to_sym]
+    end
+  end
+
 end

--- a/app/helpers/resource_list_helper.rb
+++ b/app/helpers/resource_list_helper.rb
@@ -60,22 +60,20 @@ module ResourceListHelper
     end
   end
 
-  def resource_list_advanced_search_link(list_items_details, search_query, parent_item)
+  def resource_list_advanced_search_link(list_items_details, search_query, parent_item = nil)
     return nil if list_items_details[:is_external]
     return nil unless safe_class_lookup(list_items_details[:type]).available_filters.any?
     return nil unless (search_query || parent_item)
     right_arrow_glyph = "<span class='glyphicon glyphicon-arrow-right' aria-hidden='true'></span>"
-     if search_query
-          more_results_link_text = "Advanced #{list_items_details[:visible_resource_type]} search with filtering #{right_arrow_glyph}".html_safe
-     elsif parent_item
-          more_results_link_text = "Advanced #{list_items_details[:visible_resource_type]} list for this #{internationalized_resource_name(parent_item.model_name.to_s, false)} with search and filtering #{right_arrow_glyph}".html_safe
-     end
+    if search_query
+      more_results_link_text = "Advanced #{list_items_details[:visible_resource_type]} search with filtering #{right_arrow_glyph}".html_safe
+    elsif parent_item
+      more_results_link_text = "Advanced #{list_items_details[:visible_resource_type]} list for this #{internationalized_resource_name(parent_item.model_name.to_s, false)} with search and filtering #{right_arrow_glyph}".html_safe
+    end
 
     content_tag(:span, id: 'advanced-search-link') do
       link_to(more_results_link_text, resource_list_more_results_path(list_items_details, search_query, parent_item), class: 'pull-right')
     end
-
-
   end
 
   def resource_list_items_shown_text(list_items_details, search_query, parent_item)

--- a/app/helpers/resource_list_helper.rb
+++ b/app/helpers/resource_list_helper.rb
@@ -71,13 +71,17 @@ module ResourceListHelper
           more_results_link_text = "Advanced #{list_items_details[:visible_resource_type]} list for this #{internationalized_resource_name(parent_item.model_name.to_s, false)} with search and filtering #{right_arrow_glyph}".html_safe
      end
 
-     link_to(more_results_link_text, resource_list_more_results_path(list_items_details, search_query, parent_item), class: 'pull-right')
+    content_tag(:span, id: 'advanced-search-link') do
+      link_to(more_results_link_text, resource_list_more_results_path(list_items_details, search_query, parent_item), class: 'pull-right')
+    end
+
+
   end
 
   def resource_list_items_shown_text(list_items_details, search_query, parent_item)
     return nil if list_items_details[:is_external] || list_items_details[:extra_count] <= 0
 
-    content_tag(:span, id: 'resource-shown-count') do
+    content_tag(:span, id: 'resources-shown-count') do
       link = link_to(pluralize(resource_type_total_visible_count(list_items_details),list_items_details[:visible_resource_type]), resource_list_more_results_path(list_items_details, search_query, parent_item))
       "Showing #{list_items_details[:items_count]} out of a possible #{link}".html_safe
     end

--- a/app/views/assets/_resource_listing_tabbed_by_class.html.erb
+++ b/app/views/assets/_resource_listing_tabbed_by_class.html.erb
@@ -45,15 +45,15 @@
                   <% end %>
 
                   <% if !type[:is_external] && safe_class_lookup(type[:type]).available_filters.any? %>
-                    <% if query  %>
-
-                      <%= link_to "Advanced #{type[:visible_resource_type]} search with filtering ...",
-                                  more_results_path, class:'pull-right'  %>
-                    <% elsif item %>
-                      <%= link_to "Advanced #{type[:visible_resource_type]} list for this #{internationalized_resource_name(item.model_name.to_s, false)} with search and filtering ...",
-                                  more_results_path, class:'pull-right'  %>
-
-                    <% end %>
+                    <%= if query
+                          more_results_link_text = "Advanced #{type[:visible_resource_type]} search with filtering <span class='glyphicon glyphicon-arrow-right'></span>".html_safe
+                        elsif item
+                          more_results_link_text = "Advanced #{type[:visible_resource_type]} list for this #{internationalized_resource_name(item.model_name.to_s, false)} with search and filtering <span class='glyphicon glyphicon-arrow-right'></span>".html_safe
+                        else
+                          more_results_link_text = nil
+                        end
+                        link_to(more_results_link_text, more_results_path, class: 'pull-right') if more_results_link_text
+                    %>
                   <% end %>
 
                   <% unless type[:items].empty? %>
@@ -69,9 +69,12 @@
                         </div>
                       </div>
                   <% end %>
-                  <%= if type[:extra_count] > 0
-                    link_to("All #{pluralize(resource_type_total_visible_count(type),type[:visible_resource_type])} ...", more_results_path, class:'pull-right')
-                  end %>
+                    <%= if type[:extra_count] > 0
+                          content_tag(:div, id:'more-results', class:'text-center') do
+                            link_text = "View all #{pluralize(resource_type_total_visible_count(type),type[:visible_resource_type])} <span class='glyphicon glyphicon-arrow-right'></span>".html_safe
+                            link_to(link_text, more_results_path)
+                          end
+                    end %>
                 </div>
               <% active = false %>
             <% end -%>

--- a/app/views/assets/_resource_listing_tabbed_by_class.html.erb
+++ b/app/views/assets/_resource_listing_tabbed_by_class.html.erb
@@ -23,7 +23,13 @@
       <div class="tab-content">
         <% active = true %>
         <% ordered_resource_types.each_with_index do |type, i| -%>
-          <% more_results_path = polymorphic_path(type[:type].tableize.to_sym,'filter[query]':query) %>
+          <% more_results_path = if query
+                                   polymorphic_path(type[:type].tableize.to_sym, 'filter[query]': query)
+                                 else
+                                   [item, type[:type].tableize.to_sym]
+                                 end
+          %>
+
 
             <% unless type[:items].empty? && (type[:hidden_count] == 0) %>
                 <div id="<%= type[:tab_id] -%>" role="tabpanel" class="tab-pane <%= 'active' if active -%>">
@@ -42,11 +48,10 @@
                     <% if query  %>
 
                       <%= link_to "Advanced #{type[:visible_resource_type]} search with filtering ...",
-                                  polymorphic_path(type[:type].tableize.to_sym,
-                                                   'filter[query]':query), class:'pull-right'  %>
+                                  more_results_path, class:'pull-right'  %>
                     <% elsif item %>
                       <%= link_to "Advanced #{type[:visible_resource_type]} list for this #{internationalized_resource_name(item.model_name.to_s, false)} with search and filtering ...",
-                                  [item, type[:type].tableize.to_sym], class:'pull-right'  %>
+                                  more_results_path, class:'pull-right'  %>
 
                     <% end %>
                   <% end %>
@@ -64,6 +69,9 @@
                         </div>
                       </div>
                   <% end %>
+                  <%= if type[:extra_count] > 0
+                    link_to("All #{pluralize(resource_type_total_visible_count(type),type[:visible_resource_type])} ...", more_results_path, class:'pull-right')
+                  end %>
                 </div>
               <% active = false %>
             <% end -%>

--- a/app/views/assets/_resource_listing_tabbed_by_class.html.erb
+++ b/app/views/assets/_resource_listing_tabbed_by_class.html.erb
@@ -5,17 +5,19 @@
 
 <%
    actions_partial_disable ||= false
-   item ||= nil
+
+   #parent will be from a nested route, e.g. project/5/data_files parent would be project
+   parent_item ||= nil
+
    display_immediately ||= false
    index_params ||= {}
 
    ordered_resource_types = prepare_resource_hash(resource_hash)
 
-   query = index_params.dig(:filter, :query)
+   search_query = index_params.dig(:filter, :query)
 
    any_list_items = resource_hash.any? { |key, res| res[:items_count] > 0 || res[:hidden_count] > 0 }
 
-   right_arrow_glyph = "<span class='glyphicon glyphicon-arrow-right' aria-hidden='true'></span>"
 %>
 
 <% if any_list_items %>
@@ -23,63 +25,36 @@
       <%= render :partial => 'assets/resource_listing_tab_nav', :locals => { :types => ordered_resource_types } %>
       <div class="tab-content">
         <% active = true %>
-        <% ordered_resource_types.each_with_index do |type, i| -%>
-
+        <% ordered_resource_types.each_with_index do |list_items_details, i| -%>
           <%
-            unless type[:is_external]
-              more_results_path = if query
-                                    polymorphic_path(type[:type].tableize.to_sym, 'filter[query]': query)
-                                  else
-                                    [item, type[:type].tableize.to_sym]
-                                  end
-            end
+            # links to the index view with the appropriate text, and will be nil if not applicable
+            advanced_filtering_link = resource_list_advanced_search_link(list_items_details, search_query, parent_item)
+            resources_shown_count_text = resource_list_items_shown_text(list_items_details, search_query, parent_item)
+            view_all_results_link = resource_list_all_results_link(list_items_details, search_query, parent_item)
           %>
 
 
-            <% unless type[:items].empty? && (type[:hidden_count] == 0) %>
-                <div id="<%= type[:tab_id] -%>" role="tabpanel" class="tab-pane <%= 'active' if active -%>">
+            <% unless list_items_details[:items].empty? && (list_items_details[:hidden_count] == 0) %>
+                <div id="<%= list_items_details[:tab_id] -%>" role="tabpanel" class="tab-pane <%= 'active' if active -%>">
 
-                  <% if type[:extra_count] > 0 %>
-                    <span id='resource-shown-count'>
-                      Showing <%= type[:items_count] %> out of a possible
-                      <%=
-                        link_to(pluralize(resource_type_total_visible_count(type),type[:visible_resource_type]),
-                                more_results_path)
-                      %>
-                    </span>
-                  <% end %>
+                  <%= resources_shown_count_text if resources_shown_count_text.present? %>
 
-                  <% if !type[:is_external] && safe_class_lookup(type[:type]).available_filters.any? %>
-                    <%= if query
-                          more_results_link_text = "Advanced #{type[:visible_resource_type]} search with filtering #{right_arrow_glyph}".html_safe
-                        elsif item
-                          more_results_link_text = "Advanced #{type[:visible_resource_type]} list for this #{internationalized_resource_name(item.model_name.to_s, false)} with search and filtering <span class='glyphicon glyphicon-arrow-right'></span>".html_safe
-                        else
-                          more_results_link_text = nil
-                        end
-                        link_to(more_results_link_text, more_results_path, class: 'pull-right') if more_results_link_text
-                    %>
-                  <% end %>
+                  <%= advanced_filtering_link if advanced_filtering_link.present? %>
 
-                  <% unless type[:items].empty? %>
-                      <%= render :partial => "assets/resource_list", :locals => { :collection => type[:items],
+                  <% unless list_items_details[:items].empty? %>
+                      <%= render :partial => "assets/resource_list", :locals => { :collection => list_items_details[:items],
                                                                                   :authorization_for_showing_already_done => true,
                                                                                   :actions_partial_disable => actions_partial_disable} -%>
                   <% end %>
 
-                  <% if type[:hidden_count] > 0 %>
+                  <% if list_items_details[:hidden_count] > 0 %>
                       <div class="list_items_container">
                         <div class="hidden_list_item">
-                          <%= hidden_items_html(type[:hidden_items], pluralize(type[:hidden_count], 'hidden item'))  %>
+                          <%= hidden_items_html(list_items_details[:hidden_items], pluralize(list_items_details[:hidden_count], 'hidden item'))  %>
                         </div>
                       </div>
                   <% end %>
-                    <%= if type[:extra_count] > 0
-                          content_tag(:div, id:'more-results', class:'text-center') do
-                            link_text = "View all #{pluralize(resource_type_total_visible_count(type),type[:visible_resource_type])} #{right_arrow_glyph}".html_safe
-                            link_to(link_text, more_results_path)
-                          end
-                    end %>
+                    <%= view_all_results_link if view_all_results_link.present? %>
                 </div>
               <% active = false %>
             <% end -%>

--- a/app/views/assets/_resource_listing_tabbed_by_class.html.erb
+++ b/app/views/assets/_resource_listing_tabbed_by_class.html.erb
@@ -13,8 +13,9 @@
 
    query = index_params.dig(:filter, :query)
 
-
    any_list_items = resource_hash.any? { |key, res| res[:items_count] > 0 || res[:hidden_count] > 0 }
+
+   right_arrow_glyph = "<span class='glyphicon glyphicon-arrow-right' aria-hidden='true'></span>"
 %>
 
 <% if any_list_items %>
@@ -23,11 +24,15 @@
       <div class="tab-content">
         <% active = true %>
         <% ordered_resource_types.each_with_index do |type, i| -%>
-          <% more_results_path = if query
-                                   polymorphic_path(type[:type].tableize.to_sym, 'filter[query]': query)
-                                 else
-                                   [item, type[:type].tableize.to_sym]
-                                 end
+
+          <%
+            unless type[:is_external]
+              more_results_path = if query
+                                    polymorphic_path(type[:type].tableize.to_sym, 'filter[query]': query)
+                                  else
+                                    [item, type[:type].tableize.to_sym]
+                                  end
+            end
           %>
 
 
@@ -46,7 +51,7 @@
 
                   <% if !type[:is_external] && safe_class_lookup(type[:type]).available_filters.any? %>
                     <%= if query
-                          more_results_link_text = "Advanced #{type[:visible_resource_type]} search with filtering <span class='glyphicon glyphicon-arrow-right'></span>".html_safe
+                          more_results_link_text = "Advanced #{type[:visible_resource_type]} search with filtering #{right_arrow_glyph}".html_safe
                         elsif item
                           more_results_link_text = "Advanced #{type[:visible_resource_type]} list for this #{internationalized_resource_name(item.model_name.to_s, false)} with search and filtering <span class='glyphicon glyphicon-arrow-right'></span>".html_safe
                         else
@@ -71,7 +76,7 @@
                   <% end %>
                     <%= if type[:extra_count] > 0
                           content_tag(:div, id:'more-results', class:'text-center') do
-                            link_text = "View all #{pluralize(resource_type_total_visible_count(type),type[:visible_resource_type])} <span class='glyphicon glyphicon-arrow-right'></span>".html_safe
+                            link_text = "View all #{pluralize(resource_type_total_visible_count(type),type[:visible_resource_type])} #{right_arrow_glyph}".html_safe
                             link_to(link_text, more_results_path)
                           end
                     end %>

--- a/app/views/assets/_resource_listing_tabbed_by_class.html.erb
+++ b/app/views/assets/_resource_listing_tabbed_by_class.html.erb
@@ -13,6 +13,7 @@
 
    query = index_params.dig(:filter, :query)
 
+
    any_list_items = resource_hash.any? { |key, res| res[:items_count] > 0 || res[:hidden_count] > 0 }
 %>
 
@@ -22,12 +23,19 @@
       <div class="tab-content">
         <% active = true %>
         <% ordered_resource_types.each_with_index do |type, i| -%>
+          <% more_results_path = polymorphic_path(type[:type].tableize.to_sym,'filter[query]':query) %>
 
             <% unless type[:items].empty? && (type[:hidden_count] == 0) %>
                 <div id="<%= type[:tab_id] -%>" role="tabpanel" class="tab-pane <%= 'active' if active -%>">
 
                   <% if type[:extra_count] > 0 %>
-                    Showing <%= type[:items_count] %> out of a possible <%= pluralize(resource_type_total_visible_count(type),'item') %>
+                    <span id='resource-shown-count'>
+                      Showing <%= type[:items_count] %> out of a possible
+                      <%=
+                        link_to(pluralize(resource_type_total_visible_count(type),type[:visible_resource_type]),
+                                more_results_path)
+                      %>
+                    </span>
                   <% end %>
 
                   <% if !type[:is_external] && safe_class_lookup(type[:type]).available_filters.any? %>

--- a/app/views/assets/_resource_listing_tabbed_by_class.html.erb
+++ b/app/views/assets/_resource_listing_tabbed_by_class.html.erb
@@ -6,7 +6,7 @@
 <%
    actions_partial_disable ||= false
 
-   #parent will be from a nested route, e.g. project/5/data_files parent would be project
+   # parent_item will be from a nested route, e.g. for project/5/data_files parent_item would be an instance of the project
    parent_item ||= nil
 
    display_immediately ||= false

--- a/app/views/general/_items_related_to.html.erb
+++ b/app/views/general/_items_related_to.html.erb
@@ -1,8 +1,8 @@
-<% item = items_related_to %>
+<% parent_item = items_related_to %>
 <% limit ||= Seek::Config.related_items_limit %>
-<% resource_hash = get_related_resources(item, limit) %>
+<% resource_hash = get_related_resources(parent_item, limit) %>
 <% title ||= 'Related items' %>
 <h2><%= title %></h2>
 <%= render :partial => "assets/resource_listing_tabbed_by_class", :locals => {:resource_hash => resource_hash,
-                                                                              :item => item,
+                                                                              :parent_item => parent_item,
                                                                               :actions_partial_disable => false} -%>

--- a/app/views/human_diseases/_items_related_to.html.erb
+++ b/app/views/human_diseases/_items_related_to.html.erb
@@ -1,8 +1,8 @@
-<% item = items_related_to %>
+<% parent_item = items_related_to %>
 <% limit ||= Seek::Config.related_items_limit %>
-<% resource_hash = get_transitive_related_resources(item, limit) %>
+<% resource_hash = get_transitive_related_resources(parent_item, limit) %>
 <% title ||= 'Related items' %>
 <h2><%= title %></h2>
 <%= render :partial => "assets/resource_listing_tabbed_by_class", :locals => {:resource_hash => resource_hash,
-                                                                              :item => item,
+                                                                              :parent_item => parent_item,
                                                                               :actions_partial_disable => false} -%>

--- a/test/functional/samples_controller_test.rb
+++ b/test/functional/samples_controller_test.rb
@@ -742,7 +742,9 @@ class SamplesControllerTest < ActionController::TestCase
     end
 
     assert_response :success
-    assert_select 'div.related-items a[href=?]', sample_samples_path(sample), text: "Advanced Samples list for this Sample with search and filtering ..."
+
+    assert_select 'div.related-items #resources-shown-count a[href=?]', sample_samples_path(sample), text: "2 Samples"
+    assert_select 'div.related-items #advanced-search-link a[href=?]', sample_samples_path(sample), text: "Advanced Samples list for this Sample with search and filtering"
   end
 
   test 'related samples index page works correctly' do

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -160,8 +160,8 @@ class SearchControllerTest < ActionController::TestCase
       end
     end
 
-    assert_select '#resource-shown-count',text:/Showing 2 out of a possible/
-    assert_select '#resource-shown-count a[href=?]',documents_path('filter[query]':'test'), text:'5 Documents'
+    assert_select '#resources-shown-count',text:/Showing 2 out of a possible/
+    assert_select '#resources-shown-count a[href=?]',documents_path('filter[query]':'test'), text:'5 Documents'
     assert_select '#more-results a[href=?]',documents_path('filter[query]':'test'), text:/View all 5 Documents/
 
     # not shown if within limit
@@ -171,7 +171,7 @@ class SearchControllerTest < ActionController::TestCase
       end
     end
 
-    assert_select '#resource-shown-count', count:0
+    assert_select '#resources-shown-count', count:0
     assert_select '#more-results', count: 0
 
   end

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -151,4 +151,26 @@ class SearchControllerTest < ActionController::TestCase
     assert_equal "1 item matched '<b>&lt;a href=&quot;#test-123&quot;&gt;test&lt;/a&gt;</b>' within their title or content.", flash[:notice]
     assert_select 'a[href="#test-123"]', count: 0
   end
+
+  test 'link for more results' do
+    FactoryBot.create_list(:public_document, 5)
+    with_config_value(:search_results_limit, 2) do
+      Document.stub(:solr_cache, -> (q) { Document.pluck(:id).last(5) }) do
+        get :index, params: { q: 'test' }
+      end
+    end
+
+    assert_select '#resource-shown-count',text:/Showing 2 out of a possible/
+    assert_select '#resource-shown-count a[href=?]',documents_path('filter[query]':'test'), text:'5 Documents'
+
+    # not shown if within limit
+    with_config_value(:search_results_limit, 6) do
+      Document.stub(:solr_cache, -> (q) { Document.pluck(:id).last(5) }) do
+        get :index, params: { q: 'test' }
+      end
+    end
+
+    assert_select '#resource-shown-count', count:0
+
+  end
 end

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -162,6 +162,7 @@ class SearchControllerTest < ActionController::TestCase
 
     assert_select '#resource-shown-count',text:/Showing 2 out of a possible/
     assert_select '#resource-shown-count a[href=?]',documents_path('filter[query]':'test'), text:'5 Documents'
+    assert_select '#more-results a[href=?]',documents_path('filter[query]':'test'), text:/View all 5 Documents/
 
     # not shown if within limit
     with_config_value(:search_results_limit, 6) do
@@ -171,6 +172,7 @@ class SearchControllerTest < ActionController::TestCase
     end
 
     assert_select '#resource-shown-count', count:0
+    assert_select '#more-results', count: 0
 
   end
 end

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -54,7 +54,7 @@ class SearchControllerTest < ActionController::TestCase
       get :index, params: { q: 'test' }
     end
 
-    assert_select '#documents a[href=?]', documents_path(filter: { query: 'test' }), text: 'Advanced Documents search with filtering ...'
+    assert_select '#documents a[href=?]', documents_path(filter: { query: 'test' }), text: /Advanced Documents search with filtering/
   end
 
   test 'can render external search results' do


### PR DESCRIPTION
Made it clearer there are more search results than shown, and how get to them. Also applies to related items. As described on the issue #1452 :

- where and when it says, e.g. "Showing 20 out of a possible 180 items", the 180 items will be changed to a link to the full results
- if there are more results than displayed, then a link will be shown at the bottom that takes you to the full results, the same as Advanced Workflows search with filtering but with different wording, such as "All results with advanced filtering"