### PR TITLE
Add setting for LifeMonitor UI URL

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -163,6 +163,7 @@ class AdminController < ApplicationController
     Seek::Config.life_monitor_url = params[:life_monitor_url]&.strip&.chomp('/')
     Seek::Config.life_monitor_client_id = params[:life_monitor_client_id]&.strip
     Seek::Config.life_monitor_client_secret = params[:life_monitor_client_secret]&.strip
+    Seek::Config.life_monitor_ui_url = params[:life_monitor_ui_url]&.strip&.chomp('/')
 
     Seek::Config.bio_tools_enabled = string_to_boolean(params[:bio_tools_enabled])
 

--- a/app/helpers/workflows_helper.rb
+++ b/app/helpers/workflows_helper.rb
@@ -49,6 +49,10 @@ module WorkflowsHelper
     content_tag(:span, t("maturity_level.#{level}"), class: "maturity-level label #{label_class}")
   end
 
+  def life_monitor_status_page_url(resource, base: Seek::Config.life_monitor_ui_url)
+    URI.join(base, "/workflow;uuid=#{resource.uuid}").to_s
+  end
+
   def test_status_badge(resource)
     status = resource.test_status
     case status
@@ -65,9 +69,8 @@ module WorkflowsHelper
       label_class = 'label-default'
       label = t('test_status.not_available')
     end
-    url = LifeMonitor::Rest::Client.status_page_url(resource)
-    link_to(url, class: 'lifemonitor-status btn btn-default', target: '_blank', rel: 'noopener',
-            'data-tooltip' => 'Click to view in LifeMonitor') do
+    link_to(life_monitor_status_page_url(resource), class: 'lifemonitor-status btn btn-default', target: '_blank',
+            rel: 'noopener', 'data-tooltip' => 'Click to view in LifeMonitor') do
       image('life_monitor_icon', class: 'icon lifemonitor-logo') +
         'Tests ' +
         content_tag(:span, label, class: "test-status label #{label_class}")

--- a/app/views/admin/features_enabled.html.erb
+++ b/app/views/admin/features_enabled.html.erb
@@ -193,11 +193,13 @@
     <div class="row">
       <div class="col-sm-7">
         <%= admin_text_setting(:life_monitor_url, Seek::Config.life_monitor_url,
-                               'LifeMonitor URL', "The URL of a LifeMonitor instance.") %>
+                               'LifeMonitor API URL', "The API URL of a LifeMonitor instance.") %>
         <%= admin_text_setting(:life_monitor_client_id, Seek::Config.life_monitor_client_id,
                                'LifeMonitor OAuth client ID', 'The ID for this application to authenticate users through the LifeMonitor OAuth provider.') %>
         <%= admin_text_setting(:life_monitor_client_secret, Seek::Config.life_monitor_client_secret,
                                'LifeMonitor OAuth client secret', 'The secret token for this application to authenticate users through the LifeMonitor OAuth provider.') %>
+        <%= admin_text_setting(:life_monitor_ui_url, Seek::Config.life_monitor_ui_url,
+                               'LifeMonitor UI URL', "The UI (app) URL of a LifeMonitor instance.") %>
       </div>
     </div>
   </div>

--- a/config/initializers/seek_configuration.rb
+++ b/config/initializers/seek_configuration.rb
@@ -257,6 +257,7 @@ def load_seek_config_defaults!
 
   Seek::Config.default :life_monitor_enabled, false
   Seek::Config.default :life_monitor_url, 'https://api.lifemonitor.eu/'
+  Seek::Config.default :life_monitor_ui_url, 'https://app.lifemonitor.eu/'
   Seek::Config.default :git_support_enabled, false
   Seek::Config.default :bio_tools_enabled, false
 

--- a/lib/life_monitor/rest/client.rb
+++ b/lib/life_monitor/rest/client.rb
@@ -55,10 +55,6 @@ module LifeMonitor
         perform("/registries/current/workflows?status=true&versions=true", :get, content_type: :json)
       end
 
-      def self.status_page_url(workflow, base: Seek::Config.life_monitor_url)
-        URI.join(base, "/workflow;uuid=#{workflow.uuid}").to_s
-      end
-
       private
 
       def perform(path, method, opts = {})

--- a/lib/seek/config_setting_attributes.yml
+++ b/lib/seek/config_setting_attributes.yml
@@ -238,6 +238,7 @@ life_monitor_enabled:
 life_monitor_url:
 life_monitor_client_id:
 life_monitor_client_secret:
+life_monitor_ui_url:
 galaxy_instance_name:
 galaxy_instance_trs_import_url:
 # Controlled vocabs

--- a/test/functional/collections_controller_test.rb
+++ b/test/functional/collections_controller_test.rb
@@ -65,13 +65,14 @@ class CollectionsControllerTest < ActionController::TestCase
 
   test 'should show all item types without error' do
     all_types_collection = FactoryBot.create(:collection_with_all_types)
-    items = all_types_collection.collection_items
+    items = all_types_collection.items
+    assert items.any?
 
     get :show, params: { id: all_types_collection }
 
     assert_response :success
     items.each do |item|
-      assert_select '#items-table tr a[href=?]', polymorphic_path(item.asset), "#{item.asset_type} collection item missing"
+      assert_select 'ul.feed li a[href=?]', Seek::Util.routes.polymorphic_path(item.asset)
     end
   end
 

--- a/test/functional/workflows_controller_test.rb
+++ b/test/functional/workflows_controller_test.rb
@@ -1764,6 +1764,6 @@ class WorkflowsControllerTest < ActionController::TestCase
 
     get :show, params: { id: wf }
 
-    assert_select 'a.lifemonitor-status[href=?]', "https://localhost:8443/workflow;uuid=#{wf.uuid}"
+    assert_select 'a.lifemonitor-status[href=?]', "https://app.lifemonitor.eu/workflow;uuid=#{wf.uuid}"
   end
 end


### PR DESCRIPTION
In production they use separate URLs/domains for the API and UI.

The link to the test results page needs to go to the web UI.

Also fixes an unrelated test that wasn't actually working.