### PR TITLE
Refactor pending events warnings

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -463,7 +463,7 @@ module ApplicationHelper
 
   def pending_project_join_request?
     return false unless project_administrator_logged_in?
-    return false if ProjectMembershipMessageLog.pending_requests.count == 0
+    return false if ProjectMembershipMessageLog.pending.count == 0
     person = User.current_user.person
     projects = person.administered_projects
     return ProjectMembershipMessageLog.pending_requests(projects).any?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -455,6 +455,7 @@ module ApplicationHelper
 
   def pending_project_creation_request?
     return false unless admin_logged_in? || programme_administrator_logged_in?
+
     ProjectCreationMessageLog.pending_requests.detect do |log|
       log.can_respond_project_creation_request?(User.current_user)
     end.present?
@@ -462,6 +463,7 @@ module ApplicationHelper
 
   def pending_project_join_request?
     return false unless project_administrator_logged_in?
+    return false if ProjectMembershipMessageLog.pending_requests.count == 0
     person = User.current_user.person
     projects = person.administered_projects
     return ProjectMembershipMessageLog.pending_requests(projects).any?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -454,7 +454,7 @@ module ApplicationHelper
   end
 
   def pending_project_creation_request?
-    return false unless logged_in_and_registered?
+    return false unless admin_logged_in? || programme_administrator_logged_in?
     ProjectCreationMessageLog.pending_requests.detect do |log|
       log.can_respond_project_creation_request?(User.current_user)
     end.present?

--- a/app/views/layouts/_pending_events_warnings.html.erb
+++ b/app/views/layouts/_pending_events_warnings.html.erb
@@ -1,32 +1,39 @@
-<% if current_user && ProjectCreationMessageLog.pending_requests.limit(1).any? %>
-  <% cache [current_user, ProjectCreationMessageLog.pending_requests.last] do %>
+<% if logged_in_and_registered? %>
+
+  <% if join_or_create_project_banner? %>
+    <div class="alert alert-warning text-center">
+      As a newly registered user, you are not yet a member of a <%= t('project') %>. Please
+      <%=
+        link_to(
+          button_tag("Join or Create a #{t('project')}", class: 'btn btn-success'),
+          create_or_join_project_home_path)
+      %>
+    </div>
+  <% end %>
+
+  <% if ProjectCreationMessageLog.pending_requests.count > 0 || ProjectMembershipMessageLog.pending_requests.count > 0 %>
+
     <% if pending_project_creation_request? %>
       <div id='pending-project-creation-warning' class="alert alert-danger text-center">
-        There are pending <%= t('project') %> creation requests - <%= link_to('Full List',project_creation_requests_projects_path) %>
+        There are pending <%= t('project') %> creation requests
+        - <%= link_to('Full List', project_creation_requests_projects_path) %>
       </div>
     <% end %>
+
+    <% if pending_project_join_request? %>
+      <div id='pending-project-join-warning' class="alert alert-danger text-center">
+        There are pending join requests for <%= t('project').pluralize %> you administer
+        - <%= link_to('Full List', project_join_requests_projects_path) %>
+      </div>
+    <% end %>
+
   <% end %>
-<% end %>
 
-<% if pending_programme_creation_request? %>
-  <div id='pending-programme-creation-warning' class="alert alert-danger text-center">
-    There are pending <%= t('programme') %> creation requests - <%= link_to('Full List',awaiting_activation_programmes_path) %>
-  </div>
-<% end %>
+  <% if pending_programme_creation_request? %>
+    <div id='pending-programme-creation-warning' class="alert alert-danger text-center">
+      There are pending <%= t('programme') %> creation requests
+      - <%= link_to('Full List', awaiting_activation_programmes_path) %>
+    </div>
+  <% end %>
 
-<% if pending_project_join_request? %>
-  <div id='pending-project-join-warning' class="alert alert-danger text-center">
-    There are pending join requests for <%= t('project').pluralize %> you administer - <%= link_to('Full List',project_join_requests_projects_path) %>
-  </div>
-<% end %>
-
-<% if join_or_create_project_banner? %>
-  <div class="alert alert-warning text-center">
-    As a newly registered user, you are not yet a member of a <%= t('project') %>. Please
-    <%=
-      link_to(
-        button_tag("Join or Create a #{t('project')}", class:'btn btn-success'),
-        create_or_join_project_home_path)
-    %>
-  </div>
 <% end %>

--- a/app/views/layouts/_pending_events_warnings.html.erb
+++ b/app/views/layouts/_pending_events_warnings.html.erb
@@ -11,22 +11,18 @@
     </div>
   <% end %>
 
-  <% if ProjectCreationMessageLog.pending_requests.count > 0 || ProjectMembershipMessageLog.pending_requests.count > 0 %>
+  <% if pending_project_creation_request? %>
+    <div id='pending-project-creation-warning' class="alert alert-danger text-center">
+      There are pending <%= t('project') %> creation requests
+      - <%= link_to('Full List', project_creation_requests_projects_path) %>
+    </div>
+  <% end %>
 
-    <% if pending_project_creation_request? %>
-      <div id='pending-project-creation-warning' class="alert alert-danger text-center">
-        There are pending <%= t('project') %> creation requests
-        - <%= link_to('Full List', project_creation_requests_projects_path) %>
-      </div>
-    <% end %>
-
-    <% if pending_project_join_request? %>
-      <div id='pending-project-join-warning' class="alert alert-danger text-center">
-        There are pending join requests for <%= t('project').pluralize %> you administer
-        - <%= link_to('Full List', project_join_requests_projects_path) %>
-      </div>
-    <% end %>
-
+  <% if pending_project_join_request? %>
+    <div id='pending-project-join-warning' class="alert alert-danger text-center">
+      There are pending join requests for <%= t('project').pluralize %> you administer
+      - <%= link_to('Full List', project_join_requests_projects_path) %>
+    </div>
   <% end %>
 
   <% if pending_programme_creation_request? %>


### PR DESCRIPTION
Slight refactoring, to improve the effeciency of checks to see if the warnings need to be shown. I don't think it actually makes a great deal of difference but is a bit tidier.

Removed the caching, in most cases it was overkill. Generating the collection cache_key seemed more expensive than just checking if there were pending requests, and it also had a problem of needing invalidating if the person changes roles or becomes an admin - just not worth the added complexity