### PR TITLE
Bugfix: Make sure vanilla assays and studies can be deleted.

### DIFF
--- a/app/controllers/assays_controller.rb
+++ b/app/controllers/assays_controller.rb
@@ -114,6 +114,7 @@ class AssaysController < ApplicationController
 
   def delete_linked_sample_types
     return unless is_single_page_assay?
+    return if @assay.sample_type.nil?
 
     @assay.sample_type.destroy
   end

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -91,6 +91,7 @@ class StudiesController < ApplicationController
 
   def delete_linked_sample_types
     return unless is_single_page_study?
+    return if @study.sample_types.empty?
 
     # The study sample types must be destroyed in reversed order
     # otherwise the first sample type won't be removed becaused it is linked from the second


### PR DESCRIPTION
Small bugfix. Users were not able to delete vanilla assays and studies from the Single Page view because of the assumption that all studies and assays in single page have sample types.
This has been fixed now.