### PR TITLE
Remove required field from SampleControlledVocab

### DIFF
--- a/app/serializers/sample_controlled_vocab_serializer.rb
+++ b/app/serializers/sample_controlled_vocab_serializer.rb
@@ -1,5 +1,5 @@
 class SampleControlledVocabSerializer < BaseSerializer
-  attributes :title, :description, :source_ontology, :ols_root_term_uri, :required, :short_name
+  attributes :title, :description, :source_ontology, :ols_root_term_uri, :short_name
   attributes :sample_controlled_vocab_terms_attributes
   
   has_many :sample_controlled_vocab_terms

--- a/db/migrate/20231115152940_remove_required_from_sample_controlled_vocab.rb
+++ b/db/migrate/20231115152940_remove_required_from_sample_controlled_vocab.rb
@@ -1,0 +1,5 @@
+class RemoveRequiredFromSampleControlledVocab < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :sample_controlled_vocabs, :required , :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_11_14_110917) do
+ActiveRecord::Schema.define(version: 2023_11_15_152940) do
 
   create_table "activity_logs", id: :integer, force: :cascade do |t|
     t.string "action"
@@ -1744,7 +1744,6 @@ ActiveRecord::Schema.define(version: 2023_11_14_110917) do
     t.string "first_letter", limit: 1
     t.string "source_ontology"
     t.string "ols_root_term_uri"
-    t.boolean "required"
     t.string "short_name"
     t.string "key"
     t.integer "template_id"

--- a/public/api/examples/sampleControlledVocabPatch.json
+++ b/public/api/examples/sampleControlledVocabPatch.json
@@ -1,17 +1,16 @@
 {
   "data": {
-    "id": "11",
+    "id": "18",
     "type": "sample_controlled_vocabs",
     "attributes": {
       "title": "new title",
       "description": "new description",
       "source_ontology": "new source ontology",
       "ols_root_term_uri": "http://new-uri.org",
-      "required": true,
       "short_name": "new short name",
       "sample_controlled_vocab_terms_attributes": [
         {
-          "id": "35",
+          "id": "17",
           "label": "new term label",
           "iri": "new iri",
           "parent_iri": "new parent_iri"

--- a/public/api/examples/sampleControlledVocabPatchResponse.json
+++ b/public/api/examples/sampleControlledVocabPatchResponse.json
@@ -1,17 +1,16 @@
 {
   "data": {
-    "id": "11",
+    "id": "18",
     "type": "sample_controlled_vocabs",
     "attributes": {
       "title": "new title",
       "description": "new description",
       "source_ontology": "new source ontology",
       "ols_root_term_uri": "http://new-uri.org",
-      "required": true,
       "short_name": "new short name",
       "sample_controlled_vocab_terms_attributes": [
         {
-          "id": "35",
+          "id": "17",
           "label": "new term label",
           "iri": "new iri",
           "parent_iri": "new parent_iri"
@@ -22,18 +21,18 @@
       "sample_controlled_vocab_terms": {
         "data": [
           {
-            "id": "35",
+            "id": "17",
             "type": "sample_controlled_vocab_terms"
           }
         ]
       }
     },
     "links": {
-      "self": "/sample_controlled_vocabs/11"
+      "self": "/sample_controlled_vocabs/18"
     },
     "meta": {
-      "created": "2022-06-07T14:14:38.000Z",
-      "modified": "2022-06-07T14:14:38.000Z",
+      "created": "2023-11-15T16:36:00.000Z",
+      "modified": "2023-11-15T16:36:00.000Z",
       "api_version": "0.3",
       "base_url": "http://localhost:3000"
     }

--- a/public/api/examples/sampleControlledVocabPost.json
+++ b/public/api/examples/sampleControlledVocabPost.json
@@ -6,7 +6,6 @@
       "description": "some description",
       "source_ontology": "EFO",
       "ols_root_term_uri": null,
-      "required": true,
       "short_name": "short_name",
       "sample_controlled_vocab_terms_attributes": [
         {

--- a/public/api/examples/sampleControlledVocabPostResponse.json
+++ b/public/api/examples/sampleControlledVocabPostResponse.json
@@ -1,17 +1,16 @@
 {
   "data": {
-    "id": "10",
+    "id": "17",
     "type": "sample_controlled_vocabs",
     "attributes": {
       "title": "New Vocab Max",
       "description": "some description",
       "source_ontology": "EFO",
       "ols_root_term_uri": null,
-      "required": true,
       "short_name": "short_name",
       "sample_controlled_vocab_terms_attributes": [
         {
-          "id": "34",
+          "id": "16",
           "label": "organism",
           "iri": "http://some_iri",
           "parent_iri": "http://another_iri"
@@ -22,18 +21,18 @@
       "sample_controlled_vocab_terms": {
         "data": [
           {
-            "id": "34",
+            "id": "16",
             "type": "sample_controlled_vocab_terms"
           }
         ]
       }
     },
     "links": {
-      "self": "/sample_controlled_vocabs/10"
+      "self": "/sample_controlled_vocabs/17"
     },
     "meta": {
-      "created": "2022-06-07T14:14:38.000Z",
-      "modified": "2022-06-07T14:14:38.000Z",
+      "created": "2023-11-15T16:36:00.000Z",
+      "modified": "2023-11-15T16:36:00.000Z",
       "api_version": "0.3",
       "base_url": "http://localhost:3000"
     }

--- a/test/fixtures/json/requests/patch_max_sample_controlled_vocab.json.erb
+++ b/test/fixtures/json/requests/patch_max_sample_controlled_vocab.json.erb
@@ -7,7 +7,6 @@
       "description": "new description",
       "source_ontology": "new source ontology",
       "ols_root_term_uri": "http://new-uri.org",
-      "required": true,
       "short_name": "new short name",
       "sample_controlled_vocab_terms_attributes": [
         {

--- a/test/fixtures/json/requests/post_max_sample_controlled_vocab.json.erb
+++ b/test/fixtures/json/requests/post_max_sample_controlled_vocab.json.erb
@@ -6,7 +6,6 @@
       "description": "some description",
       "source_ontology": "EFO",
       "ols_root_term_uri": null,
-      "required": true,
       "short_name": "short_name",
       "sample_controlled_vocab_terms_attributes": [
         {

--- a/test/fixtures/json/responses/get_max_sample_controlled_vocab.json.erb
+++ b/test/fixtures/json/responses/get_max_sample_controlled_vocab.json.erb
@@ -7,7 +7,6 @@
       "description": "Description for organism",
       "source_ontology": "EFO",
       "ols_root_term_uri": "",
-      "required": "true",
       "short_name": "organism",
       "sample_controlled_vocab_terms_attributes": [
         {

--- a/test/fixtures/json/responses/get_min_sample_controlled_vocab.json.erb
+++ b/test/fixtures/json/responses/get_min_sample_controlled_vocab.json.erb
@@ -7,7 +7,6 @@
       "description": null,
       "source_ontology": null,
       "ols_root_term_uri": null,
-      "required": null,
       "short_name": null,
       "sample_controlled_vocab_terms_attributes": null,
       "repository_standard": null

--- a/test/integration/api/sample_controlled_vocab_api_test.rb
+++ b/test/integration/api/sample_controlled_vocab_api_test.rb
@@ -10,7 +10,7 @@ class SampleControlledVocabApiTest < ActionDispatch::IntegrationTest
 
     @sample_controlled_vocab = SampleControlledVocab.new({ title:"a title", description:"some description",
                                                            source_ontology: "EFO", ols_root_term_uri: "http://a_uri",
-                                                           required: "true", short_name: "short_name" })
+                                                           short_name: "short_name" })
                                                            
     @sample_controlled_vocab_term = SampleControlledVocabTerm.new({ label: "organism", iri: "http://some_iri",
                                                                     parent_iri: "http://another_iri" })


### PR DESCRIPTION
an old artifact that is no longer needed. Required updating the api tests and examples, but otherwise unused. There are no API docs for sample controlled vocab that needed updating.

* fix for #1661 