### PR TITLE
Fix project selector text

### DIFF
--- a/app/views/projects/_project_selector.html.erb
+++ b/app/views/projects/_project_selector.html.erb
@@ -30,7 +30,7 @@
   title = t('project').pluralize
   title += '<span class="required">*</span>'.html_safe unless allow_nil
 
-  object_type_text = resource.class.name.underscore.humanize
+  object_type_text = text_for_resource(resource)
 %>
 
 <%= folding_panel(title, false, id: "add_projects_form",


### PR DESCRIPTION
Now object type text used in project selector help text takes translations into account