### PR TITLE
Remove ontology attribute type

### DIFF
--- a/app/assets/javascripts/sample_types.js
+++ b/app/assets/javascripts/sample_types.js
@@ -72,12 +72,10 @@ var SampleTypes = {
     attributeTypeChanged: function (e, resetSelection=true) {
         //check if it is a controlled vocab, and change the state of the controlled vocab selector if need be
         var use_cv = $j(this).find(':selected').data('use-cv');
-				var is_ontology = $j(this).find(':selected').data('is-ontology');
         var cv_element = $j(this).siblings('.controlled-vocab-block');
         if (use_cv) {
 					var cv_selection = cv_element.find('.controlled-vocab-selection');
 					cv_selection.find('option').show();
-					cv_selection.find(`option[data-is-ontology="${!is_ontology}"]`).hide();
 					if (resetSelection) cv_selection.find('option:selected').prop("selected", false);
           cv_element.show();
         }

--- a/app/models/sample_attribute.rb
+++ b/app/models/sample_attribute.rb
@@ -59,6 +59,11 @@ class SampleAttribute < ApplicationRecord
     nil
   end
 
+  # whether this attribute is tied to a controlled vocab which has a source ontology
+  def ontology_based?
+    controlled_vocab? && sample_controlled_vocab&.source_ontology.present?
+  end
+
   private
 
   def store_accessor_name

--- a/app/models/sample_attribute.rb
+++ b/app/models/sample_attribute.rb
@@ -22,7 +22,7 @@ class SampleAttribute < ApplicationRecord
   # sample type exists
   attr_reader :deferred_link_to_self
 
-  # whether this attribute is tied to a controlled vocab which has a source ontology
+  # whether this attribute is tied to a controlled vocab which is based on an ontology
   delegate :ontology_based?, to: :sample_controlled_vocab, allow_nil: true
 
   def title=(title)

--- a/app/models/sample_attribute.rb
+++ b/app/models/sample_attribute.rb
@@ -22,6 +22,9 @@ class SampleAttribute < ApplicationRecord
   # sample type exists
   attr_reader :deferred_link_to_self
 
+  # whether this attribute is tied to a controlled vocab which has a source ontology
+  delegate :ontology_based?, to: :sample_controlled_vocab, allow_nil: true
+
   def title=(title)
     super
     store_accessor_name
@@ -57,11 +60,6 @@ class SampleAttribute < ApplicationRecord
 
   def linked_custom_metadata_type
     nil
-  end
-
-  # whether this attribute is tied to a controlled vocab which has a source ontology
-  def ontology_based?
-    controlled_vocab? && sample_controlled_vocab&.source_ontology.present?
   end
 
   private

--- a/app/models/sample_attribute_type.rb
+++ b/app/models/sample_attribute_type.rb
@@ -4,6 +4,7 @@ class SampleAttributeType < ApplicationRecord
   validate :validate_allowed_type, :validate_regular_expression, :validate_resolution
 
   has_many :sample_attributes, inverse_of: :sample_attribute_type
+  has_many :isa_template_attributes, class_name: 'TemplateAttribute', inverse_of: :sample_attribute_type
   has_many :custom_metadata_attributes, inverse_of: :sample_attribute_type
 
   before_save :set_defaults_attributes

--- a/app/models/sample_attribute_type.rb
+++ b/app/models/sample_attribute_type.rb
@@ -109,10 +109,6 @@ class SampleAttributeType < ApplicationRecord
     base_type == Seek::Samples::BaseType::SEEK_DATA_FILE
   end
 
-  def ontology?
-    controlled_vocab? && title == 'Ontology'
-  end
-
   def base_type_handler(additional_options = {})
     Seek::Samples::AttributeTypeHandlers::AttributeTypeHandlerFactory.instance.for_base_type(base_type, additional_options)
   end

--- a/app/views/sample_types/_sample_attribute_form.html.erb
+++ b/app/views/sample_types/_sample_attribute_form.html.erb
@@ -52,13 +52,15 @@
   </td>
   <td>
     <%= select_tag "#{field_name_prefix}[sample_attribute_type_id]",
-                   options_for_select(displayed_sample_attribute_types.sort_by(&:title).sort_by { |t| t.default? ? 0 : 1 }.map { |t| [t.title, t.id,{'data-use-cv'=>t.controlled_vocab? || t.seek_cv_list?, 'data-is-seek-sample'=>t.seek_sample? || t.seek_sample_multi? }] }, attribute_type_id),
+                   options_for_select(displayed_sample_attribute_types.sort_by(&:title).sort_by { |t| t.default? ? 0 : 1 }.map do |t|
+                     [t.title, t.id,{'data-use-cv': t.controlled_vocab? || t.seek_cv_list?, 'data-is-seek-sample': t.seek_sample? || t.seek_sample_multi? }]
+                   end , attribute_type_id),
                    class: 'form-control sample-type-attribute-type',
                    disabled: !allow_type_change, data: { attr: "type" } %>
     <div class='controlled-vocab-block' style="<%= 'display:none;' unless sample_attribute.try(:controlled_vocab?) || sample_attribute.try(:seek_cv_list?) %>">
       <br/>
       <%= select_tag "#{field_name_prefix}[sample_controlled_vocab_id]",
-                     options_for_select(SampleControlledVocab.all.map { |scv| [scv.title, scv.id, {'data-editable'=>scv.can_edit?}] },
+                     options_for_select(SampleControlledVocab.all.map { |scv| [scv.title, scv.id, {'data-editable': scv.can_edit?}] },
                                         sample_controlled_vocab_id),
                      include_blank: true,
                      class: 'form-control controlled-vocab-selection',

--- a/app/views/sample_types/_sample_attribute_form.html.erb
+++ b/app/views/sample_types/_sample_attribute_form.html.erb
@@ -52,13 +52,13 @@
   </td>
   <td>
     <%= select_tag "#{field_name_prefix}[sample_attribute_type_id]",
-                   options_for_select(displayed_sample_attribute_types.sort_by(&:title).sort_by { |t| t.default? ? 0 : 1 }.map { |t| [t.title, t.id,{'data-use-cv'=>t.controlled_vocab? || t.seek_cv_list?,'data-is-ontology'=>t.ontology?, 'data-is-seek-sample'=>t.seek_sample? || t.seek_sample_multi? }] }, attribute_type_id),
+                   options_for_select(displayed_sample_attribute_types.sort_by(&:title).sort_by { |t| t.default? ? 0 : 1 }.map { |t| [t.title, t.id,{'data-use-cv'=>t.controlled_vocab? || t.seek_cv_list?, 'data-is-seek-sample'=>t.seek_sample? || t.seek_sample_multi? }] }, attribute_type_id),
                    class: 'form-control sample-type-attribute-type',
                    disabled: !allow_type_change, data: { attr: "type" } %>
     <div class='controlled-vocab-block' style="<%= 'display:none;' unless sample_attribute.try(:controlled_vocab?) || sample_attribute.try(:seek_cv_list?) %>">
       <br/>
       <%= select_tag "#{field_name_prefix}[sample_controlled_vocab_id]",
-                     options_for_select(SampleControlledVocab.all.map { |scv| [scv.title, scv.id, {'data-editable'=>scv.can_edit?, 'data-is-ontology'=>scv.custom_input?}] },
+                     options_for_select(SampleControlledVocab.all.map { |scv| [scv.title, scv.id, {'data-editable'=>scv.can_edit?}] },
                                         sample_controlled_vocab_id),
                      include_blank: true,
                      class: 'form-control controlled-vocab-selection',

--- a/app/views/templates/_template_attribute_form.erb
+++ b/app/views/templates/_template_attribute_form.erb
@@ -42,13 +42,15 @@
   </td>
   <td>
     <%= select_tag "#{field_name_prefix}[sample_attribute_type_id]",
-                   options_for_select(SampleAttributeType.all.sort_by(&:title).sort_by { |t| t.default? ? 0 : 1 }.map { |t| [t.title, t.id,{'data-is-cv'=>t.controlled_vocab?,'data-is-seek-sample'=>t.seek_sample? || t.seek_sample_multi? }] }, attribute_type_id),
+                   options_for_select(SampleAttributeType.all.sort_by(&:title).sort_by { |t| t.default? ? 0 : 1 }.map do |t|
+                     [t.title, t.id,{'data-is-cv': t.controlled_vocab?,'data-is-seek-sample': t.seek_sample? || t.seek_sample_multi? }]
+                   end, attribute_type_id),
                    class: 'form-control sample-type-attribute-type', data: {attr: "type"} %>
 
     <div class='controlled-vocab-block' style="<%= 'display:none;' unless template_attribute.try(:controlled_vocab?) %>">
       <br/>
       <%= select_tag "#{field_name_prefix}[sample_controlled_vocab_id]",
-                     options_for_select(SampleControlledVocab.all.map { |scv| [scv.title, scv.id, {'data-editable'=>scv.can_edit?}] },
+                     options_for_select(SampleControlledVocab.all.map { |scv| [scv.title, scv.id, {'data-editable': scv.can_edit?}] },
                       sample_controlled_vocab_id),include_blank: true,
                      class: 'form-control controlled-vocab-selection', data: {attr: "cv_id"} %>
 

--- a/app/views/templates/_template_attribute_form.erb
+++ b/app/views/templates/_template_attribute_form.erb
@@ -42,13 +42,13 @@
   </td>
   <td>
     <%= select_tag "#{field_name_prefix}[sample_attribute_type_id]",
-                   options_for_select(SampleAttributeType.all.sort_by(&:title).sort_by { |t| t.default? ? 0 : 1 }.map { |t| [t.title, t.id,{'data-is-cv'=>t.controlled_vocab?,'data-is-ontology'=>t.ontology?, 'data-is-seek-sample'=>t.seek_sample? || t.seek_sample_multi? }] }, attribute_type_id),
+                   options_for_select(SampleAttributeType.all.sort_by(&:title).sort_by { |t| t.default? ? 0 : 1 }.map { |t| [t.title, t.id,{'data-is-cv'=>t.controlled_vocab?,'data-is-seek-sample'=>t.seek_sample? || t.seek_sample_multi? }] }, attribute_type_id),
                    class: 'form-control sample-type-attribute-type', data: {attr: "type"} %>
 
     <div class='controlled-vocab-block' style="<%= 'display:none;' unless template_attribute.try(:controlled_vocab?) %>">
       <br/>
       <%= select_tag "#{field_name_prefix}[sample_controlled_vocab_id]",
-                     options_for_select(SampleControlledVocab.all.map { |scv| [scv.title, scv.id, {'data-editable'=>scv.can_edit?, 'data-is-ontology'=>scv.custom_input?}] },
+                     options_for_select(SampleControlledVocab.all.map { |scv| [scv.title, scv.id, {'data-editable'=>scv.can_edit?}] },
                       sample_controlled_vocab_id),include_blank: true,
                      class: 'form-control controlled-vocab-selection', data: {attr: "cv_id"} %>
 

--- a/db/seeds/007_sample_attribute_types.seeds.rb
+++ b/db/seeds/007_sample_attribute_types.seeds.rb
@@ -79,9 +79,6 @@ ncbi_type.update(base_type: Seek::Samples::BaseType::STRING, regexp: '[0-9]+', p
 data_file_type = SampleAttributeType.find_or_initialize_by(title: 'Registered Data file')
 data_file_type.update(base_type: Seek::Samples::BaseType::SEEK_DATA_FILE)
 
-ontology_type = SampleAttributeType.find_or_initialize_by(title:'Ontology')
-ontology_type.update(base_type: Seek::Samples::BaseType::CV)
-
 cv_list_type = SampleAttributeType.find_or_initialize_by(title:'Controlled Vocabulary List')
 cv_list_type.update(base_type: Seek::Samples::BaseType::CV_LIST)
 

--- a/lib/isa_exporter.rb
+++ b/lib/isa_exporter.rb
@@ -173,7 +173,7 @@ module IsaExporter
       sample_types = @investigation.studies.map(&:sample_types) + @investigation.assays.map(&:sample_type)
       sample_types.flatten.each do |sa|
         sa.sample_attributes.each do |atr|
-          source_ontologies << atr.sample_controlled_vocab.source_ontology if atr.sample_attribute_type.ontology?
+          source_ontologies << atr.sample_controlled_vocab.source_ontology if atr.ontology_based?
         end
       end
       source_ontologies.uniq.map { |s| { name: s, file: '', version: '', description: '' } }
@@ -487,7 +487,7 @@ module IsaExporter
     end
 
     def get_ontology_details(sample_attribute, label, vocab_term)
-      is_ontology = sample_attribute.sample_attribute_type.ontology?
+      is_ontology = sample_attribute.ontology_based?
       iri = ''
       if is_ontology
         iri =

--- a/lib/tasks/seek_upgrades.rake
+++ b/lib/tasks/seek_upgrades.rake
@@ -89,7 +89,7 @@ namespace :seek do
 
         ontology_attr_type.destroy
       else
-        puts '..... Target Controlled Vocabulary attribute not found'
+        puts '..... Target Controlled Vocabulary attribute type not found'
       end
     end
   end

--- a/test/unit/sample_attribute_test.rb
+++ b/test/unit/sample_attribute_test.rb
@@ -330,6 +330,22 @@ class SampleAttributeTest < ActiveSupport::TestCase
     assert_equal '', attribute.short_pid
   end
 
+  test 'ontology_based?' do
+    attribute = FactoryBot.create(:sample_sample_attribute, sample_type: FactoryBot.create(:simple_sample_type))
+    refute attribute.ontology_based?
+
+    attribute = FactoryBot.create(:simple_string_sample_attribute, sample_type: FactoryBot.create(:simple_sample_type))
+    refute attribute.ontology_based?
+
+    attribute = FactoryBot.create(:apples_controlled_vocab_attribute, sample_type: FactoryBot.create(:simple_sample_type))
+    refute attribute.sample_controlled_vocab.ontology_based?
+    refute attribute.ontology_based?
+
+    attribute.sample_controlled_vocab = FactoryBot.create(:topics_controlled_vocab)
+    assert attribute.sample_controlled_vocab.ontology_based?
+    assert attribute.ontology_based?
+  end
+
   private
 
   def valid_value?(attribute, value)

--- a/test/unit/sample_attribute_type_test.rb
+++ b/test/unit/sample_attribute_type_test.rb
@@ -247,4 +247,22 @@ class SampleAttributeTypeTest < ActiveSupport::TestCase
     type = FactoryBot.create(:controlled_vocab_attribute_type)
     refute type.seek_data_file?
   end
+
+  test 'isa_template_attributes' do
+    type = FactoryBot.create(:age_sample_attribute_type)
+    type2 = FactoryBot.create(:weight_sample_attribute_type)
+
+    ta1 = FactoryBot.create(:template_attribute, sample_attribute_type: type)
+    ta2 = FactoryBot.create(:template_attribute, sample_attribute_type: type)
+    ta3 = FactoryBot.create(:template_attribute, sample_attribute_type: type)
+    ta4 = FactoryBot.create(:template_attribute, sample_attribute_type: type2)
+
+    type.reload
+    template_attributes = type.isa_template_attributes
+    assert_equal 3, template_attributes.count
+    assert_includes template_attributes, ta1
+    assert_includes template_attributes, ta2
+    assert_includes template_attributes, ta3
+    assert_not_includes template_attributes, ta4
+  end
 end


### PR DESCRIPTION
Remove '_Ontology_' `SampleAttributeType`, which was really a duplicate of '_Controlled Vocabulary_'

required removing some legacy javascript behaviour that filtered the list of CV's available, but based on `.custom_input?` rather than whether they are ontology based. 
An upgrade task migrates existing sample attributes linked to '_Ontololgy_' to '_Controlled Vocabularly_'

* fix for  #1632