### PR TITLE
Fix typo in page title when responding to programme activation requests

### DIFF
--- a/app/views/programmes/activation_review.html.erb
+++ b/app/views/programmes/activation_review.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => "general/item_title",:locals => {:item=>@programme, :title_prefix=>"Acitivation required for: "} %>
+<%= render :partial => "general/item_title",:locals => {:item=>@programme, :title_prefix=>"Activation required for: "} %>
 
 <p>
   A <%= t('programme') %> has been created by a user, and requires activation. The <%= t('programme') %> created is <%= link_to @programme.title, @programme %>.


### PR DESCRIPTION
Fix to #1583 