### PR TITLE
Allow new cv terms when populated from an ontology

### DIFF
--- a/app/assets/javascripts/controlled_vocabs.js.erb
+++ b/app/assets/javascripts/controlled_vocabs.js.erb
@@ -135,23 +135,6 @@ CVTerms = {
             }
         });
     },
-    disableAddTermButton: function(reason) {
-        $j('a#add-term').attr('disabled', true);
-        if (!$j('a#add-term').parent().is('span')) {
-            let span = $j('a#add-term').wrap('<span />').parent();
-            $j(span).attr('data-tooltip', reason);
-            bindTooltips('div#controlled-vocab-terms');
-            $j(span).click(function () {
-                alert(reason);
-            });
-        }
-    },
-    enableAddTermButton: function() {
-        let button = $j('a#add-term');
-        button.attr('disabled',false);
-        button.removeClass('disabled');
-        button.unwrap('span');
-    },
     // sets up and trigger the ajax call to fetch the terms list
     fetchTermsAJAX: function () {
         $j('div#controlled-vocab-terms').hide();
@@ -209,10 +192,8 @@ CVTerms = {
             if (selected.value == "") {
                 $j('#sample_controlled_vocab_ols_root_term_uri').val('');
                 $j('#ontology-root-uri').hide();
-                CVTerms.enableAddTermButton();
             } else {
                 $j('#ontology-root-uri').show();
-                CVTerms.disableAddTermButton('<%= I18n.t('controlled_vocabs.add_new_term_disabled_reason') %>');
                 var link = $j('a#selected-ols-link');
                 link.text(selected.text);
                 link.attr('href', '<%= Ebi::OlsClient::ROOT_URL %>/ontologies/' + selected.value);

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -19,6 +19,7 @@
 *= require organisms
 *= require human_diseases
 *= require samples
+*= require controlled_vocabs
 *= require DataTables-1.11.3/dataTables.bootstrap
 *= require DataTables-1.11.3/select.bootstrap
 *= require DataTables-1.11.3/buttons.bootstrap

--- a/app/assets/stylesheets/controlled_vocabs.css
+++ b/app/assets/stylesheets/controlled_vocabs.css
@@ -1,0 +1,7 @@
+#controlled-vocab-terms #controlled-vocab-terms-fixed {
+    margin-bottom: 1em;
+}
+
+#controlled-vocab-terms #new-terms {
+    width: 100%;
+}

--- a/app/views/sample_controlled_vocabs/_form.html.erb
+++ b/app/views/sample_controlled_vocabs/_form.html.erb
@@ -103,11 +103,7 @@
         </table>
       </div>
       <div>
-        <%
-          options = {id: 'add-term'}
-          options.merge!({disabled:true, disabled_reason:t('controlled_vocabs.add_new_term_disabled_reason')}) if @sample_controlled_vocab.ontology_based?
-        %>
-        <%= button_link_to('Add new term', 'add', '#', options) %>
+        <%= button_link_to('Add new term', 'add', '#', id: 'add-term') %>
         <%= button_link_to('Remove all terms', 'destroy', '#', :id => 'clear-terms', class:'btn btn-danger') %>
       </div>
     </div>

--- a/app/views/sample_controlled_vocabs/_form.html.erb
+++ b/app/views/sample_controlled_vocabs/_form.html.erb
@@ -67,7 +67,7 @@
 
     <div id='controlled-vocab-terms'>
       <div id='controlled-vocab-terms-fixed'>
-        <table id="new-terms" class="table" style="width:100%;">
+        <table id='new-terms' class='table'>
           <thead>
           <th>Label<span class="required">*</span></th>
           <th>URI</th>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -284,9 +284,6 @@ you can choose to have a %{project} linked to a site managed %{programme} instea
   Alternatively, if you are unable to use the %{issue_tracker_link}, or the issue is of a private nature, then you can use the %{feedback_link}.
   <p>'
 
-  controlled_vocabs:
-    add_new_term_disabled_reason: "You are unable to add new terms when linked to an Ontology"
-
   info_text:
     institution: "An Institution in SEEK is where someone is employed or works or a person's affiliation."
     #person: "A Person (People) in SEEK is a registered user or a Profile of a person that has not registered with SEEK. A Person is someone who participates directly or indirectly in the scientific research described within SEEK."

--- a/test/functional/sample_controlled_vocabs_controller_test.rb
+++ b/test/functional/sample_controlled_vocabs_controller_test.rb
@@ -246,10 +246,6 @@ class SampleControlledVocabsControllerTest < ActionController::TestCase
       end
     end
 
-    assert_select('a#add-term') do |button|
-      assert button.attr('disabled').present?
-    end
-
   end
 
   test 'edit simple, non ontology cv should have editable terms' do


### PR DESCRIPTION
Removed the actions that disabled/enabled the add term button.

Also tweaked the styling slightly to give a gap between the term list and the buttons, and moved to CSS