### PR TITLE
Editable extracted samples

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -75,6 +75,11 @@ class SamplesController < ApplicationController
 
   def edit
     @sample = Sample.find(params[:id])
+    if !@sample.originating_data_file.nil? && (@sample.created_at == @sample.updated_at)
+      flash.now[:error] = '<strong>Warning:</strong> This sample was extracted from a datafile.
+                           If you edit the sample, it will no longer correspond to the original source data.<br/>
+                           Unless you cancel, a label will be added to the sample\'s source field to indicate it is no longer valid.'.html_safe
+    end
     respond_with(@sample)
   end
 

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -75,7 +75,7 @@ class SamplesController < ApplicationController
 
   def edit
     @sample = Sample.find(params[:id])
-    if !@sample.originating_data_file.nil? && (@sample.created_at == @sample.updated_at)
+    if !@sample.originating_data_file.nil? && @sample.edit_count.zero?
       flash.now[:error] = '<strong>Warning:</strong> This sample was extracted from a datafile.
                            If you edit the sample, it will no longer correspond to the original source data.<br/>
                            Unless you cancel, a label will be added to the sample\'s source field to indicate it is no longer valid.'.html_safe

--- a/app/models/data_file.rb
+++ b/app/models/data_file.rb
@@ -150,7 +150,7 @@ class DataFile < ApplicationRecord
       sample.project_ids = project_ids
       sample.contributor = contributor
       sample.originating_data_file = self
-      sample.policy = policy
+      sample.policy = policy.deep_copy
       sample.save if sample.valid? && confirm
 
       extracted << sample

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -89,10 +89,6 @@ class Sample < ApplicationRecord
     referenced_resources.select { |r| r.is_a?(Sample) }
   end
 
-  def state_allows_edit?(*args)
-    (id.nil? || originating_data_file.nil?) && super
-  end
-
   def extracted?
     !!originating_data_file
   end

--- a/app/views/samples/show.html.erb
+++ b/app/views/samples/show.html.erb
@@ -20,7 +20,7 @@
               <p>
                 <label>Source data:</label>
                 <%= link_to @sample.originating_data_file.title, @sample.originating_data_file %>
-                <% if @sample.created_at != @sample.updated_at %>
+                <% if @sample.edit_count.positive? %>
                   <span class="label label-danger"
                         data-tooltip='<%= tooltip("The sample has been edited since it was extracted from this datafile.") -%>'>
                     No longer valid

--- a/app/views/samples/show.html.erb
+++ b/app/views/samples/show.html.erb
@@ -20,6 +20,12 @@
               <p>
                 <label>Source data:</label>
                 <%= link_to @sample.originating_data_file.title, @sample.originating_data_file %>
+                <% if @sample.created_at != @sample.updated_at %>
+                  <span class="label label-danger"
+                        data-tooltip='<%= tooltip("The sample has been edited since it was extracted from this datafile.") -%>'>
+                    No longer valid
+                  </span>
+                <% end %>
               </p>
             <% end %>
             <%= render :partial => "attribute_values", :locals => { :sample => @sample } %>

--- a/lib/seek/stats/activity_counts.rb
+++ b/lib/seek/stats/activity_counts.rb
@@ -8,6 +8,10 @@ module Seek
         has_many :activity_logs, as: :activity_loggable
       end
 
+      def edit_count
+        count_actions('update')
+      end
+
       def download_count
         count_actions('download')
       end

--- a/lib/tasks/seek_upgrades.rake
+++ b/lib/tasks/seek_upgrades.rake
@@ -45,7 +45,7 @@ namespace :seek do
     end
   end
 
-  task(decouple_extracted_samples_policies) do
+  task(decouple_extracted_samples_policies: [:environment]) do
     puts '... creating independent policies for extracted samples...'
     decoupled = 0
     disable_authorization_checks do

--- a/lib/tasks/seek_upgrades.rake
+++ b/lib/tasks/seek_upgrades.rake
@@ -8,6 +8,7 @@ namespace :seek do
   # these are the tasks required for this version upgrade
   task upgrade_version_tasks: %i[
     environment
+    decouple_extracted_samples_policies
   ]
 
   # these are the tasks that are executes for each upgrade as standard, and rarely change
@@ -42,6 +43,22 @@ namespace :seek do
     ensure
       Seek::Config.solr_enabled = solr
     end
+  end
+
+  task(decouple_extracted_samples_policies) do
+    puts '... creating independent policies for extracted samples...'
+    decoupled = 0
+    disable_authorization_checks do
+      Sample.find_each do |sample|
+        # check if the sample was extracted from a datafile and their policies are linked
+        if sample.extracted? && sample.policy == sample.originating_data_file&.policy
+          sample.policy = sample.policy.deep_copy
+          sample.policy.save
+          decoupled += 1
+        end
+      end
+    end
+    puts " ... finished creating independent policies of #{decoupled.to_s} extracted samples"
   end
 
   private

--- a/test/unit/policy_test.rb
+++ b/test/unit/policy_test.rb
@@ -194,37 +194,39 @@ class PolicyTest < ActiveSupport::TestCase
     end
   end
 
-  test 'policy not destroyed if still referenced by assets' do
-    policy = FactoryBot.create(:public_policy)
-    sample_type = FactoryBot.create(:strain_sample_type)
-    data_file = FactoryBot.create(:strain_sample_data_file, policy: policy)
-    samples = data_file.extract_samples(sample_type, true).select(&:persisted?)
-    sample = samples.first
-
-    assert_equal sample.policy, data_file.policy
-
-    assert_no_difference('Policy.count') do
-      disable_authorization_checks { data_file.destroy }
-    end
-
-    assert_not_nil sample.reload.policy
-    assert_not_nil Policy.find_by_id(policy.id)
-  end
-
-  test 'policy destroyed when no longer referenced' do
-    policy = FactoryBot.create(:public_policy)
-    sample_type = FactoryBot.create(:strain_sample_type)
-    data_file = FactoryBot.create(:strain_sample_data_file, policy: policy)
-    samples = data_file.extract_samples(sample_type, true).select(&:persisted?)
-
-    disable_authorization_checks { data_file.destroy }
-
-    assert_difference('Policy.count', -1) do
-      disable_authorization_checks { samples.each(&:destroy) }
-    end
-
-    assert_nil Policy.find_by_id(policy.id)
-  end
+  # Samples no longer reference the policy, they make a copy of it.
+  #
+  # test 'policy not destroyed if still referenced by assets' do
+  #   policy = FactoryBot.create(:public_policy)
+  #   sample_type = FactoryBot.create(:strain_sample_type)
+  #   data_file = FactoryBot.create(:strain_sample_data_file, policy: policy)
+  #   samples = data_file.extract_samples(sample_type, true).select(&:persisted?)
+  #   sample = samples.first
+  #
+  #   assert_equal sample.policy, data_file.policy
+  #
+  #   assert_no_difference('Policy.count') do
+  #     disable_authorization_checks { data_file.destroy }
+  #   end
+  #
+  #   assert_not_nil sample.reload.policy
+  #   assert_not_nil Policy.find_by_id(policy.id)
+  # end
+  #
+  # test 'policy destroyed when no longer referenced' do
+  #   policy = FactoryBot.create(:public_policy)
+  #   sample_type = FactoryBot.create(:strain_sample_type)
+  #   data_file = FactoryBot.create(:strain_sample_data_file, policy: policy)
+  #   samples = data_file.extract_samples(sample_type, true).select(&:persisted?)
+  #
+  #   disable_authorization_checks { data_file.destroy }
+  #
+  #   assert_difference('Policy.count', -1) do
+  #     disable_authorization_checks { samples.each(&:destroy) }
+  #   end
+  #
+  #   assert_nil Policy.find_by_id(policy.id)
+  # end
 
   test 'public? false if sharing scope ALL::USERS' do
     policy = FactoryBot.create(:public_policy,sharing_scope:Policy::ALL_USERS, access_type:Policy::ACCESSIBLE)

--- a/test/unit/policy_test.rb
+++ b/test/unit/policy_test.rb
@@ -194,39 +194,33 @@ class PolicyTest < ActiveSupport::TestCase
     end
   end
 
-  # Samples no longer reference the policy, they make a copy of it.
-  #
-  # test 'policy not destroyed if still referenced by assets' do
-  #   policy = FactoryBot.create(:public_policy)
-  #   sample_type = FactoryBot.create(:strain_sample_type)
-  #   data_file = FactoryBot.create(:strain_sample_data_file, policy: policy)
-  #   samples = data_file.extract_samples(sample_type, true).select(&:persisted?)
-  #   sample = samples.first
-  #
-  #   assert_equal sample.policy, data_file.policy
-  #
-  #   assert_no_difference('Policy.count') do
-  #     disable_authorization_checks { data_file.destroy }
-  #   end
-  #
-  #   assert_not_nil sample.reload.policy
-  #   assert_not_nil Policy.find_by_id(policy.id)
-  # end
-  #
-  # test 'policy destroyed when no longer referenced' do
-  #   policy = FactoryBot.create(:public_policy)
-  #   sample_type = FactoryBot.create(:strain_sample_type)
-  #   data_file = FactoryBot.create(:strain_sample_data_file, policy: policy)
-  #   samples = data_file.extract_samples(sample_type, true).select(&:persisted?)
-  #
-  #   disable_authorization_checks { data_file.destroy }
-  #
-  #   assert_difference('Policy.count', -1) do
-  #     disable_authorization_checks { samples.each(&:destroy) }
-  #   end
-  #
-  #   assert_nil Policy.find_by_id(policy.id)
-  # end
+  test 'policy not destroyed if still referenced by assets' do
+    policy = FactoryBot.create(:public_policy)
+    sop1 = FactoryBot.create(:sop, policy: policy)
+    sop2 = FactoryBot.create(:sop, policy: policy)
+
+    assert_equal sop1.policy, sop2.policy
+
+    assert_no_difference('Policy.count') do
+      disable_authorization_checks { sop1.destroy }
+    end
+
+    assert_not_nil sop2.reload.policy
+    assert_not_nil Policy.find_by_id(policy.id)
+  end
+
+  test 'policy destroyed when no longer referenced' do
+    policy = FactoryBot.create(:public_policy)
+    sop1 = FactoryBot.create(:sop, policy: policy)
+    sop2 = FactoryBot.create(:sop, policy: policy)
+    sops = [sop1, sop2]
+
+    assert_difference('Policy.count', -1) do
+      disable_authorization_checks { sops.each(&:destroy) }
+    end
+
+    assert_nil Policy.find_by_id(policy.id)
+  end
 
   test 'public? false if sharing scope ALL::USERS' do
     policy = FactoryBot.create(:public_policy,sharing_scope:Policy::ALL_USERS, access_type:Policy::ACCESSIBLE)

--- a/test/unit/sample_test.rb
+++ b/test/unit/sample_test.rb
@@ -696,10 +696,10 @@ class SampleTest < ActiveSupport::TestCase
     end
   end
 
-  test 'samples extracted from a data file cannot be edited' do
+  test 'samples extracted from a data file can be edited' do
     sample = FactoryBot.create(:sample_from_file)
 
-    refute sample.state_allows_edit?
+    assert sample.state_allows_edit?
   end
 
   test 'samples not extracted from a data file can be edited' do

--- a/test/unit/sample_test.rb
+++ b/test/unit/sample_test.rb
@@ -723,7 +723,7 @@ class SampleTest < ActiveSupport::TestCase
 
     samples = data_file.extract_samples(sample_type, true)
     sample = samples.first
-    sample2 = samples.last
+    sample2 = samples.second
 
     # check samples *copied* policy and permissions
     assert_equal Policy::PRIVATE, sample.policy.access_type
@@ -733,6 +733,17 @@ class SampleTest < ActiveSupport::TestCase
     # check policies are independent
     refute_equal sample.policy, data_file.policy
     refute_equal sample.policy, sample2.policy
+
+    disable_authorization_checks do
+      sample.policy.access_type = Policy::ACCESSIBLE
+      sample.policy.save
+    end
+    data_file.reload
+    sample.reload
+    sample2.reload
+    refute data_file.can_view?(nil)
+    assert sample.can_view?(nil)
+    refute sample2.can_view?(nil)
   end
 
   test 'extracted samples inherit projects from data file' do


### PR DESCRIPTION
Makes extracted samples editable and decouples their policy from that of the source datafile.
Resolves #1356 and #1357 .