### PR TITLE
Sample and Multi Sample form element

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -614,7 +614,7 @@ class ApplicationController < ActionController::Base
         keys = [:custom_metadata_type_id,:id,:custom_metadata_attribute_id]
         cma= []
         metadata_type.custom_metadata_attributes.each do |attr|
-          if attr.sample_attribute_type.controlled_vocab? || attr.sample_attribute_type.seek_sample_multi?
+          if attr.sample_attribute_type.controlled_vocab? || attr.sample_attribute_type.seek_sample_multi? || attr.sample_attribute_type.seek_sample?
             cma << {attr.title=>[]}
             cma << attr.title.to_s
           elsif  attr.linked_custom_metadata?

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -201,7 +201,7 @@ class SamplesController < ApplicationController
     query = params[:q] || ''
     sample_type = SampleType.find(params[:linked_sample_type_id])
     results = sample_type.samples.where("LOWER(title) like :query",
-              query: "%#{query.downcase}%").limit(params[:limit] || 100)
+              query: "%#{query.downcase}%").limit(params[:limit] || 100).authorized_for(:view)
     items = results.map do |sa|
       { id: sa.id,
         text: sa.title }

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -266,7 +266,7 @@ class SamplesController < ApplicationController
 
     if sample_type
       sample_type.sample_attributes.each do |attr|
-        if attr.sample_attribute_type.controlled_vocab? || attr.sample_attribute_type.seek_sample_multi?
+        if attr.sample_attribute_type.controlled_vocab? || attr.sample_attribute_type.seek_sample_multi? || attr.sample_attribute_type.seek_sample?
           sample_type_param_keys << { attr.title => [] }
           sample_type_param_keys << attr.title.to_sym
         else

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -79,7 +79,16 @@ module SamplesHelper
 
     existing_objects = []
     str = Struct.new(:id, :title)
-    value.each {|v| existing_objects << str.new(v[:id], v[:title]) if v} if value
+    if value
+      value = [value] unless value.is_a?(Array)
+      value.compact.each do |v|
+        id = v[:id]
+        title = v[:title]
+        title = '<em>Hidden</em>' unless Sample.find(id).can_view?
+        existing_objects << str.new(id, title)
+      end
+    end
+
     typeahead = { query_url: typeahead_samples_path + "?linked_sample_type_id=#{attribute.linked_sample_type.id}",
                   handlebars_template: 'typeahead/controlled_vocab_term' }
     objects_input(element_name, existing_objects,

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -75,13 +75,21 @@ module SamplesHelper
     html.html_safe
   end
 
-  def sample_multi_form_field(attribute, element_name, value)  
+  def sample_form_field(attribute, element_name, value, limit = 1)
+
     existing_objects = []
     str = Struct.new(:id, :title)
     value.each {|v| existing_objects << str.new(v[:id], v[:title]) if v} if value
+    typeahead = { query_url: typeahead_samples_path + "?linked_sample_type_id=#{attribute.linked_sample_type.id}",
+                  handlebars_template: 'typeahead/controlled_vocab_term' }
     objects_input(element_name, existing_objects,
-                  typeahead: { query_url: typeahead_samples_path + "?linked_sample_type_id=#{attribute.linked_sample_type.id}",
-                  handlebars_template: 'typeahead/controlled_vocab_term' }, class: 'form-control')
+                  typeahead: typeahead,
+                  limit: limit,
+                  class: 'form-control')
+  end
+
+  def sample_multi_form_field(attribute, element_name, value)
+    sample_form_field(attribute, element_name, value, nil)
   end
 
   def authorised_samples(projects = nil)
@@ -307,10 +315,7 @@ module SamplesHelper
     when Seek::Samples::BaseType::CV_LIST
       controlled_vocab_list_form_field attribute.sample_controlled_vocab, element_name, value
     when Seek::Samples::BaseType::SEEK_SAMPLE
-      terms = attribute.linked_sample_type.samples.authorized_for('view').to_a
-      options = options_from_collection_for_select(terms, :id, :title, value.try(:[], 'id'))
-      select_tag element_name, options,
-                 include_blank: !attribute.required?, class: "form-control #{element_class}"
+      sample_form_field attribute, element_name, value
     when Seek::Samples::BaseType::SEEK_SAMPLE_MULTI
       sample_multi_form_field attribute, element_name, value
     when Seek::Samples::BaseType::LINKED_CUSTOM_METADATA

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -16,8 +16,6 @@ class Sample < ApplicationRecord
 
   acts_as_asset
 
-  validates :projects, presence: true, projects: { self: true }
-
   belongs_to :sample_type, inverse_of: :samples
   alias_method :metadata_type, :sample_type
 
@@ -32,30 +30,20 @@ class Sample < ApplicationRecord
   has_many :linked_samples, through: :sample_resource_links, source: :resource, source_type: 'Sample'
   has_many :linking_samples, through: :reverse_sample_resource_links, source: :sample
 
+  validates :projects, presence: true, projects: { self: true }
   validates :title, :sample_type, presence: true
 
   validates_with SampleAttributeValidator
   validate :validate_added_linked_sample_permissions
 
   before_validation :set_title_to_title_attribute_value
-
   before_validation :update_sample_resource_links
+
   after_save :queue_sample_type_update_job
   after_save :queue_linking_samples_update_job
   after_destroy :queue_sample_type_update_job
 
   has_filter :sample_type
-
-  def validate_added_linked_sample_permissions
-    previous_linked_samples = []
-    unless new_record?
-      previous_linked_samples = Sample.find(id).referenced_samples
-    end
-    additions = linked_samples - previous_linked_samples
-    if additions.detect{|sample| !sample.can_view?}
-      errors.add(:linked_samples, 'includes a new private sample')
-    end
-  end
 
   def sample_type=(type)
     super
@@ -219,6 +207,7 @@ class Sample < ApplicationRecord
   end
 
   def update_sample_resource_links
+    return unless sample_type.present?
     self.strains = referenced_strains
     self.linked_samples = referenced_samples
   end
@@ -235,5 +224,19 @@ class Sample < ApplicationRecord
       end.map(&:pos)
     end
     sample_type_hash
+  end
+
+  # checks and validates whether new linked samples have view permission, but ignores existing ones
+  def validate_added_linked_sample_permissions
+    return if $authorization_checks_disabled
+    return if linked_samples.empty?
+    previous_linked_samples = []
+    unless new_record?
+      previous_linked_samples = Sample.find(id).referenced_samples
+    end
+    additions = linked_samples - previous_linked_samples
+    if additions.detect { |sample| !sample.can_view? }
+      errors.add(:linked_samples, 'includes a new private sample')
+    end
   end
 end

--- a/lib/seek/samples/attribute_type_handlers/seek_sample_attribute_type_handler.rb
+++ b/lib/seek/samples/attribute_type_handlers/seek_sample_attribute_type_handler.rb
@@ -16,6 +16,11 @@ module Seek
           end
         end
 
+        def convert(value)
+          return super(value) if value.is_a?(String) || value.is_a?(Integer)
+          super(value.compact_blank.first)
+        end
+
         private
 
         def find_resource(value)

--- a/test/functional/samples_controller_test.rb
+++ b/test/functional/samples_controller_test.rb
@@ -1233,6 +1233,8 @@ class SamplesControllerTest < ActionController::TestCase
       person = FactoryBot.create(:person)
       project = FactoryBot.create(:project)
 
+      login_as(person)
+
       template1 = FactoryBot.create(:isa_source_template)
       template2 = FactoryBot.create(:isa_sample_collection_template)
       template3 = FactoryBot.create(:isa_assay_template)
@@ -1252,7 +1254,7 @@ class SamplesControllerTest < ActionController::TestCase
       sample3 = FactoryBot.create :sample, title: 'sample3', sample_type: type3, project_ids: [project.id], contributor: person,
                                  data: { Input: [sample2.id], 'Protocol Assay 1': 'Protocol Assay 1', 'Assay 1 parameter value 1': 'Assay 1 parameter value 1', 'Extract Name': 'Extract Name', 'other material characteristic 1': 'other material characteristic 1' }
 
-      login_as(person)
+
 
       post :query, xhr: true, params: {
         project_ids: [project.id],

--- a/test/functional/samples_controller_test.rb
+++ b/test/functional/samples_controller_test.rb
@@ -1279,6 +1279,27 @@ class SamplesControllerTest < ActionController::TestCase
     end
   end
 
+  test 'typeahead' do
+    person = FactoryBot.create(:person)
+    sample1 = FactoryBot.create(:sample, title: 'sample1', contributor: person)
+    sample_type = sample1.sample_type
+
+    sample2 = FactoryBot.create(:sample, sample_type: sample_type, title: 'sample2')
+
+    login_as(person)
+    assert_equal sample1.sample_type, sample2.sample_type
+    assert sample1.can_view?
+    refute sample2.can_view?
+
+    get :typeahead, params:{ format: :json, linked_sample_type_id: sample_type.id, q:'samp'}
+    assert_response :success
+    res = JSON.parse(response.body)['results']
+
+    assert_equal 1, res.count
+    assert_equal 'sample1', res.first['text']
+
+  end
+
   private
 
   def populated_patient_sample

--- a/test/integration/api/sample_api_test.rb
+++ b/test/integration/api/sample_api_test.rb
@@ -127,7 +127,7 @@ class SampleApiTest < ActionDispatch::IntegrationTest
   test 'create with multi sample and cv list' do
     user_login
     max_sample_type = FactoryBot.create(:max_sample_type)
-    patients = [FactoryBot.create(:patient_sample), FactoryBot.create(:patient_sample)]
+    patients = [FactoryBot.create(:patient_sample, policy:FactoryBot.create(:public_policy)), FactoryBot.create(:patient_sample, policy:FactoryBot.create(:public_policy))]
 
     params = {
       "data": {
@@ -179,7 +179,7 @@ class SampleApiTest < ActionDispatch::IntegrationTest
   test 'create with multi sample and cv list - as array' do
     user_login
     max_sample_type = FactoryBot.create(:max_sample_type)
-    patients = [FactoryBot.create(:patient_sample), FactoryBot.create(:patient_sample)]
+    patients = [FactoryBot.create(:patient_sample, policy:FactoryBot.create(:public_policy)), FactoryBot.create(:patient_sample, policy:FactoryBot.create(:public_policy))]
 
     params = {
       "data": {

--- a/test/unit/isa_exporter_test.rb
+++ b/test/unit/isa_exporter_test.rb
@@ -24,21 +24,22 @@ class IsaExporterTest < ActionController::TestCase
               title: 'PARENT 1',
               sample_type: type_1,
               project_ids: [project.id],
+              policy: FactoryBot.create(:public_policy),
               data: {
           the_title: 'PARENT 1'
               }
 
-    child_1 = Sample.new(sample_type: type_2, project_ids: [project.id])
+    child_1 = Sample.new(sample_type: type_2, project_ids: [project.id], policy:FactoryBot.create(:public_policy))
     child_1.set_attribute_value(:patient, [parent.id])
     child_1.set_attribute_value(:title, 'CHILD 1')
     child_1.save!
 
-    child_2 = Sample.new(sample_type: type_3, project_ids: [project.id])
+    child_2 = Sample.new(sample_type: type_3, project_ids: [project.id], policy:FactoryBot.create(:public_policy))
     child_2.set_attribute_value(:patient, [child_1.id])
     child_2.set_attribute_value(:title, 'CHILD 2')
     child_2.save!
 
-    child_3 = Sample.new(sample_type: type_4, project_ids: [project.id])
+    child_3 = Sample.new(sample_type: type_4, project_ids: [project.id], policy:FactoryBot.create(:public_policy))
     child_3.set_attribute_value(:patient, [child_2.id])
     child_3.set_attribute_value(:title, 'CHILD 3')
     child_3.save!
@@ -54,6 +55,7 @@ class IsaExporterTest < ActionController::TestCase
               title: 'PARENT 2',
               sample_type: type_1,
               project_ids: [project.id],
+              policy:FactoryBot.create(:public_policy),
               data: {
           the_title: 'PARENT 2'
               }

--- a/test/unit/sample_test.rb
+++ b/test/unit/sample_test.rb
@@ -1,6 +1,7 @@
 require 'test_helper'
 
 class SampleTest < ActiveSupport::TestCase
+
   test 'validation' do
     sample = FactoryBot.create :sample, title: 'fish', sample_type: FactoryBot.create(:simple_sample_type), data: { the_title: 'fish' }
     assert sample.valid?
@@ -527,7 +528,7 @@ class SampleTest < ActiveSupport::TestCase
 
   test 'linked sample as title' do
     # setup sample type, to be linked to patient sample type
-    patient = FactoryBot.create(:patient_sample)
+    patient = FactoryBot.create(:patient_sample, policy:FactoryBot.create(:public_policy))
     assert_equal 'Fred Bloggs', patient.title
     linked_sample_type = FactoryBot.create(:linked_sample_type, project_ids: [FactoryBot.create(:project).id])
     linked_sample_type.sample_attributes.last.linked_sample_type = patient.sample_type
@@ -607,7 +608,7 @@ class SampleTest < ActiveSupport::TestCase
 
   test 'set linked sample by id' do
     # setup sample type, to be linked to patient sample type
-    patient = FactoryBot.create(:patient_sample)
+    patient = FactoryBot.create(:patient_sample, policy: FactoryBot.create(:public_policy))
     linked_sample_type = FactoryBot.create(:linked_sample_type, project_ids: [FactoryBot.create(:project).id])
     linked_sample_type.sample_attributes.last.linked_sample_type = patient.sample_type
     linked_sample_type.save!
@@ -626,7 +627,7 @@ class SampleTest < ActiveSupport::TestCase
 
   test 'set linked sample by title' do
     # setup sample type, to be linked to patient sample type
-    patient = FactoryBot.create(:patient_sample)
+    patient = FactoryBot.create(:patient_sample, policy: FactoryBot.create(:public_policy))
     linked_sample_type = FactoryBot.create(:linked_sample_type, project_ids: [FactoryBot.create(:project).id])
     linked_sample_type.sample_attributes.last.linked_sample_type = patient.sample_type
 
@@ -1119,8 +1120,8 @@ class SampleTest < ActiveSupport::TestCase
   end
 
   test 'multi linked sample validation' do
-    patient = FactoryBot.create(:patient_sample)
-    patient2 = FactoryBot.create(:patient_sample, sample_type:patient.sample_type )
+    patient = FactoryBot.create(:patient_sample, policy:FactoryBot.create(:public_policy))
+    patient2 = FactoryBot.create(:patient_sample, sample_type:patient.sample_type, policy:FactoryBot.create(:public_policy) )
     multi_linked_sample_type = FactoryBot.create(:multi_linked_sample_type, project_ids: [FactoryBot.create(:project).id])
     multi_linked_sample_type.sample_attributes.last.linked_sample_type = patient.sample_type
     multi_linked_sample_type.save!

--- a/test/unit/sample_test.rb
+++ b/test/unit/sample_test.rb
@@ -1181,11 +1181,9 @@ class SampleTest < ActiveSupport::TestCase
     person_a = FactoryBot.create(:person)
     person_b = FactoryBot.create(:person)
 
-
     pub_patient1 = FactoryBot.create(:patient_sample, contributor: person_a, policy: FactoryBot.create(:public_policy))
 
     patient_sample_type = pub_patient1.sample_type
-    pub_patient2 = FactoryBot.create(:patient_sample, sample_type:patient_sample_type, contributor: person_a, policy: FactoryBot.create(:public_policy))
 
     priv_patient1 = FactoryBot.create(:patient_sample, sample_type:patient_sample_type, contributor: person_a, policy: FactoryBot.create(:private_policy) )
 
@@ -1208,14 +1206,12 @@ class SampleTest < ActiveSupport::TestCase
     # sanity check
     User.with_current_user(person_a) do
       assert pub_patient1.can_view?
-      assert pub_patient2.can_view?
       assert priv_patient1.can_view?
       assert priv_patient2.can_view?
       assert sample.can_edit?
     end
     User.with_current_user(person_b) do
       assert pub_patient1.can_view?
-      assert pub_patient2.can_view?
       refute priv_patient1.can_view?
       refute priv_patient2.can_view?
       assert sample.can_edit?


### PR DESCRIPTION
Use select2 for both Single and Multiple Sample entry (requires handling params as an array for both cases, whereas the api still takes a non array for single case)

Also make sure non visible samples are filtered from the available options.

Also checked that non visible samples are shown as hidden when displaying the parent sample

- Fixes #1557 