### PR TITLE
Add Query by Template button to the samples' index page

### DIFF
--- a/app/views/general/_index.html.erb
+++ b/app/views/general/_index.html.erb
@@ -5,10 +5,14 @@
   show_new_button = true unless local_assigns.has_key?(:show_new_button)
   title ||= nil
   subtitle ||= nil
+	isa_templates_enabled = Seek::Config.sample_type_template_enabled && Seek::Config.project_single_page_advanced_enabled
 %>
 
 <div class="pull-right">
   <% if show_new_button && controller_model.can_create? %>
+    <% if isa_templates_enabled %>
+      <%= link_to "Query by #{t('template').pluralize}", query_form_samples_path, class: "btn btn-default btn" %>
+    <% end %>
     <%= button_link_to(new_item_label, "new", new_item_path) %>
   <% end %>
 


### PR DESCRIPTION
Small bugfix for the Samples index page:
Adds a button that takes the user to the sample query page.