### PR TITLE
Issue 1457 delete sample types with deleted assets

### DIFF
--- a/app/controllers/assays_controller.rb
+++ b/app/controllers/assays_controller.rb
@@ -115,7 +115,7 @@ class AssaysController < ApplicationController
   def delete_linked_sample_types
     return unless is_single_page_assay?
 
-    @assay.sample_type.delete
+    @assay.sample_type.destroy
   end
 
   def update

--- a/app/controllers/assays_controller.rb
+++ b/app/controllers/assays_controller.rb
@@ -115,7 +115,6 @@ class AssaysController < ApplicationController
 
     raise "You are don't have permission to delete this assay!" unless current_user.can_delete?
 
-    # hkvdghvshdbvjh
     project_id = @assay.projects&.first&.id
 
     @assay.sample_type.delete if is_single_page_assay?

--- a/app/controllers/assays_controller.rb
+++ b/app/controllers/assays_controller.rb
@@ -6,6 +6,7 @@ class AssaysController < ApplicationController
   before_action :assays_enabled?
   before_action :find_assets, :only=>[:index]
   before_action :find_and_authorize_requested_item, :only=>[:edit, :update, :destroy, :manage, :manage_update, :show, :new_object_based_on_existing_one]
+  before_action :delete_linked_sample_types, only: [:destroy]
 
   #project_membership_required_appended is an alias to project_membership_required, but is necessary to include the actions
   #defined in the application controller
@@ -110,26 +111,11 @@ class AssaysController < ApplicationController
     end
   end
 
-  def destroy
-    raise 'This assay is not empty. Unable to delete this assay' unless @assay.state_allows_delete?
 
-    raise "You are don't have permission to delete this assay!" unless current_user.can_delete?
+  def delete_linked_sample_types
+    return unless is_single_page_assay?
 
-    project_id = @assay.projects&.first&.id
-
-    @assay.sample_type.delete if is_single_page_assay?
-    @assay.delete
-
-    if is_single_page_assay?
-      flash[:notice] = "ISA Assay successfully deleted!"
-      redirect_to single_page_path(Project.find(project_id))
-    else
-      flash[:notice] = "Assay successfully deleted!"
-      redirect_to new_assay_path(:class => @assay.assay_class)
-    end
-  rescue StandardError => e
-    flash[:error] = "#{e}. Couldn't delete Assay!"
-    render json: { status: :unprocessable_entity, error: e.message }
+    @assay.sample_type.delete
   end
 
   def update
@@ -199,6 +185,8 @@ class AssaysController < ApplicationController
   end
 
   def is_single_page_assay?
+    return false unless params.key?(:return_to)
+
     params[:return_to].start_with? '/single_pages/'
   end
 end

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -90,7 +90,7 @@ class StudiesController < ApplicationController
   end
 
   def delete_linked_sample_types
-    return unless is_single_page_assay?
+    return unless is_single_page_study?
 
     @study.sample_types.each do |st|
       raise "Sample Type '#{st.title}' contains samples. Unable to delete study" unless st.samples.empty?
@@ -364,7 +364,7 @@ class StudiesController < ApplicationController
   end
 end
 
-def is_single_page_assay?
+def is_single_page_study?
   return false unless params.key?(:return_to)
 
   params[:return_to].start_with? '/single_pages/'

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -92,11 +92,10 @@ class StudiesController < ApplicationController
   def delete_linked_sample_types
     return unless is_single_page_study?
 
-    @study.sample_types.each do |st|
-      raise "Sample Type '#{st.title}' contains samples. Unable to delete study" unless st.samples.empty?
-
-      st.destroy
-    end
+    # The study sample types must be destroyed in reversed order
+    # otherwise the first sample type won't be removed becaused it is linked from the second
+    study_st_ids = @study.sample_types.map(&:id).sort { |a, b| b <=> a }
+    SampleType.destroy(study_st_ids)
   end
 
 

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -95,7 +95,7 @@ class StudiesController < ApplicationController
     @study.sample_types.each do |st|
       raise "Sample Type '#{st.title}' contains samples. Unable to delete study" unless st.samples.empty?
 
-      st.delete
+      st.destroy
     end
   end
 

--- a/app/models/assay.rb
+++ b/app/models/assay.rb
@@ -77,7 +77,7 @@ class Assay < ApplicationRecord
   end
 
   def state_allows_delete?(*args)
-    assets.empty? && publications.empty? && super
+    assets.empty? && publications.empty? && associated_samples_through_sample_type.empty? && super
   end
 
   # returns true if this is a modelling class of assay
@@ -88,6 +88,10 @@ class Assay < ApplicationRecord
   # returns true if this is an experimental class of assay
   def is_experimental?
     !assay_class.nil? && assay_class.key == 'EXP'
+  end
+
+  def associated_samples_through_sample_type
+    (sample_type.nil? || sample_type.samples.nil?) ? [] : sample_type.samples
   end
 
   # Create or update relationship of this assay to another, with a specific relationship type and version

--- a/test/functional/assays_controller_test.rb
+++ b/test/functional/assays_controller_test.rb
@@ -1923,7 +1923,7 @@ class AssaysControllerTest < ActionController::TestCase
 
   test 'should delete empty assay with linked sample type' do
     person = FactoryBot.create(:person)
-    assay_sample_type = FactoryBot.create :linked_sample_type
+    assay_sample_type = FactoryBot.create :linked_sample_type, contributor: person
     assay = FactoryBot.create(:assay,
                               policy:FactoryBot.create(:private_policy, permissions:[FactoryBot.create(:permission,contributor: person, access_type:Policy::EDITING)]),
                               sample_type: assay_sample_type,

--- a/test/functional/assays_controller_test.rb
+++ b/test/functional/assays_controller_test.rb
@@ -1921,4 +1921,20 @@ class AssaysControllerTest < ActionController::TestCase
     assert_select 'span.updated_last_by a', false, 'Last editor should not be shown if editor user has been deleted'
   end
 
+  test 'should delete empty assay with linked sample type' do
+    person = FactoryBot.create(:person)
+    assay_sample_type = FactoryBot.create :linked_sample_type
+    assay = FactoryBot.create(:assay,
+                              policy:FactoryBot.create(:private_policy, permissions:[FactoryBot.create(:permission,contributor: person, access_type:Policy::EDITING)]),
+                              sample_type: assay_sample_type,
+                              contributor: person)
+
+    login_as(person)
+
+    assert_difference('SampleType.count', -1) do
+      assert_difference('Assay.count', -1) do
+        delete :destroy, params: { id: assay.id, return_to: '/single_pages/' }
+      end
+    end
+  end
 end

--- a/test/functional/studies_controller_test.rb
+++ b/test/functional/studies_controller_test.rb
@@ -11,7 +11,7 @@ class StudiesControllerTest < ActionController::TestCase
   def setup
     login_as FactoryBot.create(:admin).user
   end
-  
+
   test 'should get index' do
     FactoryBot.create :study, policy: FactoryBot.create(:public_policy)
     get :index
@@ -1229,7 +1229,7 @@ class StudiesControllerTest < ActionController::TestCase
                             policy: FactoryBot.create(:public_policy),
                             contributor: person)
     get :show, params: { id: study.id }
-    
+
     assert_response :success
     assert_select 'a[href=?]',
                   order_assays_study_path(study), count: 0
@@ -1392,6 +1392,24 @@ class StudiesControllerTest < ActionController::TestCase
     login_as(person)
     put :update, params: { id: study.id, study: { title: 'test' }, tag_list: 'my_tag' }
     assert_equal 'my_tag', assigns(:study).tags_as_text_array.first
+  end
+
+  test 'should delete empty study with linked sample type' do
+    person = FactoryBot.create(:person)
+    study_source_sample_type = FactoryBot.create :linked_sample_type
+    study_sample_sample_type = FactoryBot.create :linked_sample_type
+    study = FactoryBot.create(:study,
+                              policy:FactoryBot.create(:private_policy, permissions:[FactoryBot.create(:permission,contributor: person, access_type:Policy::EDITING)]),
+                              sample_types: [study_source_sample_type, study_sample_sample_type],
+                              contributor: person)
+
+    login_as(person)
+
+    assert_difference('SampleType.count', -2) do
+      assert_difference('Study.count', -1) do
+        delete :destroy, params: { id: study.id, return_to: '/single_pages/' }
+      end
+    end
   end
 
 end

--- a/test/functional/studies_controller_test.rb
+++ b/test/functional/studies_controller_test.rb
@@ -1396,8 +1396,8 @@ class StudiesControllerTest < ActionController::TestCase
 
   test 'should delete empty study with linked sample type' do
     person = FactoryBot.create(:person)
-    study_source_sample_type = FactoryBot.create :linked_sample_type
-    study_sample_sample_type = FactoryBot.create :linked_sample_type
+    study_source_sample_type = FactoryBot.create :linked_sample_type, contributor: person
+    study_sample_sample_type = FactoryBot.create :linked_sample_type, contributor: person
     study = FactoryBot.create(:study,
                               policy:FactoryBot.create(:private_policy, permissions:[FactoryBot.create(:permission,contributor: person, access_type:Policy::EDITING)]),
                               sample_types: [study_source_sample_type, study_sample_sample_type],


### PR DESCRIPTION
This Pull Request fixes:
- Deletes the linked sample types of the deleted assays or studies
- Takes into account the samples in the linked sample types when checking at deletion.