### PR TITLE
Prevents snapshots if there are no creators.

### DIFF
--- a/app/controllers/snapshots_controller.rb
+++ b/app/controllers/snapshots_controller.rb
@@ -15,8 +15,14 @@ class SnapshotsController < ApplicationController
 
   def create
     @snapshot = @resource.create_snapshot
-    flash[:notice] = "Snapshot created"
-    redirect_to polymorphic_path([@resource, @snapshot])
+    if @snapshot.is_a?(Snapshot)
+      flash[:notice] = "Snapshot created"
+      redirect_to polymorphic_path([@resource, @snapshot])
+    elsif @snapshot.nil?
+      flash[:error] = "The #{self.class.name} you are trying to snapshot has no creators.
+                        Please add creators and then try again."
+      redirect_to polymorphic_path(@resource)
+    end
   end
 
   def show

--- a/app/controllers/snapshots_controller.rb
+++ b/app/controllers/snapshots_controller.rb
@@ -15,12 +15,11 @@ class SnapshotsController < ApplicationController
 
   def create
     @snapshot = @resource.create_snapshot
-    if @snapshot.is_a?(Snapshot)
+    if @snapshot
       flash[:notice] = "Snapshot created"
       redirect_to polymorphic_path([@resource, @snapshot])
-    elsif @snapshot.nil?
-      flash[:error] = "The #{self.class.name} you are trying to snapshot has no creators.
-                        Please add creators and then try again."
+    else
+      flash[:error] = @resource.errors.full_messages.join(', ')
       redirect_to polymorphic_path(@resource)
     end
   end

--- a/lib/seek/research_objects/acts_as_snapshottable.rb
+++ b/lib/seek/research_objects/acts_as_snapshottable.rb
@@ -29,7 +29,7 @@ module Seek #:nodoc:
       module InstanceMethods
         def create_snapshot
           if self.creators.empty?
-            errors.add(:base, "At least one creator is required. To add, go to Actions -> Manage #{self.class.name}.")
+            errors.add(:base, "At least one creator is required. To add, go to Actions -> Manage #{self.class.model_name.human}.")
             return nil
           end
           Rails.logger.debug("Creating snapshot for: #{self.class.name} #{id}")

--- a/lib/seek/research_objects/acts_as_snapshottable.rb
+++ b/lib/seek/research_objects/acts_as_snapshottable.rb
@@ -29,7 +29,7 @@ module Seek #:nodoc:
       module InstanceMethods
         def create_snapshot
           if self.creators.empty?
-            Rails.logger.debug("No creators for #{self.class.name} #{id}, cancelling snapshot.")
+            errors.add(:base, "At least one creator is required. To add, go to Actions -> Manage #{self.class.name}.")
             return nil
           end
           Rails.logger.debug("Creating snapshot for: #{self.class.name} #{id}")

--- a/lib/seek/research_objects/acts_as_snapshottable.rb
+++ b/lib/seek/research_objects/acts_as_snapshottable.rb
@@ -28,6 +28,10 @@ module Seek #:nodoc:
 
       module InstanceMethods
         def create_snapshot
+          if self.creators.empty?
+            Rails.logger.debug("No creators for #{self.class.name} #{id}, cancelling snapshot.")
+            return nil
+          end
           Rails.logger.debug("Creating snapshot for: #{self.class.name} #{id}")
           snapshot = snapshots.create
           filename = "#{self.class.name.underscore}-#{id}-#{snapshot.snapshot_number}.ro.zip"

--- a/test/functional/admin_controller_test.rb
+++ b/test/functional/admin_controller_test.rb
@@ -345,7 +345,7 @@ class AdminControllerTest < ActionController::TestCase
 
   test 'snapshot and doi stats' do
     investigation = FactoryBot.create(:investigation, title: 'i1', description: 'not blank',
-                            policy: FactoryBot.create(:downloadable_public_policy))
+                            policy: FactoryBot.create(:downloadable_public_policy), creators: [FactoryBot.create(:person)])
     snapshot = investigation.create_snapshot
     snapshot.update_column(:doi, '10.5072/testytest')
     AssetDoiLog.create(asset_type: 'investigation',

--- a/test/functional/homes_controller_test.rb
+++ b/test/functional/homes_controller_test.rb
@@ -259,8 +259,10 @@ class HomesControllerTest < ActionController::TestCase
 
   test 'recently added and download should include snapshot' do
     person = FactoryBot.create(:person)
-    snapshot1 = FactoryBot.create(:investigation, policy: FactoryBot.create(:publicly_viewable_policy), title: 'inv with snap', contributor: person).create_snapshot
-    snapshot2 = FactoryBot.create(:assay, policy: FactoryBot.create(:publicly_viewable_policy), title: 'assay with snap', contributor: person).create_snapshot
+    snapshot1 = FactoryBot.create(:investigation, policy: FactoryBot.create(:publicly_viewable_policy),
+                                  title: 'inv with snap', contributor: person, creators: [person]).create_snapshot
+    snapshot2 = FactoryBot.create(:assay, policy: FactoryBot.create(:publicly_viewable_policy),
+                                  title: 'assay with snap', contributor: person, creators: [person]).create_snapshot
     assert_difference 'ActivityLog.count', 2 do
       FactoryBot.create(:activity_log, action: 'create', activity_loggable: snapshot1, created_at: 1.day.ago, culprit: person.user)
       FactoryBot.create(:activity_log, action: 'download', activity_loggable: snapshot2, created_at: 1.day.ago, culprit: person.user)
@@ -374,7 +376,8 @@ class HomesControllerTest < ActionController::TestCase
 
     df = FactoryBot.create :data_file, title: 'A new data file', contributor: person, policy: FactoryBot.create(:public_policy)
     sop = FactoryBot.create :sop, title: 'A new sop', contributor: person, policy: FactoryBot.create(:public_policy)
-    assay = FactoryBot.create :assay, title: 'A new assay', contributor: person, policy: FactoryBot.create(:public_policy)
+    assay = FactoryBot.create :assay, title: 'A new assay', contributor: person,
+                              policy: FactoryBot.create(:public_policy), creators: [person]
     snapshot = assay.create_snapshot
 
     FactoryBot.create :activity_log, activity_loggable: df, controller_name: 'data_files', culprit: person.user

--- a/test/functional/investigations_controller_test.rb
+++ b/test/functional/investigations_controller_test.rb
@@ -453,7 +453,7 @@ class InvestigationsControllerTest < ActionController::TestCase
   test 'shows how to get a citation for a snapshotted investigation' do
     study = FactoryBot.create(:study)
     investigation = FactoryBot.create(:investigation, policy: FactoryBot.create(:publicly_viewable_policy),
-                                            studies: [study], contributor:study.contributor)
+                                            studies: [study], contributor:study.contributor, creators: [study.contributor])
 
     login_as(investigation.contributor)
     investigation.create_snapshot
@@ -473,7 +473,8 @@ class InvestigationsControllerTest < ActionController::TestCase
     another_person = FactoryBot.create(:person,project:person.projects.first)
     study = FactoryBot.create(:study,contributor:another_person)
     investigation = FactoryBot.create(:investigation, projects:another_person.projects, contributor:another_person,
-                                            policy: FactoryBot.create(:publicly_viewable_policy), studies: [study])
+                                            policy: FactoryBot.create(:publicly_viewable_policy), studies: [study],
+                                      creators: [another_person])
 
     login_as(person)
     investigation.create_snapshot

--- a/test/functional/snapshots_controller_test.rb
+++ b/test/functional/snapshots_controller_test.rb
@@ -150,7 +150,7 @@ class SnapshotsControllerTest < ActionController::TestCase
         post :create, params: { "#{type}_id": snap.id }
       end
       assert_redirected_to Seek::Util.routes.polymorphic_path(snap)
-      assert flash[:error].include?('no creator')
+      assert flash[:error].include?('creator is required')
     end
   end
 

--- a/test/functional/snapshots_controller_test.rb
+++ b/test/functional/snapshots_controller_test.rb
@@ -17,7 +17,8 @@ class SnapshotsControllerTest < ActionController::TestCase
 
   test 'can get snapshot preview page' do
     user = FactoryBot.create(:user)
-    investigation = FactoryBot.create(:investigation, policy: FactoryBot.create(:publicly_viewable_policy), contributor: user.person)
+    investigation = FactoryBot.create(:investigation, policy: FactoryBot.create(:publicly_viewable_policy),
+                                      contributor: user.person, creators: [user.person])
     login_as(user)
 
     get :new, params: { investigation_id: investigation }
@@ -30,7 +31,8 @@ class SnapshotsControllerTest < ActionController::TestCase
 
   test "can't get snapshot preview if no manage permissions" do
     user = FactoryBot.create(:user)
-    investigation = FactoryBot.create(:investigation, policy: FactoryBot.create(:publicly_viewable_policy))
+    investigation = FactoryBot.create(:investigation, policy: FactoryBot.create(:publicly_viewable_policy),
+                                      creators: [FactoryBot.create(:user).person])
     login_as(user)
 
     get :new, params: { investigation_id: investigation }
@@ -42,7 +44,8 @@ class SnapshotsControllerTest < ActionController::TestCase
 
   test "can't get snapshot preview if not publicly accessible" do
     user = FactoryBot.create(:user)
-    investigation = FactoryBot.create(:investigation, policy: FactoryBot.create(:private_policy), contributor: user.person)
+    investigation = FactoryBot.create(:investigation, policy: FactoryBot.create(:private_policy),
+                                      contributor: user.person, creators: [user.person])
     login_as(user)
 
     get :new, params: { investigation_id: investigation }
@@ -54,7 +57,8 @@ class SnapshotsControllerTest < ActionController::TestCase
 
   test 'can create investigation snapshot' do
     user = FactoryBot.create(:user)
-    investigation = FactoryBot.create(:investigation, policy: FactoryBot.create(:publicly_viewable_policy), contributor: user.person)
+    investigation = FactoryBot.create(:investigation, policy: FactoryBot.create(:publicly_viewable_policy),
+                                      contributor: user.person, creators: [user.person])
     login_as(user)
 
     assert_difference('Snapshot.count') do
@@ -67,7 +71,8 @@ class SnapshotsControllerTest < ActionController::TestCase
 
   test 'can create study snapshot' do
     user = FactoryBot.create(:user)
-    study = FactoryBot.create(:study, policy: FactoryBot.create(:publicly_viewable_policy), contributor: user.person)
+    study = FactoryBot.create(:study, policy: FactoryBot.create(:publicly_viewable_policy),
+                              contributor: user.person, creators: [user.person])
     login_as(user)
 
     assert_difference('Snapshot.count') do
@@ -80,7 +85,8 @@ class SnapshotsControllerTest < ActionController::TestCase
 
   test 'can create assay snapshot' do
     user = FactoryBot.create(:user)
-    assay = FactoryBot.create(:assay, policy: FactoryBot.create(:publicly_viewable_policy), contributor: user.person)
+    assay = FactoryBot.create(:assay, policy: FactoryBot.create(:publicly_viewable_policy),
+                              contributor: user.person, creators: [user.person])
     login_as(user)
 
     assert_difference('Snapshot.count') do
@@ -93,7 +99,8 @@ class SnapshotsControllerTest < ActionController::TestCase
 
   test "can't create snapshot if no manage permissions" do
     user = FactoryBot.create(:user)
-    investigation = FactoryBot.create(:investigation, policy: FactoryBot.create(:publicly_viewable_policy))
+    investigation = FactoryBot.create(:investigation, policy: FactoryBot.create(:publicly_viewable_policy),
+                                      creators: [FactoryBot.create(:user).person])
     login_as(user)
 
     assert_no_difference('Snapshot.count') do
@@ -107,7 +114,8 @@ class SnapshotsControllerTest < ActionController::TestCase
 
   test "can't create snapshot if not publicly accessible" do
     user = FactoryBot.create(:user)
-    investigation = FactoryBot.create(:investigation, policy: FactoryBot.create(:private_policy), contributor: user.person)
+    investigation = FactoryBot.create(:investigation, policy: FactoryBot.create(:private_policy),
+                                      contributor: user.person, creators: [user.person])
     login_as(user)
 
     assert_no_difference('Snapshot.count') do
@@ -117,6 +125,33 @@ class SnapshotsControllerTest < ActionController::TestCase
     assert investigation.can_manage?(user)
     assert_redirected_to investigation_path(investigation)
     assert flash[:error].include?('accessible')
+  end
+
+  test "can't create snapshot if there are no creators" do
+    user = FactoryBot.create(:user)
+    investigation = FactoryBot.create(:investigation, policy: FactoryBot.create(:publicly_viewable_policy),
+                                      contributor: user.person, creators: [])
+    study = FactoryBot.create(:study, investigation: investigation, policy: FactoryBot.create(:publicly_viewable_policy),
+                              contributor: user.person, creators: [])
+    assay = FactoryBot.create(:assay, study: study, policy: FactoryBot.create(:publicly_viewable_policy),
+                              contributor: user.person, creators: [])
+
+    login_as(user)
+    [study, investigation, assay].each do |snap|
+      assert snap.can_manage?(user)
+      assert snap.creators.empty?
+      type = snap.class.name.underscore
+      request.path = Seek::Util.routes.polymorphic_path(snap)+"/snapshots"
+      # Get preview
+      get :new, params: { "#{type}_id": snap.id }
+      assert_response :success
+      # Can't create snapshot
+      assert_no_difference('Snapshot.count') do
+        post :create, params: { "#{type}_id": snap.id }
+      end
+      assert_redirected_to Seek::Util.routes.polymorphic_path(snap)
+      assert flash[:error].include?('no creator')
+    end
   end
 
   test 'can get snapshot show page' do
@@ -543,14 +578,16 @@ class SnapshotsControllerTest < ActionController::TestCase
 
   def create_investigation_snapshot
     @user = FactoryBot.create(:user)
-    @investigation = FactoryBot.create(:investigation, description: 'not blank', policy: FactoryBot.create(:publicly_viewable_policy), contributor: @user.person)
+    @investigation = FactoryBot.create(:investigation, description: 'not blank', policy: FactoryBot.create(:publicly_viewable_policy),
+                                       contributor: @user.person, creators: [@user.person])
     @snapshot = @investigation.create_snapshot
   end
 
   def create_study_snapshot
     @user = FactoryBot.create(:user)
     @investigation = FactoryBot.create(:investigation, description: 'not blank', policy: FactoryBot.create(:publicly_viewable_policy), contributor: @user.person)
-    @study = FactoryBot.create(:study, description: 'not blank', policy: FactoryBot.create(:publicly_viewable_policy), contributor: @user.person)
+    @study = FactoryBot.create(:study, description: 'not blank', policy: FactoryBot.create(:publicly_viewable_policy),
+                               contributor: @user.person, creators: [@user.person])
     @snapshot = @study.create_snapshot
   end
 
@@ -558,7 +595,8 @@ class SnapshotsControllerTest < ActionController::TestCase
     @user = FactoryBot.create(:user)
     @investigation = FactoryBot.create(:investigation, description: 'not blank', policy: FactoryBot.create(:publicly_viewable_policy), contributor: @user.person)
     @study = FactoryBot.create(:study, description: 'not blank', policy: FactoryBot.create(:publicly_viewable_policy), contributor: @user.person)
-    @assay = FactoryBot.create(:assay, description: 'not blank', policy: FactoryBot.create(:publicly_viewable_policy), contributor: @user.person)
+    @assay = FactoryBot.create(:assay, description: 'not blank', policy: FactoryBot.create(:publicly_viewable_policy),
+                               contributor: @user.person, creators: [@user.person])
     @snapshot = @assay.create_snapshot
   end
 end

--- a/test/functional/snapshots_controller_test.rb
+++ b/test/functional/snapshots_controller_test.rb
@@ -137,11 +137,12 @@ class SnapshotsControllerTest < ActionController::TestCase
                               contributor: user.person, creators: [])
 
     login_as(user)
-    [study, investigation, assay].each do |snap|
+    [investigation, study, assay].each do |snap|
       assert snap.can_manage?(user)
       assert snap.creators.empty?
       type = snap.class.name.underscore
-      request.path = Seek::Util.routes.polymorphic_path(snap)+"/snapshots"
+      # Updating the request.path is needed so that @resource is correctly set, and the snapshots is created for the correct item in the loop
+      request.path = Seek::Util.routes.polymorphic_path([snap, :snapshots])
       # Get preview
       get :new, params: { "#{type}_id": snap.id }
       assert_response :success

--- a/test/unit/activity_log_test.rb
+++ b/test/unit/activity_log_test.rb
@@ -82,7 +82,8 @@ class ActivityLogTest < ActiveSupport::TestCase
 
       refute public_log.reload.can_render_link?
 
-      assay = FactoryBot.create(:assay, policy: FactoryBot.create(:publicly_viewable_policy))
+      assay = FactoryBot.create(:assay, policy: FactoryBot.create(:publicly_viewable_policy),
+                                        creators: [FactoryBot.create(:person)])
       snapshot = assay.create_snapshot
       snapshot_log = FactoryBot.create(:activity_log, activity_loggable: snapshot, action: 'create', created_at: 2.hour.ago)
 

--- a/test/unit/datacite_metadata_test.rb
+++ b/test/unit/datacite_metadata_test.rb
@@ -8,11 +8,12 @@ class DataciteMetadataTest < ActiveSupport::TestCase
     User.current_user = contributor.user
 
     @investigation = FactoryBot.create(:investigation, title: 'i1', description: 'not blank',
-                             policy: FactoryBot.create(:downloadable_public_policy), contributor:contributor)
+                                                       policy: FactoryBot.create(:downloadable_public_policy),
+                                                       contributor: contributor, creators: [contributor])
     @study = FactoryBot.create(:study, title: 's1', investigation: @investigation, contributor: @investigation.contributor,
-                     policy: FactoryBot.create(:downloadable_public_policy))
+                     policy: FactoryBot.create(:downloadable_public_policy), creators: [contributor])
     @assay = FactoryBot.create(:assay, title: 'a1', study: @study, contributor: @investigation.contributor,
-                     policy: FactoryBot.create(:downloadable_public_policy))
+                     policy: FactoryBot.create(:downloadable_public_policy), creators: [contributor])
     @assay2 = FactoryBot.create(:assay, title: 'a2', study: @study, contributor: @investigation.contributor,
                       policy: FactoryBot.create(:downloadable_public_policy))
     @data_file = FactoryBot.create(:data_file, title: 'df1', contributor: @investigation.contributor,

--- a/test/unit/helpers/homes_helper_test.rb
+++ b/test/unit/helpers/homes_helper_test.rb
@@ -60,8 +60,10 @@ class HomesHelperTest < ActionView::TestCase
 
   test 'should handle snapshots for download and recently added' do
     person = FactoryBot.create(:person)
-    snapshot1 = FactoryBot.create(:investigation, policy: FactoryBot.create(:publicly_viewable_policy), contributor: person).create_snapshot
-    snapshot2 = FactoryBot.create(:assay, policy: FactoryBot.create(:publicly_viewable_policy), contributor: person).create_snapshot
+    snapshot1 = FactoryBot.create(:investigation, policy: FactoryBot.create(:publicly_viewable_policy),
+                                                  contributor: person, creators: [person]).create_snapshot
+    snapshot2 = FactoryBot.create(:assay, policy: FactoryBot.create(:publicly_viewable_policy),
+                                          contributor: person, creators: [person]).create_snapshot
     FactoryBot.create(:activity_log, action: 'create', activity_loggable: snapshot1, created_at: 1.day.ago, culprit: person.user)
     FactoryBot.create(:activity_log, action: 'download', activity_loggable: snapshot2, created_at: 1.day.ago, culprit: person.user)
 

--- a/test/unit/investigation_test.rb
+++ b/test/unit/investigation_test.rb
@@ -144,7 +144,9 @@ class InvestigationTest < ActiveSupport::TestCase
   end
 
   test 'can create snapshot of investigation' do
-    investigation = FactoryBot.create(:investigation, policy: FactoryBot.create(:publicly_viewable_policy))
+    person = FactoryBot.create(:person)
+    investigation = FactoryBot.create(:investigation, policy: FactoryBot.create(:publicly_viewable_policy),
+                                      contributor: person, creators: [person])
     FactoryBot.create(:study, contributor: investigation.contributor)
     snapshot = nil
 

--- a/test/unit/jobs/regular_maintenace_job_test.rb
+++ b/test/unit/jobs/regular_maintenace_job_test.rb
@@ -15,7 +15,7 @@ class RegularMaintenaceJobTest < ActiveSupport::TestCase
     travel_to(9.hours.ago) do
       to_go = FactoryBot.create(:content_blob)
       keep1 = FactoryBot.create(:data_file).content_blob
-      keep2 = FactoryBot.create(:investigation).create_snapshot.content_blob
+      keep2 = FactoryBot.create(:investigation, creators: [FactoryBot.create(:person)]).create_snapshot.content_blob
       keep3 = FactoryBot.create(:strain_sample_type).content_blob
     end
 

--- a/test/unit/snapshot_test.rb
+++ b/test/unit/snapshot_test.rb
@@ -10,14 +10,14 @@ class SnapshotTest < ActiveSupport::TestCase
     contributor = FactoryBot.create(:person)
     User.current_user = contributor.user
 
-    @investigation = FactoryBot.create(:investigation, title: 'i1', description: 'not blank',
-                                             policy: FactoryBot.create(:downloadable_public_policy), contributor:contributor)
+    @investigation = FactoryBot.create(:investigation, title: 'i1', description: 'not blank', contributor: contributor,
+                                        policy: FactoryBot.create(:downloadable_public_policy), creators: [contributor])
     @study = FactoryBot.create(:study, title: 's1', investigation: @investigation, contributor: @investigation.contributor,
-                             policy: FactoryBot.create(:downloadable_public_policy))
+                                       policy: FactoryBot.create(:downloadable_public_policy), creators: [contributor])
     @assay = FactoryBot.create(:assay, title: 'a1', study: @study, contributor: @investigation.contributor,
-                             policy: FactoryBot.create(:downloadable_public_policy))
+                                       policy: FactoryBot.create(:downloadable_public_policy), creators: [contributor])
     @assay2 = FactoryBot.create(:assay, title: 'a2', study: @study, contributor: @investigation.contributor,
-                              policy: FactoryBot.create(:downloadable_public_policy))
+                                        policy: FactoryBot.create(:downloadable_public_policy), creators: [contributor])
     @data_file = FactoryBot.create(:data_file, title: 'df1', contributor: @investigation.contributor,
                                      content_blob: FactoryBot.create(:doc_content_blob, original_filename: 'word.doc'),
                                      policy: FactoryBot.create(:downloadable_public_policy))


### PR DESCRIPTION
This avoids issues with DOI generation.

Resolves #1390 