### PR TITLE
Fix duplicates in ISA tree

### DIFF
--- a/lib/seek/isa_graph_generator.rb
+++ b/lib/seek/isa_graph_generator.rb
@@ -183,11 +183,13 @@ module Seek
         }
       when Investigation
         {
-          children: [:positioned_studies, :publications]
+          children: [:positioned_studies],
+          related: [:publications]
         }
       when Study
         {
-          children: [:positioned_assays, :publications, :sops],
+          children: [:positioned_assays],
+          related: [:publications, :sops],
           parents: [:investigation]
         }
       when Assay

--- a/lib/seek/isa_graph_generator.rb
+++ b/lib/seek/isa_graph_generator.rb
@@ -158,10 +158,10 @@ module Seek
     end
 
     def resolve_association(object, association)
-      if object.respond_to?('related_' + association.to_s)
-        associations = object.send('related_' + association.to_s)
-      elsif object.respond_to?(association)
+      if object.respond_to?(association)
         associations = object.send(association)
+      elsif object.respond_to?('related_' + association.to_s)
+        associations = object.send('related_' + association.to_s)
       else
         return []
       end
@@ -183,14 +183,12 @@ module Seek
         }
       when Investigation
         {
-          children: [:positioned_studies],
-          related: [:publications]
+          children: [:positioned_studies, :publications]
         }
       when Study
         {
-          children: [:positioned_assays],
-          parents: [:investigation],
-          related: [:publications]
+          children: [:positioned_assays, :publications, :sops],
+          parents: [:investigation]
         }
       when Assay
         {

--- a/test/unit/isa_graph_generator_test.rb
+++ b/test/unit/isa_graph_generator_test.rb
@@ -143,8 +143,7 @@ class IsaGraphGeneratorTest < ActiveSupport::TestCase
     publication = FactoryBot.create(:publication)
     publication2 = FactoryBot.create(:publication)
     assay = FactoryBot.create(:assay, contributor: person, publications: [publication])
-    assay.study.publications << publication2
-    disable_authorization_checks { assay.study.save! }
+    disable_authorization_checks { assay.study.publications << publication2 }
 
     assert_equal [publication], assay.publications
     assert_equal [publication], assay.related_publications

--- a/test/unit/isa_graph_generator_test.rb
+++ b/test/unit/isa_graph_generator_test.rb
@@ -137,4 +137,45 @@ class IsaGraphGeneratorTest < ActiveSupport::TestCase
     refute_includes result[:nodes].map(&:object), investigation2
     refute_includes result[:nodes].map(&:object), investigation3
   end
+
+  test 'shows direct associations rather than related' do
+    person = FactoryBot.create(:person)
+    publication = FactoryBot.create(:publication)
+    publication2 = FactoryBot.create(:publication)
+    assay = FactoryBot.create(:assay, contributor: person, publications: [publication])
+    assay.study.publications << publication2
+    disable_authorization_checks { assay.study.save! }
+
+    assert_equal [publication], assay.publications
+    assert_equal [publication], assay.related_publications
+
+    assert_equal [publication2], assay.study.publications
+    assert_equal [publication, publication2].sort, assay.study.related_publications.sort
+
+    assert_empty assay.study.investigation.publications
+    assert_equal [publication, publication2].sort, assay.study.investigation.related_publications.sort
+
+    generator = Seek::IsaGraphGenerator.new(assay)
+    result = generator.generate(parent_depth: nil)
+
+    assert_equal 5, result[:nodes].count
+    assert_equal 4, result[:edges].count
+
+    assay_pub_edges = result[:edges].select { |edge| edge.include?(assay) && edge.include?(publication) }
+    assert_equal 1, assay_pub_edges.count
+    assay_pub_edges = result[:edges].select { |edge| edge.include?(assay) && edge.include?(publication2) }
+    assert_empty assay_pub_edges
+
+    study_pub_edges = result[:edges].select { |edge| edge.include?(assay.study) && edge.include?(publication) }
+    assert_empty study_pub_edges
+
+    study_pub_edges = result[:edges].select { |edge| edge.include?(assay.study) && edge.include?(publication2) }
+    assert_equal 1, study_pub_edges.count
+
+    inv_pub_edges = result[:edges].select { |edge| edge.include?(assay.study.investigation) && edge.include?(publication) }
+    assert_empty inv_pub_edges
+    inv_pub_edges = result[:edges].select { |edge| edge.include?(assay.study.investigation) && edge.include?(publication2) }
+    assert_empty inv_pub_edges
+
+  end
 end


### PR DESCRIPTION
Changed to give precedence to direct associations, rather than the looser `related_*` associations, when building the tree or graph

- Fix for #1540 