### PR TITLE
Short pid bug 

### DIFF
--- a/app/models/sample_attribute.rb
+++ b/app/models/sample_attribute.rb
@@ -8,6 +8,7 @@ class SampleAttribute < ApplicationRecord
 
   belongs_to :isa_tag
 
+  auto_strip_attributes :pid
   validates :sample_type, presence: true
   validates :pid, format: { with: URI::regexp, allow_blank: true, allow_nil: true, message: 'not a valid URI' }
   validate :validate_against_editing_constraints, if: -> { sample_type.present? }
@@ -51,6 +52,7 @@ class SampleAttribute < ApplicationRecord
 
   def short_pid
     return '' unless pid.present?
+    pid.strip!
     URI.parse(pid).fragment || pid.gsub(/.*\//,'') || pid
   end
 

--- a/app/models/sample_attribute.rb
+++ b/app/models/sample_attribute.rb
@@ -52,7 +52,6 @@ class SampleAttribute < ApplicationRecord
 
   def short_pid
     return '' unless pid.present?
-    pid.strip!
     URI.parse(pid).fragment || pid.gsub(/.*\//,'') || pid
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 2023_08_09_054421) do
 
-  create_table "activity_logs", id: :integer, force: :cascade do |t|
+  create_table "activity_logs", force: :cascade do |t|
     t.string "action"
     t.string "format"
     t.string "activity_loggable_type"
@@ -25,7 +25,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at"
     t.string "http_referer"
     t.text "user_agent"
-    t.text "data", size: :medium
+    t.text "data"
     t.string "controller_name"
     t.index ["action"], name: "act_logs_action_index"
     t.index ["activity_loggable_type", "activity_loggable_id"], name: "act_logs_act_loggable_index"
@@ -34,19 +34,19 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["referenced_type", "referenced_id"], name: "act_logs_referenced_index"
   end
 
-  create_table "admin_defined_role_programmes", id: :integer, force: :cascade do |t|
+  create_table "admin_defined_role_programmes", force: :cascade do |t|
     t.integer "programme_id"
     t.integer "person_id"
     t.integer "role_mask"
   end
 
-  create_table "admin_defined_role_projects", id: :integer, force: :cascade do |t|
+  create_table "admin_defined_role_projects", force: :cascade do |t|
     t.integer "project_id"
     t.integer "role_mask"
     t.integer "person_id"
   end
 
-  create_table "annotation_attributes", id: :integer, force: :cascade do |t|
+  create_table "annotation_attributes", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -54,7 +54,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["name"], name: "index_annotation_attributes_on_name"
   end
 
-  create_table "annotation_value_seeds", id: :integer, force: :cascade do |t|
+  create_table "annotation_value_seeds", force: :cascade do |t|
     t.integer "attribute_id", null: false
     t.string "old_value"
     t.datetime "created_at"
@@ -64,7 +64,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["attribute_id"], name: "index_annotation_value_seeds_on_attribute_id"
   end
 
-  create_table "annotation_versions", id: :integer, force: :cascade do |t|
+  create_table "annotation_versions", force: :cascade do |t|
     t.integer "annotation_id", null: false
     t.integer "version", null: false
     t.integer "version_creator_id"
@@ -81,7 +81,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["annotation_id"], name: "index_annotation_versions_on_annotation_id"
   end
 
-  create_table "annotations", id: :integer, force: :cascade do |t|
+  create_table "annotations", force: :cascade do |t|
     t.string "source_type", null: false
     t.integer "source_id", null: false
     t.string "annotatable_type", limit: 50, null: false
@@ -116,7 +116,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "assay_assets", id: :integer, force: :cascade do |t|
+  create_table "assay_assets", force: :cascade do |t|
     t.integer "assay_id"
     t.integer "asset_id"
     t.integer "version"
@@ -141,7 +141,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["user_id", "can_view"], name: "index_assay_auth_lookup_on_user_id_and_can_view"
   end
 
-  create_table "assay_classes", id: :integer, force: :cascade do |t|
+  create_table "assay_classes", force: :cascade do |t|
     t.string "title"
     t.text "description"
     t.datetime "created_at"
@@ -149,7 +149,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.string "key", limit: 10
   end
 
-  create_table "assay_human_diseases", id: :integer, force: :cascade do |t|
+  create_table "assay_human_diseases", force: :cascade do |t|
     t.integer "assay_id"
     t.integer "human_disease_id"
     t.datetime "created_at"
@@ -158,7 +158,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["human_disease_id"], name: "index_assay_diseases_on_disease_id"
   end
 
-  create_table "assay_organisms", id: :integer, force: :cascade do |t|
+  create_table "assay_organisms", force: :cascade do |t|
     t.integer "assay_id"
     t.integer "organism_id"
     t.integer "culture_growth_type_id"
@@ -170,7 +170,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["organism_id"], name: "index_assay_organisms_on_organism_id"
   end
 
-  create_table "assays", id: :integer, force: :cascade do |t|
+  create_table "assays", force: :cascade do |t|
     t.text "title"
     t.text "description"
     t.datetime "created_at"
@@ -192,7 +192,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["sample_type_id"], name: "index_assays_on_sample_type_id"
   end
 
-  create_table "asset_doi_logs", id: :integer, force: :cascade do |t|
+  create_table "asset_doi_logs", force: :cascade do |t|
     t.string "asset_type"
     t.integer "asset_id"
     t.integer "asset_version"
@@ -215,7 +215,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["asset_id", "asset_type"], name: "index_asset_links_on_asset_id_and_asset_type"
   end
 
-  create_table "assets", id: :integer, force: :cascade do |t|
+  create_table "assets", force: :cascade do |t|
     t.integer "project_id"
     t.string "resource_type"
     t.integer "resource_id"
@@ -224,7 +224,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at"
   end
 
-  create_table "assets_creators", id: :integer, force: :cascade do |t|
+  create_table "assets_creators", force: :cascade do |t|
     t.integer "asset_id"
     t.integer "creator_id"
     t.string "asset_type"
@@ -238,7 +238,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["asset_id", "asset_type"], name: "index_assets_creators_on_asset_id_and_asset_type"
   end
 
-  create_table "auth_lookup_update_queues", id: :integer, force: :cascade do |t|
+  create_table "auth_lookup_update_queues", force: :cascade do |t|
     t.integer "item_id"
     t.string "item_type"
     t.datetime "created_at"
@@ -247,7 +247,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["item_id", "item_type"], name: "index_auth_lookup_update_queues_on_item_id_and_item_type"
   end
 
-  create_table "avatars", id: :integer, force: :cascade do |t|
+  create_table "avatars", force: :cascade do |t|
     t.string "owner_type"
     t.integer "owner_id"
     t.string "original_filename"
@@ -266,7 +266,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["resource_type", "resource_id"], name: "index_bio_tools_links_on_resource"
   end
 
-  create_table "bioportal_concepts", id: :integer, force: :cascade do |t|
+  create_table "bioportal_concepts", force: :cascade do |t|
     t.string "ontology_id"
     t.string "concept_uri"
     t.text "cached_concept_yaml"
@@ -324,13 +324,13 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["project_id"], name: "index_collections_projects_on_project_id"
   end
 
-  create_table "compounds", id: :integer, force: :cascade do |t|
+  create_table "compounds", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "content_blobs", id: :integer, force: :cascade do |t|
+  create_table "content_blobs", force: :cascade do |t|
     t.string "md5sum"
     t.text "url"
     t.string "uuid"
@@ -348,13 +348,13 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["asset_id", "asset_type"], name: "index_content_blobs_on_asset_id_and_asset_type"
   end
 
-  create_table "culture_growth_types", id: :integer, force: :cascade do |t|
+  create_table "culture_growth_types", force: :cascade do |t|
     t.string "title"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "cultures", id: :integer, force: :cascade do |t|
+  create_table "cultures", force: :cascade do |t|
     t.integer "organism_id"
     t.integer "sop_id"
     t.datetime "date_at_sampling"
@@ -407,7 +407,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["user_id", "can_view"], name: "index_data_file_auth_lookup_on_user_id_and_can_view"
   end
 
-  create_table "data_file_versions", id: :integer, force: :cascade do |t|
+  create_table "data_file_versions", force: :cascade do |t|
     t.integer "data_file_id"
     t.integer "version"
     t.text "revision_comments"
@@ -435,7 +435,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.integer "version_id"
   end
 
-  create_table "data_files", id: :integer, force: :cascade do |t|
+  create_table "data_files", force: :cascade do |t|
     t.integer "contributor_id"
     t.string "title"
     t.text "description"
@@ -467,11 +467,11 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["project_id"], name: "index_data_files_projects_on_project_id"
   end
 
-  create_table "db_files", id: :integer, force: :cascade do |t|
+  create_table "db_files", force: :cascade do |t|
     t.binary "data"
   end
 
-  create_table "delayed_jobs", id: :integer, force: :cascade do |t|
+  create_table "delayed_jobs", force: :cascade do |t|
     t.integer "priority", default: 0
     t.integer "attempts", default: 0
     t.text "handler"
@@ -486,7 +486,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
-  create_table "disciplines", id: :integer, force: :cascade do |t|
+  create_table "disciplines", force: :cascade do |t|
     t.string "title"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -510,7 +510,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["user_id", "can_view"], name: "index_document_auth_lookup_on_user_id_and_can_view"
   end
 
-  create_table "document_versions", id: :integer, force: :cascade do |t|
+  create_table "document_versions", force: :cascade do |t|
     t.integer "document_id"
     t.integer "version"
     t.text "revision_comments"
@@ -531,14 +531,14 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["document_id"], name: "index_document_versions_on_document_id"
   end
 
-  create_table "document_versions_projects", id: :integer, force: :cascade do |t|
+  create_table "document_versions_projects", force: :cascade do |t|
     t.integer "version_id"
     t.integer "project_id"
     t.index ["project_id"], name: "index_document_versions_projects_on_project_id"
     t.index ["version_id", "project_id"], name: "index_document_versions_projects_on_version_id_and_project_id"
   end
 
-  create_table "documents", id: :integer, force: :cascade do |t|
+  create_table "documents", force: :cascade do |t|
     t.text "title"
     t.text "description"
     t.integer "contributor_id"
@@ -562,7 +562,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["event_id", "document_id"], name: "index_documents_events_on_event_id_and_document_id"
   end
 
-  create_table "documents_projects", id: :integer, force: :cascade do |t|
+  create_table "documents_projects", force: :cascade do |t|
     t.integer "document_id"
     t.integer "project_id"
     t.index ["document_id", "project_id"], name: "index_documents_projects_on_document_id_and_project_id"
@@ -588,7 +588,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["user_id", "can_view"], name: "index_event_auth_lookup_on_user_id_and_can_view"
   end
 
-  create_table "events", id: :integer, force: :cascade do |t|
+  create_table "events", force: :cascade do |t|
     t.datetime "start_date"
     t.datetime "end_date"
     t.text "address"
@@ -624,7 +624,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.integer "event_id"
   end
 
-  create_table "experimental_condition_links", id: :integer, force: :cascade do |t|
+  create_table "experimental_condition_links", force: :cascade do |t|
     t.string "substance_type"
     t.integer "substance_id"
     t.integer "experimental_condition_id"
@@ -632,7 +632,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at"
   end
 
-  create_table "experimental_conditions", id: :integer, force: :cascade do |t|
+  create_table "experimental_conditions", force: :cascade do |t|
     t.integer "measured_item_id"
     t.float "start_value"
     t.float "end_value"
@@ -644,7 +644,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["sop_id"], name: "index_experimental_conditions_on_sop_id"
   end
 
-  create_table "external_assets", id: :integer, force: :cascade do |t|
+  create_table "external_assets", force: :cascade do |t|
     t.string "external_service", null: false
     t.string "external_id", null: false
     t.string "external_mod_stamp"
@@ -666,7 +666,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["seek_service_type", "seek_service_id"], name: "index_external_assets_on_seek_service_type_and_seek_service_id"
   end
 
-  create_table "favourite_group_memberships", id: :integer, force: :cascade do |t|
+  create_table "favourite_group_memberships", force: :cascade do |t|
     t.integer "person_id"
     t.integer "favourite_group_id"
     t.integer "access_type", limit: 1
@@ -674,14 +674,14 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at"
   end
 
-  create_table "favourite_groups", id: :integer, force: :cascade do |t|
+  create_table "favourite_groups", force: :cascade do |t|
     t.integer "user_id"
     t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "favourites", id: :integer, force: :cascade do |t|
+  create_table "favourites", force: :cascade do |t|
     t.integer "resource_id"
     t.integer "user_id"
     t.string "resource_type"
@@ -755,7 +755,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["project_id"], name: "index_ft_projects_on_p_id"
   end
 
-  create_table "genes", id: :integer, force: :cascade do |t|
+  create_table "genes", force: :cascade do |t|
     t.string "title"
     t.string "symbol"
     t.text "description"
@@ -763,7 +763,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at"
   end
 
-  create_table "genotypes", id: :integer, force: :cascade do |t|
+  create_table "genotypes", force: :cascade do |t|
     t.integer "gene_id"
     t.integer "modification_id"
     t.integer "strain_id"
@@ -817,7 +817,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["resource_type", "resource_id"], name: "index_versions_on_resource"
   end
 
-  create_table "group_memberships", id: :integer, force: :cascade do |t|
+  create_table "group_memberships", force: :cascade do |t|
     t.integer "person_id"
     t.integer "work_group_id"
     t.datetime "created_at"
@@ -829,7 +829,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["work_group_id"], name: "index_group_memberships_on_work_group_id"
   end
 
-  create_table "help_attachments", id: :integer, force: :cascade do |t|
+  create_table "help_attachments", force: :cascade do |t|
     t.integer "help_document_id"
     t.string "title"
     t.string "content_type"
@@ -840,7 +840,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at"
   end
 
-  create_table "help_documents", id: :integer, force: :cascade do |t|
+  create_table "help_documents", force: :cascade do |t|
     t.string "identifier"
     t.string "title"
     t.text "body"
@@ -848,7 +848,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at"
   end
 
-  create_table "help_images", id: :integer, force: :cascade do |t|
+  create_table "help_images", force: :cascade do |t|
     t.integer "help_document_id"
     t.string "content_type"
     t.string "filename"
@@ -868,7 +868,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["parent_id"], name: "index_disease_parents_on_parent_id"
   end
 
-  create_table "human_diseases", id: :integer, force: :cascade do |t|
+  create_table "human_diseases", force: :cascade do |t|
     t.string "title"
     t.string "doid_id"
     t.datetime "created_at"
@@ -891,7 +891,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["publication_id"], name: "index_diseases_publications_on_publication_id"
   end
 
-  create_table "identities", id: :integer, force: :cascade do |t|
+  create_table "identities", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "provider"
@@ -901,7 +901,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["user_id"], name: "index_identities_on_user_id"
   end
 
-  create_table "institutions", id: :integer, force: :cascade do |t|
+  create_table "institutions", force: :cascade do |t|
     t.string "title"
     t.text "address"
     t.string "city"
@@ -926,7 +926,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["user_id", "can_view"], name: "index_investigation_auth_lookup_on_user_id_and_can_view"
   end
 
-  create_table "investigations", id: :integer, force: :cascade do |t|
+  create_table "investigations", force: :cascade do |t|
     t.string "title"
     t.text "description"
     t.datetime "created_at"
@@ -952,7 +952,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["title"], name: "index_isa_tags_title"
   end
 
-  create_table "mapping_links", id: :integer, force: :cascade do |t|
+  create_table "mapping_links", force: :cascade do |t|
     t.string "substance_type"
     t.integer "substance_id"
     t.integer "mapping_id"
@@ -960,7 +960,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at"
   end
 
-  create_table "mappings", id: :integer, force: :cascade do |t|
+  create_table "mappings", force: :cascade do |t|
     t.integer "sabiork_id"
     t.string "chebi_id"
     t.string "kegg_id"
@@ -968,14 +968,14 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at"
   end
 
-  create_table "measured_items", id: :integer, force: :cascade do |t|
+  create_table "measured_items", force: :cascade do |t|
     t.string "title"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean "factors_studied", default: true
   end
 
-  create_table "message_logs", id: :integer, force: :cascade do |t|
+  create_table "message_logs", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "message_type"
@@ -1000,13 +1000,13 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["user_id", "can_view"], name: "index_model_auth_lookup_on_user_id_and_can_view"
   end
 
-  create_table "model_formats", id: :integer, force: :cascade do |t|
+  create_table "model_formats", force: :cascade do |t|
     t.string "title"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "model_images", id: :integer, force: :cascade do |t|
+  create_table "model_images", force: :cascade do |t|
     t.integer "model_id"
     t.string "original_filename"
     t.string "content_type"
@@ -1016,13 +1016,13 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.integer "image_height"
   end
 
-  create_table "model_types", id: :integer, force: :cascade do |t|
+  create_table "model_types", force: :cascade do |t|
     t.string "title"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "model_versions", id: :integer, force: :cascade do |t|
+  create_table "model_versions", force: :cascade do |t|
     t.integer "model_id"
     t.integer "version"
     t.text "revision_comments"
@@ -1056,7 +1056,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.integer "version_id"
   end
 
-  create_table "models", id: :integer, force: :cascade do |t|
+  create_table "models", force: :cascade do |t|
     t.integer "contributor_id"
     t.string "title"
     t.text "description"
@@ -1088,13 +1088,13 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["project_id"], name: "index_models_projects_on_project_id"
   end
 
-  create_table "moderatorships", id: :integer, force: :cascade do |t|
+  create_table "moderatorships", force: :cascade do |t|
     t.integer "forum_id"
     t.integer "user_id"
     t.index ["forum_id"], name: "index_moderatorships_on_forum_id"
   end
 
-  create_table "modifications", id: :integer, force: :cascade do |t|
+  create_table "modifications", force: :cascade do |t|
     t.string "title"
     t.string "symbol"
     t.text "description"
@@ -1103,7 +1103,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at"
   end
 
-  create_table "notifiee_infos", id: :integer, force: :cascade do |t|
+  create_table "notifiee_infos", force: :cascade do |t|
     t.integer "notifiee_id"
     t.string "notifiee_type"
     t.string "unique_key"
@@ -1112,7 +1112,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at"
   end
 
-  create_table "number_value_versions", id: :integer, force: :cascade do |t|
+  create_table "number_value_versions", force: :cascade do |t|
     t.integer "number_value_id", null: false
     t.integer "version", null: false
     t.integer "version_creator_id"
@@ -1122,7 +1122,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["number_value_id"], name: "index_number_value_versions_on_number_value_id"
   end
 
-  create_table "number_values", id: :integer, force: :cascade do |t|
+  create_table "number_values", force: :cascade do |t|
     t.integer "version"
     t.integer "version_creator_id"
     t.integer "number", null: false
@@ -1177,7 +1177,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end
 
-  create_table "oauth_sessions", id: :integer, force: :cascade do |t|
+  create_table "oauth_sessions", force: :cascade do |t|
     t.integer "user_id"
     t.string "provider"
     t.string "access_token"
@@ -1218,7 +1218,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "openbis_endpoints", id: :integer, force: :cascade do |t|
+  create_table "openbis_endpoints", force: :cascade do |t|
     t.string "as_endpoint"
     t.string "space_perm_id"
     t.string "username"
@@ -1237,7 +1237,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.boolean "is_test", default: false
   end
 
-  create_table "organisms", id: :integer, force: :cascade do |t|
+  create_table "organisms", force: :cascade do |t|
     t.string "title"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -1252,7 +1252,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["project_id"], name: "index_organisms_projects_on_project_id"
   end
 
-  create_table "people", id: :integer, force: :cascade do |t|
+  create_table "people", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "first_name"
@@ -1270,7 +1270,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.string "orcid"
   end
 
-  create_table "permissions", id: :integer, force: :cascade do |t|
+  create_table "permissions", force: :cascade do |t|
     t.string "contributor_type"
     t.integer "contributor_id"
     t.integer "policy_id"
@@ -1280,7 +1280,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["policy_id"], name: "index_permissions_on_policy_id"
   end
 
-  create_table "phenotypes", id: :integer, force: :cascade do |t|
+  create_table "phenotypes", force: :cascade do |t|
     t.text "description"
     t.text "comment"
     t.integer "strain_id"
@@ -1328,7 +1328,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["project_id"], name: "index_ph_projects_on_p_id"
   end
 
-  create_table "policies", id: :integer, force: :cascade do |t|
+  create_table "policies", force: :cascade do |t|
     t.string "name"
     t.integer "sharing_scope", limit: 1
     t.integer "access_type", limit: 1
@@ -1350,7 +1350,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["user_id", "can_view"], name: "index_presentation_auth_lookup_on_user_id_and_can_view"
   end
 
-  create_table "presentation_versions", id: :integer, force: :cascade do |t|
+  create_table "presentation_versions", force: :cascade do |t|
     t.integer "presentation_id"
     t.integer "version"
     t.text "revision_comments"
@@ -1373,7 +1373,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.integer "version_id"
   end
 
-  create_table "presentations", id: :integer, force: :cascade do |t|
+  create_table "presentations", force: :cascade do |t|
     t.integer "contributor_id"
     t.string "title"
     t.text "description"
@@ -1402,7 +1402,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["workflow_id", "presentation_id"], name: "index_presentations_workflows_on_workflow_pres"
   end
 
-  create_table "programmes", id: :integer, force: :cascade do |t|
+  create_table "programmes", force: :cascade do |t|
     t.string "title"
     t.text "description"
     t.integer "avatar_id"
@@ -1417,7 +1417,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.boolean "open_for_projects", default: false
   end
 
-  create_table "project_folder_assets", id: :integer, force: :cascade do |t|
+  create_table "project_folder_assets", force: :cascade do |t|
     t.integer "asset_id"
     t.string "asset_type"
     t.integer "project_folder_id"
@@ -1425,7 +1425,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at"
   end
 
-  create_table "project_folders", id: :integer, force: :cascade do |t|
+  create_table "project_folders", force: :cascade do |t|
     t.integer "project_id"
     t.string "title"
     t.text "description"
@@ -1437,7 +1437,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.boolean "deletable", default: true
   end
 
-  create_table "project_subscriptions", id: :integer, force: :cascade do |t|
+  create_table "project_subscriptions", force: :cascade do |t|
     t.integer "person_id"
     t.integer "project_id"
     t.string "unsubscribed_types"
@@ -1445,7 +1445,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["person_id", "project_id"], name: "index_project_subscriptions_on_person_id_and_project_id"
   end
 
-  create_table "projects", id: :integer, force: :cascade do |t|
+  create_table "projects", force: :cascade do |t|
     t.string "title"
     t.text "web_page"
     t.text "wiki_page"
@@ -1539,7 +1539,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["user_id", "can_view"], name: "index_publication_auth_lookup_on_user_id_and_can_view"
   end
 
-  create_table "publication_authors", id: :integer, force: :cascade do |t|
+  create_table "publication_authors", force: :cascade do |t|
     t.string "first_name"
     t.string "last_name"
     t.integer "publication_id"
@@ -1549,7 +1549,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.integer "person_id"
   end
 
-  create_table "publication_types", id: :integer, force: :cascade do |t|
+  create_table "publication_types", force: :cascade do |t|
     t.string "title"
     t.string "key"
     t.datetime "created_at", null: false
@@ -1585,7 +1585,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["publication_id"], name: "index_publication_versions_on_publication_id"
   end
 
-  create_table "publications", id: :integer, force: :cascade do |t|
+  create_table "publications", force: :cascade do |t|
     t.integer "pubmed_id"
     t.text "title"
     t.text "abstract"
@@ -1622,13 +1622,13 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["item_id", "item_type"], name: "index_rdf_generation_queues_on_item_id_and_item_type"
   end
 
-  create_table "recommended_model_environments", id: :integer, force: :cascade do |t|
+  create_table "recommended_model_environments", force: :cascade do |t|
     t.string "title"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "reindexing_queues", id: :integer, force: :cascade do |t|
+  create_table "reindexing_queues", force: :cascade do |t|
     t.string "item_type"
     t.integer "item_id"
     t.datetime "created_at"
@@ -1637,7 +1637,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["item_id", "item_type"], name: "index_reindexing_queues_on_item_id_and_item_type"
   end
 
-  create_table "relationship_types", id: :integer, force: :cascade do |t|
+  create_table "relationship_types", force: :cascade do |t|
     t.string "title"
     t.text "description"
     t.datetime "created_at"
@@ -1645,7 +1645,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.string "key"
   end
 
-  create_table "relationships", id: :integer, force: :cascade do |t|
+  create_table "relationships", force: :cascade do |t|
     t.string "subject_type", null: false
     t.integer "subject_id", null: false
     t.string "predicate", null: false
@@ -1669,10 +1669,10 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
   end
 
   create_table "roles", force: :cascade do |t|
-    t.bigint "person_id"
-    t.bigint "role_type_id"
+    t.integer "person_id"
+    t.integer "role_type_id"
     t.string "scope_type"
-    t.bigint "scope_id"
+    t.integer "scope_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["person_id", "role_type_id"], name: "index_roles_on_person_id_and_role_type_id"
@@ -1681,7 +1681,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["scope_type", "scope_id"], name: "index_roles_on_scope"
   end
 
-  create_table "sample_attribute_types", id: :integer, force: :cascade do |t|
+  create_table "sample_attribute_types", force: :cascade do |t|
     t.string "title"
     t.string "base_type"
     t.text "regexp"
@@ -1692,7 +1692,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.string "resolution"
   end
 
-  create_table "sample_attributes", id: :integer, force: :cascade do |t|
+  create_table "sample_attributes", force: :cascade do |t|
     t.string "title"
     t.integer "sample_attribute_type_id"
     t.boolean "required", default: false
@@ -1725,7 +1725,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["user_id", "can_view"], name: "index_sample_auth_lookup_on_user_id_and_can_view"
   end
 
-  create_table "sample_controlled_vocab_terms", id: :integer, force: :cascade do |t|
+  create_table "sample_controlled_vocab_terms", force: :cascade do |t|
     t.text "label"
     t.integer "sample_controlled_vocab_id"
     t.datetime "created_at", null: false
@@ -1734,7 +1734,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.string "parent_iri"
   end
 
-  create_table "sample_controlled_vocabs", id: :integer, force: :cascade do |t|
+  create_table "sample_controlled_vocabs", force: :cascade do |t|
     t.string "title"
     t.text "description"
     t.datetime "created_at", null: false
@@ -1744,12 +1744,12 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.string "ols_root_term_uri"
     t.boolean "required"
     t.string "short_name"
-    t.string "key"
     t.integer "template_id"
+    t.string "key"
     t.boolean "custom_input", default: false
   end
 
-  create_table "sample_resource_links", id: :integer, force: :cascade do |t|
+  create_table "sample_resource_links", force: :cascade do |t|
     t.integer "sample_id"
     t.integer "resource_id"
     t.string "resource_type"
@@ -1757,7 +1757,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["sample_id"], name: "index_sample_resource_links_on_sample_id"
   end
 
-  create_table "sample_types", id: :integer, force: :cascade do |t|
+  create_table "sample_types", force: :cascade do |t|
     t.string "title"
     t.string "uuid"
     t.datetime "created_at", null: false
@@ -1778,7 +1778,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["study_id"], name: "index_sample_types_studies_on_study_id"
   end
 
-  create_table "samples", id: :integer, force: :cascade do |t|
+  create_table "samples", force: :cascade do |t|
     t.string "title"
     t.integer "sample_type_id"
     t.text "json_metadata"
@@ -1793,7 +1793,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.string "deleted_contributor"
   end
 
-  create_table "saved_searches", id: :integer, force: :cascade do |t|
+  create_table "saved_searches", force: :cascade do |t|
     t.integer "user_id"
     t.text "search_query"
     t.text "search_type"
@@ -1802,7 +1802,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.boolean "include_external_search", default: false
   end
 
-  create_table "sessions", id: :integer, force: :cascade do |t|
+  create_table "sessions", force: :cascade do |t|
     t.string "session_id", null: false
     t.text "data", size: :medium
     t.datetime "created_at"
@@ -1811,7 +1811,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
-  create_table "settings", id: :integer, force: :cascade do |t|
+  create_table "settings", force: :cascade do |t|
     t.string "var", null: false
     t.text "value"
     t.integer "target_id"
@@ -1823,14 +1823,14 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["target_type", "target_id", "var"], name: "index_settings_on_target_type_and_target_id_and_var", unique: true
   end
 
-  create_table "site_announcement_categories", id: :integer, force: :cascade do |t|
+  create_table "site_announcement_categories", force: :cascade do |t|
     t.string "title"
     t.string "icon_key"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "site_announcements", id: :integer, force: :cascade do |t|
+  create_table "site_announcements", force: :cascade do |t|
     t.integer "announcer_id"
     t.string "announcer_type"
     t.string "title"
@@ -1844,7 +1844,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at"
   end
 
-  create_table "snapshots", id: :integer, force: :cascade do |t|
+  create_table "snapshots", force: :cascade do |t|
     t.string "resource_type"
     t.integer "resource_id"
     t.string "doi"
@@ -1867,7 +1867,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["user_id", "can_view"], name: "index_sop_auth_lookup_on_user_id_and_can_view"
   end
 
-  create_table "sop_versions", id: :integer, force: :cascade do |t|
+  create_table "sop_versions", force: :cascade do |t|
     t.integer "sop_id"
     t.integer "version"
     t.text "revision_comments"
@@ -1888,7 +1888,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["sop_id"], name: "index_sop_versions_on_sop_id"
   end
 
-  create_table "sops", id: :integer, force: :cascade do |t|
+  create_table "sops", force: :cascade do |t|
     t.integer "contributor_id"
     t.string "title"
     t.text "description"
@@ -1919,7 +1919,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["workflow_id"], name: "index_sops_workflows_on_workflow_id"
   end
 
-  create_table "special_auth_codes", id: :integer, force: :cascade do |t|
+  create_table "special_auth_codes", force: :cascade do |t|
     t.string "code"
     t.date "expiration_date"
     t.string "asset_type"
@@ -1945,7 +1945,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.integer "descendant_id"
   end
 
-  create_table "strains", id: :integer, force: :cascade do |t|
+  create_table "strains", force: :cascade do |t|
     t.string "title"
     t.integer "organism_id"
     t.datetime "created_at"
@@ -1963,7 +1963,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.string "deleted_contributor"
   end
 
-  create_table "studied_factor_links", id: :integer, force: :cascade do |t|
+  create_table "studied_factor_links", force: :cascade do |t|
     t.string "substance_type"
     t.integer "substance_id"
     t.integer "studied_factor_id"
@@ -1971,7 +1971,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at"
   end
 
-  create_table "studied_factors", id: :integer, force: :cascade do |t|
+  create_table "studied_factors", force: :cascade do |t|
     t.integer "measured_item_id"
     t.float "start_value"
     t.float "end_value"
@@ -1985,7 +1985,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["data_file_id"], name: "index_studied_factors_on_data_file_id"
   end
 
-  create_table "studies", id: :integer, force: :cascade do |t|
+  create_table "studies", force: :cascade do |t|
     t.text "title"
     t.text "description"
     t.integer "investigation_id"
@@ -2014,7 +2014,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["user_id", "can_view"], name: "index_study_auth_lookup_on_user_id_and_can_view"
   end
 
-  create_table "subscriptions", id: :integer, force: :cascade do |t|
+  create_table "subscriptions", force: :cascade do |t|
     t.integer "person_id"
     t.integer "subscribable_id"
     t.string "subscribable_type"
@@ -2024,7 +2024,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.integer "project_subscription_id"
   end
 
-  create_table "suggested_assay_types", id: :integer, force: :cascade do |t|
+  create_table "suggested_assay_types", force: :cascade do |t|
     t.string "label"
     t.string "ontology_uri"
     t.integer "contributor_id"
@@ -2033,7 +2033,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.integer "parent_id"
   end
 
-  create_table "suggested_technology_types", id: :integer, force: :cascade do |t|
+  create_table "suggested_technology_types", force: :cascade do |t|
     t.string "label"
     t.string "ontology_uri"
     t.integer "contributor_id"
@@ -2042,7 +2042,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.integer "parent_id"
   end
 
-  create_table "synonyms", id: :integer, force: :cascade do |t|
+  create_table "synonyms", force: :cascade do |t|
     t.string "name"
     t.integer "substance_id"
     t.string "substance_type"
@@ -2051,7 +2051,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["substance_id", "substance_type"], name: "index_synonyms_on_substance_id_and_substance_type"
   end
 
-  create_table "taggings", id: :integer, force: :cascade do |t|
+  create_table "taggings", force: :cascade do |t|
     t.integer "tag_id"
     t.integer "taggable_id"
     t.integer "tagger_id"
@@ -2063,7 +2063,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context"
   end
 
-  create_table "tags", id: :integer, force: :cascade do |t|
+  create_table "tags", force: :cascade do |t|
     t.string "name"
   end
 
@@ -2136,7 +2136,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["title", "group"], name: "index_templates_title_group"
   end
 
-  create_table "text_values", id: :integer, force: :cascade do |t|
+  create_table "text_values", force: :cascade do |t|
     t.integer "version"
     t.integer "version_creator_id"
     t.text "text", size: :medium, null: false
@@ -2144,13 +2144,13 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at"
   end
 
-  create_table "tissue_and_cell_types", id: :integer, force: :cascade do |t|
+  create_table "tissue_and_cell_types", force: :cascade do |t|
     t.string "title"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "units", id: :integer, force: :cascade do |t|
+  create_table "units", force: :cascade do |t|
     t.string "title"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -2159,7 +2159,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.integer "order"
   end
 
-  create_table "users", id: :integer, force: :cascade do |t|
+  create_table "users", force: :cascade do |t|
     t.string "login"
     t.string "crypted_password", limit: 64
     t.string "salt", limit: 40
@@ -2177,7 +2177,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.string "uuid"
   end
 
-  create_table "work_groups", id: :integer, force: :cascade do |t|
+  create_table "work_groups", force: :cascade do |t|
     t.string "name"
     t.integer "institution_id"
     t.integer "project_id"
@@ -2198,7 +2198,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["user_id", "can_view"], name: "index_w_auth_lookup_on_user_id_and_can_view"
   end
 
-  create_table "workflow_classes", id: :integer, force: :cascade do |t|
+  create_table "workflow_classes", force: :cascade do |t|
     t.string "title"
     t.text "description"
     t.string "key"
@@ -2228,7 +2228,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["workflow_id", "data_file_id"], name: "index_data_files_workflows_on_workflow_data_file"
   end
 
-  create_table "workflow_versions", id: :integer, force: :cascade do |t|
+  create_table "workflow_versions", force: :cascade do |t|
     t.integer "workflow_id"
     t.integer "version"
     t.text "revision_comments"
@@ -2253,7 +2253,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["workflow_id"], name: "index_workflow_versions_on_workflow_id"
   end
 
-  create_table "workflows", id: :integer, force: :cascade do |t|
+  create_table "workflows", force: :cascade do |t|
     t.integer "contributor_id"
     t.string "title"
     t.text "description"
@@ -2274,7 +2274,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["contributor_id"], name: "index_workflows_on_contributor"
   end
 
-  create_table "worksheets", id: :integer, force: :cascade do |t|
+  create_table "worksheets", force: :cascade do |t|
     t.integer "content_blob_id"
     t.integer "last_row"
     t.integer "last_column"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 2023_08_09_054421) do
 
-  create_table "activity_logs", force: :cascade do |t|
+  create_table "activity_logs", id: :integer, force: :cascade do |t|
     t.string "action"
     t.string "format"
     t.string "activity_loggable_type"
@@ -25,7 +25,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at"
     t.string "http_referer"
     t.text "user_agent"
-    t.text "data"
+    t.text "data", size: :medium
     t.string "controller_name"
     t.index ["action"], name: "act_logs_action_index"
     t.index ["activity_loggable_type", "activity_loggable_id"], name: "act_logs_act_loggable_index"
@@ -34,19 +34,19 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["referenced_type", "referenced_id"], name: "act_logs_referenced_index"
   end
 
-  create_table "admin_defined_role_programmes", force: :cascade do |t|
+  create_table "admin_defined_role_programmes", id: :integer, force: :cascade do |t|
     t.integer "programme_id"
     t.integer "person_id"
     t.integer "role_mask"
   end
 
-  create_table "admin_defined_role_projects", force: :cascade do |t|
+  create_table "admin_defined_role_projects", id: :integer, force: :cascade do |t|
     t.integer "project_id"
     t.integer "role_mask"
     t.integer "person_id"
   end
 
-  create_table "annotation_attributes", force: :cascade do |t|
+  create_table "annotation_attributes", id: :integer, force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -54,7 +54,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["name"], name: "index_annotation_attributes_on_name"
   end
 
-  create_table "annotation_value_seeds", force: :cascade do |t|
+  create_table "annotation_value_seeds", id: :integer, force: :cascade do |t|
     t.integer "attribute_id", null: false
     t.string "old_value"
     t.datetime "created_at"
@@ -64,7 +64,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["attribute_id"], name: "index_annotation_value_seeds_on_attribute_id"
   end
 
-  create_table "annotation_versions", force: :cascade do |t|
+  create_table "annotation_versions", id: :integer, force: :cascade do |t|
     t.integer "annotation_id", null: false
     t.integer "version", null: false
     t.integer "version_creator_id"
@@ -81,7 +81,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["annotation_id"], name: "index_annotation_versions_on_annotation_id"
   end
 
-  create_table "annotations", force: :cascade do |t|
+  create_table "annotations", id: :integer, force: :cascade do |t|
     t.string "source_type", null: false
     t.integer "source_id", null: false
     t.string "annotatable_type", limit: 50, null: false
@@ -116,7 +116,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "assay_assets", force: :cascade do |t|
+  create_table "assay_assets", id: :integer, force: :cascade do |t|
     t.integer "assay_id"
     t.integer "asset_id"
     t.integer "version"
@@ -141,7 +141,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["user_id", "can_view"], name: "index_assay_auth_lookup_on_user_id_and_can_view"
   end
 
-  create_table "assay_classes", force: :cascade do |t|
+  create_table "assay_classes", id: :integer, force: :cascade do |t|
     t.string "title"
     t.text "description"
     t.datetime "created_at"
@@ -149,7 +149,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.string "key", limit: 10
   end
 
-  create_table "assay_human_diseases", force: :cascade do |t|
+  create_table "assay_human_diseases", id: :integer, force: :cascade do |t|
     t.integer "assay_id"
     t.integer "human_disease_id"
     t.datetime "created_at"
@@ -158,7 +158,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["human_disease_id"], name: "index_assay_diseases_on_disease_id"
   end
 
-  create_table "assay_organisms", force: :cascade do |t|
+  create_table "assay_organisms", id: :integer, force: :cascade do |t|
     t.integer "assay_id"
     t.integer "organism_id"
     t.integer "culture_growth_type_id"
@@ -170,7 +170,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["organism_id"], name: "index_assay_organisms_on_organism_id"
   end
 
-  create_table "assays", force: :cascade do |t|
+  create_table "assays", id: :integer, force: :cascade do |t|
     t.text "title"
     t.text "description"
     t.datetime "created_at"
@@ -192,7 +192,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["sample_type_id"], name: "index_assays_on_sample_type_id"
   end
 
-  create_table "asset_doi_logs", force: :cascade do |t|
+  create_table "asset_doi_logs", id: :integer, force: :cascade do |t|
     t.string "asset_type"
     t.integer "asset_id"
     t.integer "asset_version"
@@ -215,7 +215,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["asset_id", "asset_type"], name: "index_asset_links_on_asset_id_and_asset_type"
   end
 
-  create_table "assets", force: :cascade do |t|
+  create_table "assets", id: :integer, force: :cascade do |t|
     t.integer "project_id"
     t.string "resource_type"
     t.integer "resource_id"
@@ -224,7 +224,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at"
   end
 
-  create_table "assets_creators", force: :cascade do |t|
+  create_table "assets_creators", id: :integer, force: :cascade do |t|
     t.integer "asset_id"
     t.integer "creator_id"
     t.string "asset_type"
@@ -238,7 +238,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["asset_id", "asset_type"], name: "index_assets_creators_on_asset_id_and_asset_type"
   end
 
-  create_table "auth_lookup_update_queues", force: :cascade do |t|
+  create_table "auth_lookup_update_queues", id: :integer, force: :cascade do |t|
     t.integer "item_id"
     t.string "item_type"
     t.datetime "created_at"
@@ -247,7 +247,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["item_id", "item_type"], name: "index_auth_lookup_update_queues_on_item_id_and_item_type"
   end
 
-  create_table "avatars", force: :cascade do |t|
+  create_table "avatars", id: :integer, force: :cascade do |t|
     t.string "owner_type"
     t.integer "owner_id"
     t.string "original_filename"
@@ -266,7 +266,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["resource_type", "resource_id"], name: "index_bio_tools_links_on_resource"
   end
 
-  create_table "bioportal_concepts", force: :cascade do |t|
+  create_table "bioportal_concepts", id: :integer, force: :cascade do |t|
     t.string "ontology_id"
     t.string "concept_uri"
     t.text "cached_concept_yaml"
@@ -324,13 +324,13 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["project_id"], name: "index_collections_projects_on_project_id"
   end
 
-  create_table "compounds", force: :cascade do |t|
+  create_table "compounds", id: :integer, force: :cascade do |t|
     t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "content_blobs", force: :cascade do |t|
+  create_table "content_blobs", id: :integer, force: :cascade do |t|
     t.string "md5sum"
     t.text "url"
     t.string "uuid"
@@ -348,13 +348,13 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["asset_id", "asset_type"], name: "index_content_blobs_on_asset_id_and_asset_type"
   end
 
-  create_table "culture_growth_types", force: :cascade do |t|
+  create_table "culture_growth_types", id: :integer, force: :cascade do |t|
     t.string "title"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "cultures", force: :cascade do |t|
+  create_table "cultures", id: :integer, force: :cascade do |t|
     t.integer "organism_id"
     t.integer "sop_id"
     t.datetime "date_at_sampling"
@@ -407,7 +407,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["user_id", "can_view"], name: "index_data_file_auth_lookup_on_user_id_and_can_view"
   end
 
-  create_table "data_file_versions", force: :cascade do |t|
+  create_table "data_file_versions", id: :integer, force: :cascade do |t|
     t.integer "data_file_id"
     t.integer "version"
     t.text "revision_comments"
@@ -435,7 +435,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.integer "version_id"
   end
 
-  create_table "data_files", force: :cascade do |t|
+  create_table "data_files", id: :integer, force: :cascade do |t|
     t.integer "contributor_id"
     t.string "title"
     t.text "description"
@@ -467,11 +467,11 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["project_id"], name: "index_data_files_projects_on_project_id"
   end
 
-  create_table "db_files", force: :cascade do |t|
+  create_table "db_files", id: :integer, force: :cascade do |t|
     t.binary "data"
   end
 
-  create_table "delayed_jobs", force: :cascade do |t|
+  create_table "delayed_jobs", id: :integer, force: :cascade do |t|
     t.integer "priority", default: 0
     t.integer "attempts", default: 0
     t.text "handler"
@@ -486,7 +486,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
-  create_table "disciplines", force: :cascade do |t|
+  create_table "disciplines", id: :integer, force: :cascade do |t|
     t.string "title"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -510,7 +510,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["user_id", "can_view"], name: "index_document_auth_lookup_on_user_id_and_can_view"
   end
 
-  create_table "document_versions", force: :cascade do |t|
+  create_table "document_versions", id: :integer, force: :cascade do |t|
     t.integer "document_id"
     t.integer "version"
     t.text "revision_comments"
@@ -531,14 +531,14 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["document_id"], name: "index_document_versions_on_document_id"
   end
 
-  create_table "document_versions_projects", force: :cascade do |t|
+  create_table "document_versions_projects", id: :integer, force: :cascade do |t|
     t.integer "version_id"
     t.integer "project_id"
     t.index ["project_id"], name: "index_document_versions_projects_on_project_id"
     t.index ["version_id", "project_id"], name: "index_document_versions_projects_on_version_id_and_project_id"
   end
 
-  create_table "documents", force: :cascade do |t|
+  create_table "documents", id: :integer, force: :cascade do |t|
     t.text "title"
     t.text "description"
     t.integer "contributor_id"
@@ -562,7 +562,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["event_id", "document_id"], name: "index_documents_events_on_event_id_and_document_id"
   end
 
-  create_table "documents_projects", force: :cascade do |t|
+  create_table "documents_projects", id: :integer, force: :cascade do |t|
     t.integer "document_id"
     t.integer "project_id"
     t.index ["document_id", "project_id"], name: "index_documents_projects_on_document_id_and_project_id"
@@ -588,7 +588,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["user_id", "can_view"], name: "index_event_auth_lookup_on_user_id_and_can_view"
   end
 
-  create_table "events", force: :cascade do |t|
+  create_table "events", id: :integer, force: :cascade do |t|
     t.datetime "start_date"
     t.datetime "end_date"
     t.text "address"
@@ -624,7 +624,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.integer "event_id"
   end
 
-  create_table "experimental_condition_links", force: :cascade do |t|
+  create_table "experimental_condition_links", id: :integer, force: :cascade do |t|
     t.string "substance_type"
     t.integer "substance_id"
     t.integer "experimental_condition_id"
@@ -632,7 +632,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at"
   end
 
-  create_table "experimental_conditions", force: :cascade do |t|
+  create_table "experimental_conditions", id: :integer, force: :cascade do |t|
     t.integer "measured_item_id"
     t.float "start_value"
     t.float "end_value"
@@ -644,7 +644,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["sop_id"], name: "index_experimental_conditions_on_sop_id"
   end
 
-  create_table "external_assets", force: :cascade do |t|
+  create_table "external_assets", id: :integer, force: :cascade do |t|
     t.string "external_service", null: false
     t.string "external_id", null: false
     t.string "external_mod_stamp"
@@ -666,7 +666,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["seek_service_type", "seek_service_id"], name: "index_external_assets_on_seek_service_type_and_seek_service_id"
   end
 
-  create_table "favourite_group_memberships", force: :cascade do |t|
+  create_table "favourite_group_memberships", id: :integer, force: :cascade do |t|
     t.integer "person_id"
     t.integer "favourite_group_id"
     t.integer "access_type", limit: 1
@@ -674,14 +674,14 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at"
   end
 
-  create_table "favourite_groups", force: :cascade do |t|
+  create_table "favourite_groups", id: :integer, force: :cascade do |t|
     t.integer "user_id"
     t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "favourites", force: :cascade do |t|
+  create_table "favourites", id: :integer, force: :cascade do |t|
     t.integer "resource_id"
     t.integer "user_id"
     t.string "resource_type"
@@ -755,7 +755,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["project_id"], name: "index_ft_projects_on_p_id"
   end
 
-  create_table "genes", force: :cascade do |t|
+  create_table "genes", id: :integer, force: :cascade do |t|
     t.string "title"
     t.string "symbol"
     t.text "description"
@@ -763,7 +763,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at"
   end
 
-  create_table "genotypes", force: :cascade do |t|
+  create_table "genotypes", id: :integer, force: :cascade do |t|
     t.integer "gene_id"
     t.integer "modification_id"
     t.integer "strain_id"
@@ -817,7 +817,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["resource_type", "resource_id"], name: "index_versions_on_resource"
   end
 
-  create_table "group_memberships", force: :cascade do |t|
+  create_table "group_memberships", id: :integer, force: :cascade do |t|
     t.integer "person_id"
     t.integer "work_group_id"
     t.datetime "created_at"
@@ -829,7 +829,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["work_group_id"], name: "index_group_memberships_on_work_group_id"
   end
 
-  create_table "help_attachments", force: :cascade do |t|
+  create_table "help_attachments", id: :integer, force: :cascade do |t|
     t.integer "help_document_id"
     t.string "title"
     t.string "content_type"
@@ -840,7 +840,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at"
   end
 
-  create_table "help_documents", force: :cascade do |t|
+  create_table "help_documents", id: :integer, force: :cascade do |t|
     t.string "identifier"
     t.string "title"
     t.text "body"
@@ -848,7 +848,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at"
   end
 
-  create_table "help_images", force: :cascade do |t|
+  create_table "help_images", id: :integer, force: :cascade do |t|
     t.integer "help_document_id"
     t.string "content_type"
     t.string "filename"
@@ -868,7 +868,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["parent_id"], name: "index_disease_parents_on_parent_id"
   end
 
-  create_table "human_diseases", force: :cascade do |t|
+  create_table "human_diseases", id: :integer, force: :cascade do |t|
     t.string "title"
     t.string "doid_id"
     t.datetime "created_at"
@@ -891,7 +891,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["publication_id"], name: "index_diseases_publications_on_publication_id"
   end
 
-  create_table "identities", force: :cascade do |t|
+  create_table "identities", id: :integer, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "provider"
@@ -901,7 +901,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["user_id"], name: "index_identities_on_user_id"
   end
 
-  create_table "institutions", force: :cascade do |t|
+  create_table "institutions", id: :integer, force: :cascade do |t|
     t.string "title"
     t.text "address"
     t.string "city"
@@ -926,7 +926,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["user_id", "can_view"], name: "index_investigation_auth_lookup_on_user_id_and_can_view"
   end
 
-  create_table "investigations", force: :cascade do |t|
+  create_table "investigations", id: :integer, force: :cascade do |t|
     t.string "title"
     t.text "description"
     t.datetime "created_at"
@@ -952,7 +952,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["title"], name: "index_isa_tags_title"
   end
 
-  create_table "mapping_links", force: :cascade do |t|
+  create_table "mapping_links", id: :integer, force: :cascade do |t|
     t.string "substance_type"
     t.integer "substance_id"
     t.integer "mapping_id"
@@ -960,7 +960,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at"
   end
 
-  create_table "mappings", force: :cascade do |t|
+  create_table "mappings", id: :integer, force: :cascade do |t|
     t.integer "sabiork_id"
     t.string "chebi_id"
     t.string "kegg_id"
@@ -968,14 +968,14 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at"
   end
 
-  create_table "measured_items", force: :cascade do |t|
+  create_table "measured_items", id: :integer, force: :cascade do |t|
     t.string "title"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean "factors_studied", default: true
   end
 
-  create_table "message_logs", force: :cascade do |t|
+  create_table "message_logs", id: :integer, force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "message_type"
@@ -1000,13 +1000,13 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["user_id", "can_view"], name: "index_model_auth_lookup_on_user_id_and_can_view"
   end
 
-  create_table "model_formats", force: :cascade do |t|
+  create_table "model_formats", id: :integer, force: :cascade do |t|
     t.string "title"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "model_images", force: :cascade do |t|
+  create_table "model_images", id: :integer, force: :cascade do |t|
     t.integer "model_id"
     t.string "original_filename"
     t.string "content_type"
@@ -1016,13 +1016,13 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.integer "image_height"
   end
 
-  create_table "model_types", force: :cascade do |t|
+  create_table "model_types", id: :integer, force: :cascade do |t|
     t.string "title"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "model_versions", force: :cascade do |t|
+  create_table "model_versions", id: :integer, force: :cascade do |t|
     t.integer "model_id"
     t.integer "version"
     t.text "revision_comments"
@@ -1056,7 +1056,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.integer "version_id"
   end
 
-  create_table "models", force: :cascade do |t|
+  create_table "models", id: :integer, force: :cascade do |t|
     t.integer "contributor_id"
     t.string "title"
     t.text "description"
@@ -1088,13 +1088,13 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["project_id"], name: "index_models_projects_on_project_id"
   end
 
-  create_table "moderatorships", force: :cascade do |t|
+  create_table "moderatorships", id: :integer, force: :cascade do |t|
     t.integer "forum_id"
     t.integer "user_id"
     t.index ["forum_id"], name: "index_moderatorships_on_forum_id"
   end
 
-  create_table "modifications", force: :cascade do |t|
+  create_table "modifications", id: :integer, force: :cascade do |t|
     t.string "title"
     t.string "symbol"
     t.text "description"
@@ -1103,7 +1103,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at"
   end
 
-  create_table "notifiee_infos", force: :cascade do |t|
+  create_table "notifiee_infos", id: :integer, force: :cascade do |t|
     t.integer "notifiee_id"
     t.string "notifiee_type"
     t.string "unique_key"
@@ -1112,7 +1112,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at"
   end
 
-  create_table "number_value_versions", force: :cascade do |t|
+  create_table "number_value_versions", id: :integer, force: :cascade do |t|
     t.integer "number_value_id", null: false
     t.integer "version", null: false
     t.integer "version_creator_id"
@@ -1122,7 +1122,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["number_value_id"], name: "index_number_value_versions_on_number_value_id"
   end
 
-  create_table "number_values", force: :cascade do |t|
+  create_table "number_values", id: :integer, force: :cascade do |t|
     t.integer "version"
     t.integer "version_creator_id"
     t.integer "number", null: false
@@ -1177,7 +1177,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end
 
-  create_table "oauth_sessions", force: :cascade do |t|
+  create_table "oauth_sessions", id: :integer, force: :cascade do |t|
     t.integer "user_id"
     t.string "provider"
     t.string "access_token"
@@ -1218,7 +1218,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "openbis_endpoints", force: :cascade do |t|
+  create_table "openbis_endpoints", id: :integer, force: :cascade do |t|
     t.string "as_endpoint"
     t.string "space_perm_id"
     t.string "username"
@@ -1237,7 +1237,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.boolean "is_test", default: false
   end
 
-  create_table "organisms", force: :cascade do |t|
+  create_table "organisms", id: :integer, force: :cascade do |t|
     t.string "title"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -1252,7 +1252,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["project_id"], name: "index_organisms_projects_on_project_id"
   end
 
-  create_table "people", force: :cascade do |t|
+  create_table "people", id: :integer, force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "first_name"
@@ -1270,7 +1270,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.string "orcid"
   end
 
-  create_table "permissions", force: :cascade do |t|
+  create_table "permissions", id: :integer, force: :cascade do |t|
     t.string "contributor_type"
     t.integer "contributor_id"
     t.integer "policy_id"
@@ -1280,7 +1280,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["policy_id"], name: "index_permissions_on_policy_id"
   end
 
-  create_table "phenotypes", force: :cascade do |t|
+  create_table "phenotypes", id: :integer, force: :cascade do |t|
     t.text "description"
     t.text "comment"
     t.integer "strain_id"
@@ -1328,7 +1328,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["project_id"], name: "index_ph_projects_on_p_id"
   end
 
-  create_table "policies", force: :cascade do |t|
+  create_table "policies", id: :integer, force: :cascade do |t|
     t.string "name"
     t.integer "sharing_scope", limit: 1
     t.integer "access_type", limit: 1
@@ -1350,7 +1350,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["user_id", "can_view"], name: "index_presentation_auth_lookup_on_user_id_and_can_view"
   end
 
-  create_table "presentation_versions", force: :cascade do |t|
+  create_table "presentation_versions", id: :integer, force: :cascade do |t|
     t.integer "presentation_id"
     t.integer "version"
     t.text "revision_comments"
@@ -1373,7 +1373,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.integer "version_id"
   end
 
-  create_table "presentations", force: :cascade do |t|
+  create_table "presentations", id: :integer, force: :cascade do |t|
     t.integer "contributor_id"
     t.string "title"
     t.text "description"
@@ -1402,7 +1402,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["workflow_id", "presentation_id"], name: "index_presentations_workflows_on_workflow_pres"
   end
 
-  create_table "programmes", force: :cascade do |t|
+  create_table "programmes", id: :integer, force: :cascade do |t|
     t.string "title"
     t.text "description"
     t.integer "avatar_id"
@@ -1417,7 +1417,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.boolean "open_for_projects", default: false
   end
 
-  create_table "project_folder_assets", force: :cascade do |t|
+  create_table "project_folder_assets", id: :integer, force: :cascade do |t|
     t.integer "asset_id"
     t.string "asset_type"
     t.integer "project_folder_id"
@@ -1425,7 +1425,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at"
   end
 
-  create_table "project_folders", force: :cascade do |t|
+  create_table "project_folders", id: :integer, force: :cascade do |t|
     t.integer "project_id"
     t.string "title"
     t.text "description"
@@ -1437,7 +1437,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.boolean "deletable", default: true
   end
 
-  create_table "project_subscriptions", force: :cascade do |t|
+  create_table "project_subscriptions", id: :integer, force: :cascade do |t|
     t.integer "person_id"
     t.integer "project_id"
     t.string "unsubscribed_types"
@@ -1445,7 +1445,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["person_id", "project_id"], name: "index_project_subscriptions_on_person_id_and_project_id"
   end
 
-  create_table "projects", force: :cascade do |t|
+  create_table "projects", id: :integer, force: :cascade do |t|
     t.string "title"
     t.text "web_page"
     t.text "wiki_page"
@@ -1539,7 +1539,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["user_id", "can_view"], name: "index_publication_auth_lookup_on_user_id_and_can_view"
   end
 
-  create_table "publication_authors", force: :cascade do |t|
+  create_table "publication_authors", id: :integer, force: :cascade do |t|
     t.string "first_name"
     t.string "last_name"
     t.integer "publication_id"
@@ -1549,7 +1549,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.integer "person_id"
   end
 
-  create_table "publication_types", force: :cascade do |t|
+  create_table "publication_types", id: :integer, force: :cascade do |t|
     t.string "title"
     t.string "key"
     t.datetime "created_at", null: false
@@ -1585,7 +1585,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["publication_id"], name: "index_publication_versions_on_publication_id"
   end
 
-  create_table "publications", force: :cascade do |t|
+  create_table "publications", id: :integer, force: :cascade do |t|
     t.integer "pubmed_id"
     t.text "title"
     t.text "abstract"
@@ -1622,13 +1622,13 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["item_id", "item_type"], name: "index_rdf_generation_queues_on_item_id_and_item_type"
   end
 
-  create_table "recommended_model_environments", force: :cascade do |t|
+  create_table "recommended_model_environments", id: :integer, force: :cascade do |t|
     t.string "title"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "reindexing_queues", force: :cascade do |t|
+  create_table "reindexing_queues", id: :integer, force: :cascade do |t|
     t.string "item_type"
     t.integer "item_id"
     t.datetime "created_at"
@@ -1637,7 +1637,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["item_id", "item_type"], name: "index_reindexing_queues_on_item_id_and_item_type"
   end
 
-  create_table "relationship_types", force: :cascade do |t|
+  create_table "relationship_types", id: :integer, force: :cascade do |t|
     t.string "title"
     t.text "description"
     t.datetime "created_at"
@@ -1645,7 +1645,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.string "key"
   end
 
-  create_table "relationships", force: :cascade do |t|
+  create_table "relationships", id: :integer, force: :cascade do |t|
     t.string "subject_type", null: false
     t.integer "subject_id", null: false
     t.string "predicate", null: false
@@ -1669,10 +1669,10 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
   end
 
   create_table "roles", force: :cascade do |t|
-    t.integer "person_id"
-    t.integer "role_type_id"
+    t.bigint "person_id"
+    t.bigint "role_type_id"
     t.string "scope_type"
-    t.integer "scope_id"
+    t.bigint "scope_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["person_id", "role_type_id"], name: "index_roles_on_person_id_and_role_type_id"
@@ -1681,7 +1681,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["scope_type", "scope_id"], name: "index_roles_on_scope"
   end
 
-  create_table "sample_attribute_types", force: :cascade do |t|
+  create_table "sample_attribute_types", id: :integer, force: :cascade do |t|
     t.string "title"
     t.string "base_type"
     t.text "regexp"
@@ -1692,7 +1692,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.string "resolution"
   end
 
-  create_table "sample_attributes", force: :cascade do |t|
+  create_table "sample_attributes", id: :integer, force: :cascade do |t|
     t.string "title"
     t.integer "sample_attribute_type_id"
     t.boolean "required", default: false
@@ -1725,7 +1725,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["user_id", "can_view"], name: "index_sample_auth_lookup_on_user_id_and_can_view"
   end
 
-  create_table "sample_controlled_vocab_terms", force: :cascade do |t|
+  create_table "sample_controlled_vocab_terms", id: :integer, force: :cascade do |t|
     t.text "label"
     t.integer "sample_controlled_vocab_id"
     t.datetime "created_at", null: false
@@ -1734,7 +1734,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.string "parent_iri"
   end
 
-  create_table "sample_controlled_vocabs", force: :cascade do |t|
+  create_table "sample_controlled_vocabs", id: :integer, force: :cascade do |t|
     t.string "title"
     t.text "description"
     t.datetime "created_at", null: false
@@ -1744,12 +1744,12 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.string "ols_root_term_uri"
     t.boolean "required"
     t.string "short_name"
-    t.integer "template_id"
     t.string "key"
+    t.integer "template_id"
     t.boolean "custom_input", default: false
   end
 
-  create_table "sample_resource_links", force: :cascade do |t|
+  create_table "sample_resource_links", id: :integer, force: :cascade do |t|
     t.integer "sample_id"
     t.integer "resource_id"
     t.string "resource_type"
@@ -1757,7 +1757,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["sample_id"], name: "index_sample_resource_links_on_sample_id"
   end
 
-  create_table "sample_types", force: :cascade do |t|
+  create_table "sample_types", id: :integer, force: :cascade do |t|
     t.string "title"
     t.string "uuid"
     t.datetime "created_at", null: false
@@ -1778,7 +1778,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["study_id"], name: "index_sample_types_studies_on_study_id"
   end
 
-  create_table "samples", force: :cascade do |t|
+  create_table "samples", id: :integer, force: :cascade do |t|
     t.string "title"
     t.integer "sample_type_id"
     t.text "json_metadata"
@@ -1793,7 +1793,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.string "deleted_contributor"
   end
 
-  create_table "saved_searches", force: :cascade do |t|
+  create_table "saved_searches", id: :integer, force: :cascade do |t|
     t.integer "user_id"
     t.text "search_query"
     t.text "search_type"
@@ -1802,7 +1802,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.boolean "include_external_search", default: false
   end
 
-  create_table "sessions", force: :cascade do |t|
+  create_table "sessions", id: :integer, force: :cascade do |t|
     t.string "session_id", null: false
     t.text "data", size: :medium
     t.datetime "created_at"
@@ -1811,7 +1811,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
-  create_table "settings", force: :cascade do |t|
+  create_table "settings", id: :integer, force: :cascade do |t|
     t.string "var", null: false
     t.text "value"
     t.integer "target_id"
@@ -1823,14 +1823,14 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["target_type", "target_id", "var"], name: "index_settings_on_target_type_and_target_id_and_var", unique: true
   end
 
-  create_table "site_announcement_categories", force: :cascade do |t|
+  create_table "site_announcement_categories", id: :integer, force: :cascade do |t|
     t.string "title"
     t.string "icon_key"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "site_announcements", force: :cascade do |t|
+  create_table "site_announcements", id: :integer, force: :cascade do |t|
     t.integer "announcer_id"
     t.string "announcer_type"
     t.string "title"
@@ -1844,7 +1844,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at"
   end
 
-  create_table "snapshots", force: :cascade do |t|
+  create_table "snapshots", id: :integer, force: :cascade do |t|
     t.string "resource_type"
     t.integer "resource_id"
     t.string "doi"
@@ -1867,7 +1867,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["user_id", "can_view"], name: "index_sop_auth_lookup_on_user_id_and_can_view"
   end
 
-  create_table "sop_versions", force: :cascade do |t|
+  create_table "sop_versions", id: :integer, force: :cascade do |t|
     t.integer "sop_id"
     t.integer "version"
     t.text "revision_comments"
@@ -1888,7 +1888,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["sop_id"], name: "index_sop_versions_on_sop_id"
   end
 
-  create_table "sops", force: :cascade do |t|
+  create_table "sops", id: :integer, force: :cascade do |t|
     t.integer "contributor_id"
     t.string "title"
     t.text "description"
@@ -1919,7 +1919,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["workflow_id"], name: "index_sops_workflows_on_workflow_id"
   end
 
-  create_table "special_auth_codes", force: :cascade do |t|
+  create_table "special_auth_codes", id: :integer, force: :cascade do |t|
     t.string "code"
     t.date "expiration_date"
     t.string "asset_type"
@@ -1945,7 +1945,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.integer "descendant_id"
   end
 
-  create_table "strains", force: :cascade do |t|
+  create_table "strains", id: :integer, force: :cascade do |t|
     t.string "title"
     t.integer "organism_id"
     t.datetime "created_at"
@@ -1963,7 +1963,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.string "deleted_contributor"
   end
 
-  create_table "studied_factor_links", force: :cascade do |t|
+  create_table "studied_factor_links", id: :integer, force: :cascade do |t|
     t.string "substance_type"
     t.integer "substance_id"
     t.integer "studied_factor_id"
@@ -1971,7 +1971,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at"
   end
 
-  create_table "studied_factors", force: :cascade do |t|
+  create_table "studied_factors", id: :integer, force: :cascade do |t|
     t.integer "measured_item_id"
     t.float "start_value"
     t.float "end_value"
@@ -1985,7 +1985,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["data_file_id"], name: "index_studied_factors_on_data_file_id"
   end
 
-  create_table "studies", force: :cascade do |t|
+  create_table "studies", id: :integer, force: :cascade do |t|
     t.text "title"
     t.text "description"
     t.integer "investigation_id"
@@ -2014,7 +2014,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["user_id", "can_view"], name: "index_study_auth_lookup_on_user_id_and_can_view"
   end
 
-  create_table "subscriptions", force: :cascade do |t|
+  create_table "subscriptions", id: :integer, force: :cascade do |t|
     t.integer "person_id"
     t.integer "subscribable_id"
     t.string "subscribable_type"
@@ -2024,7 +2024,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.integer "project_subscription_id"
   end
 
-  create_table "suggested_assay_types", force: :cascade do |t|
+  create_table "suggested_assay_types", id: :integer, force: :cascade do |t|
     t.string "label"
     t.string "ontology_uri"
     t.integer "contributor_id"
@@ -2033,7 +2033,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.integer "parent_id"
   end
 
-  create_table "suggested_technology_types", force: :cascade do |t|
+  create_table "suggested_technology_types", id: :integer, force: :cascade do |t|
     t.string "label"
     t.string "ontology_uri"
     t.integer "contributor_id"
@@ -2042,7 +2042,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.integer "parent_id"
   end
 
-  create_table "synonyms", force: :cascade do |t|
+  create_table "synonyms", id: :integer, force: :cascade do |t|
     t.string "name"
     t.integer "substance_id"
     t.string "substance_type"
@@ -2051,7 +2051,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["substance_id", "substance_type"], name: "index_synonyms_on_substance_id_and_substance_type"
   end
 
-  create_table "taggings", force: :cascade do |t|
+  create_table "taggings", id: :integer, force: :cascade do |t|
     t.integer "tag_id"
     t.integer "taggable_id"
     t.integer "tagger_id"
@@ -2063,7 +2063,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context"
   end
 
-  create_table "tags", force: :cascade do |t|
+  create_table "tags", id: :integer, force: :cascade do |t|
     t.string "name"
   end
 
@@ -2136,7 +2136,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["title", "group"], name: "index_templates_title_group"
   end
 
-  create_table "text_values", force: :cascade do |t|
+  create_table "text_values", id: :integer, force: :cascade do |t|
     t.integer "version"
     t.integer "version_creator_id"
     t.text "text", size: :medium, null: false
@@ -2144,13 +2144,13 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.datetime "updated_at"
   end
 
-  create_table "tissue_and_cell_types", force: :cascade do |t|
+  create_table "tissue_and_cell_types", id: :integer, force: :cascade do |t|
     t.string "title"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "units", force: :cascade do |t|
+  create_table "units", id: :integer, force: :cascade do |t|
     t.string "title"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -2159,7 +2159,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.integer "order"
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", id: :integer, force: :cascade do |t|
     t.string "login"
     t.string "crypted_password", limit: 64
     t.string "salt", limit: 40
@@ -2177,7 +2177,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.string "uuid"
   end
 
-  create_table "work_groups", force: :cascade do |t|
+  create_table "work_groups", id: :integer, force: :cascade do |t|
     t.string "name"
     t.integer "institution_id"
     t.integer "project_id"
@@ -2198,7 +2198,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["user_id", "can_view"], name: "index_w_auth_lookup_on_user_id_and_can_view"
   end
 
-  create_table "workflow_classes", force: :cascade do |t|
+  create_table "workflow_classes", id: :integer, force: :cascade do |t|
     t.string "title"
     t.text "description"
     t.string "key"
@@ -2228,7 +2228,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["workflow_id", "data_file_id"], name: "index_data_files_workflows_on_workflow_data_file"
   end
 
-  create_table "workflow_versions", force: :cascade do |t|
+  create_table "workflow_versions", id: :integer, force: :cascade do |t|
     t.integer "workflow_id"
     t.integer "version"
     t.text "revision_comments"
@@ -2253,7 +2253,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["workflow_id"], name: "index_workflow_versions_on_workflow_id"
   end
 
-  create_table "workflows", force: :cascade do |t|
+  create_table "workflows", id: :integer, force: :cascade do |t|
     t.integer "contributor_id"
     t.string "title"
     t.text "description"
@@ -2274,7 +2274,7 @@ ActiveRecord::Schema.define(version: 2023_08_09_054421) do
     t.index ["contributor_id"], name: "index_workflows_on_contributor"
   end
 
-  create_table "worksheets", force: :cascade do |t|
+  create_table "worksheets", id: :integer, force: :cascade do |t|
     t.integer "content_blob_id"
     t.integer "last_row"
     t.integer "last_column"

--- a/lib/tasks/seek_upgrades.rake
+++ b/lib/tasks/seek_upgrades.rake
@@ -8,6 +8,7 @@ namespace :seek do
   # these are the tasks required for this version upgrade
   task upgrade_version_tasks: %i[
     environment
+    strip_sample_attribute_pids
   ]
 
   # these are the tasks that are executes for each upgrade as standard, and rarely change
@@ -42,6 +43,19 @@ namespace :seek do
     ensure
       Seek::Config.solr_enabled = solr
     end
+  end
+
+  task(strip_sample_attribute_pids: [:environment]) do
+    puts '... Stripping Sample Attribute PIds ...'
+    n = 0
+    SampleAttribute.where('pid is NOT NULL AND pid !=?','').each do |attribute|
+      new_pid = attribute.pid.strip
+      if attribute.pid != new_pid
+        attribute.update_column(:pid, new_pid)
+        n += 1
+      end
+    end
+    puts "... Finished stripping #{n} Sample Attribute PIds."
   end
 
   private

--- a/test/unit/sample_attribute_test.rb
+++ b/test/unit/sample_attribute_test.rb
@@ -326,12 +326,6 @@ class SampleAttributeTest < ActiveSupport::TestCase
     attribute = FactoryBot.create(:string_sample_attribute_with_description_and_pid, is_title: true, pid: 'http://pid.org/attr/title', sample_type: FactoryBot.create(:simple_sample_type))
     assert_equal 'title',attribute.short_pid
 
-    attribute.update_column(:pid, "CHEBI:222\t")
-    assert_equal 'CHEBI:222',attribute.short_pid
-
-    attribute.pid = "   CHEBI:222  "
-    assert_equal 'CHEBI:222',attribute.short_pid
-
     attribute = FactoryBot.create(:sample_sample_attribute, sample_type: FactoryBot.create(:simple_sample_type))
     assert_equal '', attribute.short_pid
   end

--- a/test/unit/sample_attribute_test.rb
+++ b/test/unit/sample_attribute_test.rb
@@ -66,6 +66,7 @@ class SampleAttributeTest < ActiveSupport::TestCase
                                     sample_attribute_type: FactoryBot.create(:integer_sample_attribute_type),
                                     sample_type: FactoryBot.create(:simple_sample_type)
     refute attribute.valid?
+
     attribute.pid = 'http://somewhere.org#fish'
     assert attribute.valid?
     attribute.pid = 'dc:fish'
@@ -74,6 +75,17 @@ class SampleAttributeTest < ActiveSupport::TestCase
 
     attribute = SampleAttribute.new
     refute attribute.valid?
+  end
+
+  test 'auto strip pid' do
+    attribute = SampleAttribute.new title: 'fish', pid:"   wibble:12\t  ",
+                                    sample_attribute_type: FactoryBot.create(:integer_sample_attribute_type),
+                                    sample_type: FactoryBot.create(:simple_sample_type)
+    assert attribute.valid?
+    assert_equal 'wibble:12', attribute.pid
+    attribute.pid = "  wibble:12\n "
+    assert attribute.valid?
+    assert_equal 'wibble:12', attribute.pid
   end
 
   test 'validate value - without required' do
@@ -313,6 +325,12 @@ class SampleAttributeTest < ActiveSupport::TestCase
 
     attribute = FactoryBot.create(:string_sample_attribute_with_description_and_pid, is_title: true, pid: 'http://pid.org/attr/title', sample_type: FactoryBot.create(:simple_sample_type))
     assert_equal 'title',attribute.short_pid
+
+    attribute.update_column(:pid, "CHEBI:222\t")
+    assert_equal 'CHEBI:222',attribute.short_pid
+
+    attribute.pid = "   CHEBI:222  "
+    assert_equal 'CHEBI:222',attribute.short_pid
 
     attribute = FactoryBot.create(:sample_sample_attribute, sample_type: FactoryBot.create(:simple_sample_type))
     assert_equal '', attribute.short_pid


### PR DESCRIPTION
Fix for generating the short_pid for cases where the longer pid includes tabs or newline, or trailing spaces. Although passing the URI validation, it was causing an error when trying to parse the URI

* Fix for #1627 

Now automatcally strips the pid, and upgrade task will fix any previous ones created before the autosplitting