### PR TITLE
Datafile attribute relates samples and datafiles

### DIFF
--- a/app/models/data_file.rb
+++ b/app/models/data_file.rb
@@ -122,7 +122,8 @@ class DataFile < ApplicationRecord
   end
 
   def related_samples
-    extracted_samples
+    sample_ids = SampleResourceLink.where('resource_type': DataFile, 'resource_id': id).pluck('sample_id')
+    extracted_samples + Sample.where(id: sample_ids)
   end
 
   # Extracts samples using the given sample_type

--- a/app/models/data_file.rb
+++ b/app/models/data_file.rb
@@ -20,6 +20,8 @@ class DataFile < ApplicationRecord
 
   belongs_to :file_template
   has_many :extracted_samples, class_name: 'Sample', foreign_key: :originating_data_file_id
+  has_many :sample_resource_links, -> { where(resource_type: 'DataFile') }, class_name: 'SampleResourceLink', foreign_key: :resource_id
+  has_many :linked_samples, through: :sample_resource_links, source: :sample
 
   has_many :workflow_data_files, dependent: :destroy, autosave: true
   has_many :workflows, ->{ distinct }, through: :workflow_data_files
@@ -122,8 +124,7 @@ class DataFile < ApplicationRecord
   end
 
   def related_samples
-    sample_ids = SampleResourceLink.where('resource_type': 'DataFile', 'resource_id': id).pluck('sample_id')
-    extracted_samples + Sample.where(id: sample_ids)
+    extracted_samples + linked_samples
   end
 
   # Extracts samples using the given sample_type

--- a/app/models/data_file.rb
+++ b/app/models/data_file.rb
@@ -122,7 +122,7 @@ class DataFile < ApplicationRecord
   end
 
   def related_samples
-    sample_ids = SampleResourceLink.where('resource_type': DataFile, 'resource_id': id).pluck('sample_id')
+    sample_ids = SampleResourceLink.where('resource_type': 'DataFile', 'resource_id': id).pluck('sample_id')
     extracted_samples + Sample.where(id: sample_ids)
   end
 

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -60,8 +60,13 @@ class Sample < ApplicationRecord
     User.logged_in_and_member? && Seek::Config.samples_enabled
   end
 
-  def related_data_file
-    originating_data_file
+  def related_data_files
+    rdf = [originating_data_file].compact
+    data_file_ids = sample_type.sample_attributes.joins(:sample_attribute_type)
+                               .where('sample_attribute_types.base_type' => Seek::Samples::BaseType::SEEK_DATA_FILE)
+                               .map { |attr| get_attribute_value(attr)["id"] }
+    rdf += DataFile.where(id: data_file_ids)
+    rdf
   end
 
   def related_samples

--- a/lib/tasks/seek_upgrades.rake
+++ b/lib/tasks/seek_upgrades.rake
@@ -92,8 +92,10 @@ namespace :seek do
       df_attrs = SampleAttribute.joins(:sample_attribute_type).where('sample_attribute_types.base_type' => Seek::Samples::BaseType::SEEK_DATA_FILE).pluck(:id)
       samples = Sample.joins(sample_type: :sample_attributes).where('sample_attributes.id' => df_attrs)
       samples.each do |sample|
-        sample.send(:update_sample_resource_links)
-        samples_updated += 1
+        if sample.sample_resource_links.where(resource_type: 'DataFile').empty?
+          sample.send(:update_sample_resource_links)
+          samples_updated += 1
+        end
       end
     end
     puts " ... finished updating sample_resource_links of #{samples_updated.to_s} samples with data_file attributes"

--- a/test/unit/data_file_test.rb
+++ b/test/unit/data_file_test.rb
@@ -492,22 +492,22 @@ class DataFileTest < ActiveSupport::TestCase
 
   test 'related samples include extracted samples and samples linked in attributes' do
     project = FactoryBot.create(:project)
-    df1 = FactoryBot.create(:data_file)   # No samples
-    df2 = FactoryBot.create(:data_file)   # Extracted samples
-    df3 = FactoryBot.create(:data_file)   # Linked in sample's attributes only
-    df4 = FactoryBot.create(:data_file)   # Extracted samples and linked in sample's attributes
+    df_no_samples = FactoryBot.create(:data_file) # No samples
+    df_extracted = FactoryBot.create(:data_file)  # Extracted samples
+    df_attributes = FactoryBot.create(:data_file) # Linked in sample's attributes only
+    df_ext_attr = FactoryBot.create(:data_file)   # Extracted samples and linked in sample's attributes
     type = FactoryBot.create(:data_file_sample_type, project_ids: [project.id])
-    sample1 = Sample.new(sample_type: type, project_ids: [project.id], originating_data_file: df2)
-    sample1.update(data: { 'data file': df4.id })
+    sample1 = Sample.new(sample_type: type, project_ids: [project.id], originating_data_file: df_extracted)
+    sample1.update(data: { 'data file': df_ext_attr.id })
     sample1.save!
-    sample2 = Sample.new(sample_type: type, project_ids: [project.id], originating_data_file: df4)
-    sample2.update(data: { 'data file': df3.id })
+    sample2 = Sample.new(sample_type: type, project_ids: [project.id], originating_data_file: df_ext_attr)
+    sample2.update(data: { 'data file': df_attributes.id })
     sample2.save!
 
-    assert_equal [], df1.related_samples
-    assert_equal [sample1], df2.related_samples
-    assert_equal [sample2].sort_by(&:id), df3.related_samples
-    assert_equal [sample1, sample2].sort_by(&:id), df4.related_samples.sort_by(&:id)
+    assert_equal [], df_no_samples.related_samples
+    assert_equal [sample1], df_extracted.related_samples
+    assert_equal [sample2].sort_by(&:id), df_attributes.related_samples
+    assert_equal [sample1, sample2].sort_by(&:id), df_ext_attr.related_samples.sort_by(&:id)
   end
 
 end

--- a/test/unit/sample_test.rb
+++ b/test/unit/sample_test.rb
@@ -1354,31 +1354,32 @@ class SampleTest < ActiveSupport::TestCase
 
   test 'related datafiles include datafiles in attributes and originating datafile' do
     project = FactoryBot.create(:project)
-    type1 = FactoryBot.create(:simple_sample_type, project_ids: [project.id])
-    type2 = FactoryBot.create(:data_file_sample_type, project_ids: [project.id])
-    type2.sample_attributes << FactoryBot.build(:data_file_sample_attribute, title: 'data file 2', sample_type: type2)
+    simple_type = FactoryBot.create(:simple_sample_type, project_ids: [project.id])
+    type_with_df_attr = FactoryBot.create(:data_file_sample_type, project_ids: [project.id])
+    df_attr = FactoryBot.build(:data_file_sample_attribute, title: 'data file 2', sample_type: type_with_df_attr)
+    type_with_df_attr.sample_attributes << df_attr
     df1 = FactoryBot.create(:data_file)
     df2 = FactoryBot.create(:data_file)
     df3 = FactoryBot.create(:data_file)
     # Sample with no data files linked as attribute nor originating data file
-    sample1 = Sample.new(sample_type: type1, project_ids: [project.id])
+    sample_no_df = Sample.new(sample_type: simple_type, project_ids: [project.id])
     # Sample with originating data file only
-    sample2 = Sample.new(sample_type: type1, project_ids: [project.id], originating_data_file: df3)
+    sample_extracted = Sample.new(sample_type: simple_type, project_ids: [project.id], originating_data_file: df3)
     # Sample with data files linked as attributes
-    sample3 = Sample.new(sample_type: type2, project_ids: [project.id])
-    sample3.update(data: { 'data file': df1.id })
-    sample3.update(data: { 'data file 2': df2.id })
-    sample3.save!
+    sample_attributes = Sample.new(sample_type: type_with_df_attr, project_ids: [project.id])
+    sample_attributes.update(data: { 'data file': df1.id })
+    sample_attributes.update(data: { 'data file 2': df2.id })
+    sample_attributes.save!
     # Sample with data files linked as attributes and originating data file
-    sample4 = Sample.new(sample_type: type2, project_ids: [project.id], originating_data_file: df3)
-    sample4.update(data: { 'data file': df1.id })
-    sample4.update(data: { 'data file 2': df2.id })
-    sample4.save!
+    sample_ext_attr = Sample.new(sample_type: type_with_df_attr, project_ids: [project.id], originating_data_file: df3)
+    sample_ext_attr.update(data: { 'data file': df1.id })
+    sample_ext_attr.update(data: { 'data file 2': df2.id })
+    sample_ext_attr.save!
 
-    assert_equal [], sample1.related_data_files
-    assert_equal [df3], sample2.related_data_files
-    assert_equal [df1, df2].sort_by(&:id), sample3.related_data_files.sort_by(&:id)
-    assert_equal [df1, df2, df3].sort_by(&:id), sample4.related_data_files.sort_by(&:id)
+    assert_equal [], sample_no_df.related_data_files
+    assert_equal [df3], sample_extracted.related_data_files
+    assert_equal [df1, df2].sort_by(&:id), sample_attributes.related_data_files.sort_by(&:id)
+    assert_equal [df1, df2, df3].sort_by(&:id), sample_ext_attr.related_data_files.sort_by(&:id)
   end
 
 end


### PR DESCRIPTION
Samples with data file attributes are now "related" to the data files.
- Sample's related data files include the originating data file and the data files listed in its attributes.
- Data file's related samples include the samples extracted from it and the samples that list it in their attributes.
Resolves #1534 .