### PR TITLE
Tiny bugfix Safari users dynamic table

### DIFF
--- a/app/assets/javascripts/single_page/dynamic_table.js.erb
+++ b/app/assets/javascripts/single_page/dynamic_table.js.erb
@@ -223,12 +223,14 @@ const handleSelect = (e) => {
 
         this.table.rows.add(rows).draw();
 
-        if (sampleLinksTitles.length)
+          if (sampleLinksTitles.length)
           alert(
             "No value is pasted for the following column(s): \n" +
             sampleLinksTitles.map((x) => `"${x}"`).join(", ") +
             "\nYou need to manually input them."
           );
+      }).catch((error) =>{
+        alert(`Error occurred:\n${error}`);
       });
     },
     newRow: function() {

--- a/app/assets/javascripts/single_page/dynamic_table.js.erb
+++ b/app/assets/javascripts/single_page/dynamic_table.js.erb
@@ -223,14 +223,14 @@ const handleSelect = (e) => {
 
         this.table.rows.add(rows).draw();
 
-          if (sampleLinksTitles.length)
+        if (sampleLinksTitles.length)
           alert(
             "No value is pasted for the following column(s): \n" +
             sampleLinksTitles.map((x) => `"${x}"`).join(", ") +
             "\nYou need to manually input them."
           );
       }).catch((error) =>{
-        alert(`Error occurred:\n${error}`);
+        alert(`Paste action aborted:\n\n${error}\n\nNote: Some browsers require to click 'paste' to paste the information in the table.`);
       });
     },
     newRow: function() {


### PR DESCRIPTION
Added a catch clause to the promise so the promise error also shows a popup instead of only outputting an error in the browser console. This can be particularly be useful for Safari users that forget to click 'paste' after clicking 'paste from clipboard'.