### PR TITLE
Fix isa exporter permissions

### DIFF
--- a/app/views/investigations/_buttons.html.erb
+++ b/app/views/investigations/_buttons.html.erb
@@ -9,13 +9,14 @@
 <% if item.can_edit? -%>
   <% if displaying_single_page? %>
     <%= button_link_to("Design #{t('study')}", 'new', new_isa_study_path(investigation_id: item, single_page: params[:single_page])) %>
-    <% if Seek::Config.isa_json_compliance_enabled %>
-      <%= button_link_to("Export ISA", 'download', export_isa_single_page_path(id: params[:single_page], investigation_id: item)) %>
-    <% end -%>
   <% else -%>
     <%= add_new_item_to_dropdown(item) %>
   <% end -%>
 <% end -%>
+
+<% if item.can_view? && displaying_single_page? && Seek::Config.isa_json_compliance_enabled%>
+  <%= button_link_to("Export ISA", 'download', export_isa_single_page_path(id: params[:single_page], investigation_id: item)) %>
+<% end %>
 
 <%= item_actions_dropdown do %>
   <% if item.can_edit? %>

--- a/lib/isa_exporter.rb
+++ b/lib/isa_exporter.rb
@@ -323,11 +323,19 @@ module IsaExporter
         sample_type.sample_attributes.select { |sa| sa.isa_tag&.isa_source_characteristic? }
 
       sample_type.samples.map do |s|
-        {
-          '@id': "#source/#{s.id}",
-          name: s.get_attribute_value(with_tag_source),
-          characteristics: convert_characteristics(s, with_tag_source_characteristic)
-        }
+        if s.can_view?(@current_user)
+          {
+            '@id': "#source/#{s.id}",
+            name: s.get_attribute_value(with_tag_source),
+            characteristics: convert_characteristics(s, with_tag_source_characteristic)
+          }
+        else
+          {
+            '@id': "#source/HIDDEN",
+            name: 'Hidden Sample',
+            characteristics: []
+          }
+        end
       end
     end
 

--- a/lib/isa_exporter.rb
+++ b/lib/isa_exporter.rb
@@ -36,7 +36,7 @@ module IsaExporter
       isa_investigation[:people] = people
 
       studies = []
-      @investigation.studies.each { |s| studies << convert_study(s) }
+      @investigation.studies.each { |s| studies << convert_study(s) if s.can_view?(@current_user) }
       isa_investigation[:studies] = studies
 
       @OBJECT_MAP = @OBJECT_MAP.merge(isa_investigation)
@@ -62,7 +62,6 @@ module IsaExporter
           })
         end
       end
-      ###################################################
 
       study_comments.append({
         '@id': "#study_comment/#{ [study_id, UUID.new.generate].join('_') }",
@@ -136,7 +135,7 @@ module IsaExporter
         assay_stream
       end
 
-      isa_study[:assays] = assay_streams.map { |assay_stream| convert_assays(assay_stream) }
+      isa_study[:assays] = assay_streams.map { |assay_stream| convert_assays(assay_stream) }.compact
 
       isa_study[:factors] = []
       isa_study[:unitCategories] = []
@@ -186,6 +185,8 @@ module IsaExporter
     end
 
     def convert_assays(assays)
+      return unless assays.all? { |a| a.can_view?(@current_user) }
+
       all_sample_types = assays.map(&:sample_type)
       first_assay = assays.detect { |s| s.position.zero? }
       raise 'No assay could be found!' unless first_assay

--- a/lib/isa_exporter.rb
+++ b/lib/isa_exporter.rb
@@ -642,7 +642,7 @@ module IsaExporter
 
     def process_sequence_input(inputs, type)
       input_ids = inputs.map { |input| input[:id] }
-      authorized_sample_ids = Sample.where(id: input_ids).select { |s| s.can_view?(@current_user) }.map(&:id).compact
+      authorized_sample_ids = Sample.where(id: input_ids).authorized_for(:view, @current_user).map(&:id)
       input_ids.map do |input_id|
         if authorized_sample_ids.include?(input_id)
           { '@id': "##{type}/#{input_id}" }
@@ -696,7 +696,7 @@ module IsaExporter
 
     def extract_sample_ids(input_obj_list, type)
       sample_ids = input_obj_list.map { |io| io[:id] }
-      authorized_sample_ids = Sample.where(id: sample_ids).select { |sample| sample.can_view?(@current_user) }.map(&:id)
+      authorized_sample_ids = Sample.where(id: sample_ids).authorized_for(:view, @current_user).map(&:id)
 
       sample_ids.map do |s_id|
         if authorized_sample_ids.include?(s_id)

--- a/lib/isa_exporter.rb
+++ b/lib/isa_exporter.rb
@@ -123,7 +123,7 @@ module IsaExporter
       isa_study[:protocols] = protocols
 
       isa_study[:processSequence] = convert_process_sequence(study.sample_types.second, study.sops.map(&:id).join("_"), study.id)
-      assay_streams = study.assays.map { |assay| [assay] if assay&.position&.zero? }.compact
+      assay_streams = study.assays.map { |assay| [assay] if assay&.position&.zero? }
                            .compact
                            .map do |assay_stream|
         last_assay = assay_stream.first

--- a/lib/isa_exporter.rb
+++ b/lib/isa_exporter.rb
@@ -640,11 +640,12 @@ module IsaExporter
       grouped_samples.transform_keys { |key| group_id(key) }
     end
 
-    def process_sequence_input(input_ids, type)
-      authorized_sample_ids = Sample.where(id: input_ids).select { |s| s.can_view?(@current_user).map(&:id) }
-      input_ids.map do |input|
-        if authorized_sample_ids.include?(input[:id])
-          { '@id': "##{type}/#{input[:id]}" }
+    def process_sequence_input(inputs, type)
+      input_ids = inputs.map { |input| input[:id] }
+      authorized_sample_ids = Sample.where(id: input_ids).select { |s| s.can_view?(@current_user) }.map(&:id).compact
+      input_ids.map do |input_id|
+        if authorized_sample_ids.include?(input_id)
+          { '@id': "##{type}/#{input_id}" }
         else
           { '@id': "##{type}/HIDDEN" }
         end

--- a/lib/isa_exporter.rb
+++ b/lib/isa_exporter.rb
@@ -123,7 +123,7 @@ module IsaExporter
       isa_study[:protocols] = protocols
 
       isa_study[:processSequence] = convert_process_sequence(study.sample_types.second, study.sops.map(&:id).join("_"), study.id)
-      assay_streams = study.assays.map { |assay| [assay] if assay.position.zero? }
+      assay_streams = study.assays.map { |assay| [assay] if assay&.position&.zero? }.compact
                            .compact
                            .map do |assay_stream|
         last_assay = assay_stream.first

--- a/lib/isa_exporter.rb
+++ b/lib/isa_exporter.rb
@@ -1,8 +1,9 @@
 # noinspection ALL
 module IsaExporter
   class Exporter
-    def initialize(investigation)
+    def initialize(investigation, user)
       @investigation = investigation
+      @current_user = user
       @OBJECT_MAP = {}
     end
 

--- a/test/functional/single_pages_controller_test.rb
+++ b/test/functional/single_pages_controller_test.rb
@@ -100,30 +100,233 @@ class SinglePagesControllerTest < ActionController::TestCase
               },
               contributor: other_user.person)
 
-      assay_sample_type = FactoryBot.create(:isa_assay_material_sample_type, linked_sample_type: sample_collection_sample_type, template_id: FactoryBot.create(:isa_assay_material_template).id)
-      # Create a 'private' assay
-      FactoryBot.create(:assay, sample_type: assay_sample_type, study: accessible_study, contributor: other_user.person)
+      # Create a 'private' assay in an assay stream
+      assay_1_stream_1_sample_type = FactoryBot.create(:isa_assay_material_sample_type, linked_sample_type: sample_collection_sample_type, template_id: FactoryBot.create(:isa_assay_material_template).id)
+      assay_1_stream_1 = FactoryBot.create(:assay, position: 0, sample_type: assay_1_stream_1_sample_type, study: accessible_study, contributor: current_user.person)
+      assay_2_stream_1_sample_type = FactoryBot.create(:isa_assay_data_file_sample_type, linked_sample_type: assay_1_stream_1_sample_type, template_id: FactoryBot.create(:isa_assay_data_file_template).id)
+      assay_2_stream_1 = FactoryBot.create(:assay, position:1, sample_type: assay_2_stream_1_sample_type, study: accessible_study, contributor: other_user.person)
+
+      # Create an assay stream with all assays visible
+      assay_1_stream_2_sample_type = FactoryBot.create(:isa_assay_material_sample_type, linked_sample_type: sample_collection_sample_type, template_id: FactoryBot.create(:isa_assay_material_template).id)
+      assay_1_stream_2 = FactoryBot.create(:assay, position: 0, sample_type: assay_1_stream_2_sample_type, study: accessible_study, contributor: current_user.person)
+      assay_2_stream_2_sample_type = FactoryBot.create(:isa_assay_data_file_sample_type, linked_sample_type: assay_1_stream_2_sample_type, template_id: FactoryBot.create(:isa_assay_data_file_template).id)
+      assay_2_stream_2 = FactoryBot.create(:assay, position:1, sample_type: assay_2_stream_2_sample_type, study: accessible_study, contributor: current_user.person)
+
+      # create samples in second assay stream with viewing permission
+
+      assay_1_stream_2_sample =
+      FactoryBot.create(:sample,
+              title: 'Assay 1 - stream 2 - sample 1',
+              sample_type: assay_1_stream_2_sample_type,
+              project_ids: [project.id],
+              data: {
+                Input: [study_sample.id],
+                'Protocol Assay 1': 'Protocol Assay 1',
+                'Assay 1 parameter value 1': 'Assay 1 parameter value 1',
+                'Assay 1 parameter value 2': assay_1_stream_2_sample_type
+                                            .sample_attributes
+                                            .find_by(title: 'Assay 1 parameter value 2')
+                                            .sample_controlled_vocab
+                                            .sample_controlled_vocab_terms
+                                            .first
+                                            .label,
+                'Assay 1 parameter value 3': assay_1_stream_2_sample_type
+                                            .sample_attributes
+                                            .find_by(title: 'Assay 1 parameter value 3')
+                                            .sample_controlled_vocab
+                                            .sample_controlled_vocab_terms
+                                            .first
+                                            .label,
+                'Extract Name': 'Extract 1 stream 2',
+                'other material characteristic 1': 'other material characteristic 1',
+                'other material characteristic 2': assay_1_stream_2_sample_type
+                                                  .sample_attributes
+                                                  .find_by(title: 'other material characteristic 2')
+                                                  .sample_controlled_vocab
+                                                  .sample_controlled_vocab_terms
+                                                  .first
+                                                  .label,
+                'other material characteristic 3': assay_1_stream_2_sample_type
+                                                  .sample_attributes
+                                                  .find_by(title: 'other material characteristic 3')
+                                                  .sample_controlled_vocab
+                                                  .sample_controlled_vocab_terms
+                                                  .first
+                                                  .label},
+              contributor: current_user.person)
+
+              assay_1_stream_2_hidden_sample =
+              FactoryBot.create(:sample,
+                      title: 'Assay 1 - stream 2 - sample 2',
+                      sample_type: assay_1_stream_2_sample_type,
+                      project_ids: [project.id],
+                      data: {
+                        Input: [study_sample.id],
+                        'Protocol Assay 1': 'Protocol Assay 1',
+                        'Assay 1 parameter value 1': 'Assay 1 parameter value 1',
+                        'Assay 1 parameter value 2': assay_1_stream_2_sample_type
+                                                    .sample_attributes
+                                                    .find_by(title: 'Assay 1 parameter value 2')
+                                                    .sample_controlled_vocab
+                                                    .sample_controlled_vocab_terms
+                                                    .second
+                                                    .label,
+                        'Assay 1 parameter value 3': assay_1_stream_2_sample_type
+                                                    .sample_attributes
+                                                    .find_by(title: 'Assay 1 parameter value 3')
+                                                    .sample_controlled_vocab
+                                                    .sample_controlled_vocab_terms
+                                                    .second
+                                                    .label,
+                        'Extract Name': 'Extract 1 stream 2',
+                        'other material characteristic 1': 'other material characteristic 1',
+                        'other material characteristic 2': assay_1_stream_2_sample_type
+                                                          .sample_attributes
+                                                          .find_by(title: 'other material characteristic 2')
+                                                          .sample_controlled_vocab
+                                                          .sample_controlled_vocab_terms
+                                                          .second
+                                                          .label,
+                        'other material characteristic 3': assay_1_stream_2_sample_type
+                                                          .sample_attributes
+                                                          .find_by(title: 'other material characteristic 3')
+                                                          .sample_controlled_vocab
+                                                          .sample_controlled_vocab_terms
+                                                          .second
+                                                          .label},
+                      contributor: other_user.person)
+
+      assay_2_stream_2_sample =
+      FactoryBot.create(:sample,
+              title: 'Assay 2 - stream 2 - sample 1',
+              sample_type: assay_2_stream_2_sample_type,
+              project_ids: [project.id],
+              data: {
+                Input: [assay_1_stream_2_sample.id],
+                'Protocol Assay 2': 'Protocol Assay 2',
+                'Assay 2 parameter value 1': 'Assay 2 parameter value 1',
+                'Assay 2 parameter value 2': assay_2_stream_2_sample_type
+                                            .sample_attributes
+                                            .find_by(title: 'Assay 2 parameter value 2')
+                                            .sample_controlled_vocab
+                                            .sample_controlled_vocab_terms
+                                            .first
+                                            .label,
+                'Assay 2 parameter value 3': assay_2_stream_2_sample_type
+                                            .sample_attributes
+                                            .find_by(title: 'Assay 2 parameter value 3')
+                                            .sample_controlled_vocab
+                                            .sample_controlled_vocab_terms
+                                            .first
+                                            .label,
+                'File Name': 'file 1 stream 2',
+                'Data file comment 1': 'Data file comment 1',
+                'Data file comment 2': assay_2_stream_2_sample_type
+                                      .sample_attributes
+                                      .find_by(title: 'Data file comment 2')
+                                      .sample_controlled_vocab
+                                      .sample_controlled_vocab_terms
+                                      .first
+                                      .label,
+                'Data file comment 3': assay_2_stream_2_sample_type
+                                      .sample_attributes
+                                      .find_by(title: 'Data file comment 3')
+                                      .sample_controlled_vocab
+                                      .sample_controlled_vocab_terms
+                                      .first
+                                      .label},
+              contributor: current_user.person)
+
+      assay_2_stream_2_hidden_sample =
+      FactoryBot.create(:sample,
+              title: 'Assay 2 - stream 2 - sample 2',
+              sample_type: assay_2_stream_2_sample_type,
+              project_ids: [project.id],
+              data: {
+                Input: [assay_1_stream_2_sample.id],
+                'Protocol Assay 2': 'Protocol Assay 2',
+                'Assay 2 parameter value 1': 'Assay 2 parameter value 1',
+                'Assay 2 parameter value 2': assay_2_stream_2_sample_type
+                                            .sample_attributes
+                                            .find_by(title: 'Assay 2 parameter value 2')
+                                            .sample_controlled_vocab
+                                            .sample_controlled_vocab_terms
+                                            .second
+                                            .label,
+                'Assay 2 parameter value 3': assay_2_stream_2_sample_type
+                                            .sample_attributes
+                                            .find_by(title: 'Assay 2 parameter value 3')
+                                            .sample_controlled_vocab
+                                            .sample_controlled_vocab_terms
+                                            .second
+                                            .label,
+                'File Name': 'file 1 stream 2',
+                'Data file comment 1': 'Data file comment 1',
+                'Data file comment 2': assay_2_stream_2_sample_type
+                                      .sample_attributes
+                                      .find_by(title: 'Data file comment 2')
+                                      .sample_controlled_vocab
+                                      .sample_controlled_vocab_terms
+                                      .second
+                                      .label,
+                'Data file comment 3': assay_2_stream_2_sample_type
+                                      .sample_attributes
+                                      .find_by(title: 'Data file comment 3')
+                                      .sample_controlled_vocab
+                                      .sample_controlled_vocab_terms
+                                      .second
+                                      .label},
+              contributor: other_user.person)
+
 
       get :export_isa, params: { id: project.id, investigation_id: investigation.id }
 
+      assert_response :success
       json_investigation = JSON.parse(response.body)
       assert json_investigation['studies'].map { |s| s['title'] }.include? accessible_study.title
       study_json = json_investigation['studies'].first
-      assert study_json['assays'].blank?
 
-      sample_names = study_json['materials']['samples'].map { |sample| sample['name'] }
+      # Only one assay should end up in 1 assay stream in the ISA JSON
+      assert_equal accessible_study.assays.count, 4
+      assert_equal study_json['assays'].count, 1
 
-      assert sample_names.include?(study_sample.title)
-      refute sample_names.include?(hidden_study_sample.title)
+      sample_ids = study_json['materials']['samples'].map { |sample| sample['@id'] }
 
-      study_process_sequence = study_json['processSequence']
-      output_ids=[]
-      study_process_samples = study_process_sequence.map do |process|
-        process['outputs'].map { |output| output_ids.push(output['@id']) }
+      # Check whether permitted samples end up in the materials
+      assert sample_ids.include?("#sample/#{study_sample.id}")
+      refute sample_ids.include?("#sample/#{hidden_study_sample.id}")
+
+      # Check whether permitted study samples end up in the study's processSequence
+      study_output_ids = []
+      study_json['processSequence'].map do |process|
+        process['outputs'].map { |output| study_output_ids.push(output['@id']) }
       end
 
-      assert output_ids.include? "#sample/#{study_sample.id}"
-      refute output_ids.include? "#sample/#{hidden_study_sample.id}"
+      assert study_output_ids.include? "#sample/#{study_sample.id}"
+      refute study_output_ids.include? "#sample/#{hidden_study_sample.id}"
+
+      assay_json = study_json['assays'].first
+
+      # Check otherMaterials
+      other_material_ids = assay_json['materials']['otherMaterials'].map { |om| om['@id'] }
+      assert other_material_ids.include? "#other_material/#{assay_1_stream_2_sample.id}"
+      refute other_material_ids.include? "#other_material/#{assay_1_stream_2_hidden_sample.id}"
+
+      # Check dataFiles
+      data_file_ids = assay_json['dataFiles'].map { |df| df['@id'] }
+      assert data_file_ids.include? "#data_file/#{assay_2_stream_2_sample.id}"
+      refute data_file_ids.include? "#data_file/#{assay_2_stream_2_hidden_sample.id}"
+
+      # Check whether permitted study samples end up in the assay's processSequence
+      assay_output_ids = []
+      assay_json['processSequence'].map do |process|
+        process['outputs'].map { |output| assay_output_ids.push(output['@id']) }
+      end
+
+      assert assay_output_ids.include? "#other_material/#{assay_1_stream_2_sample.id}"
+      assert assay_output_ids.include? "#data_file/#{assay_2_stream_2_sample.id}"
+      refute assay_output_ids.include? "#other_material/#{assay_1_stream_2_hidden_sample.id}"
+      refute assay_output_ids.include? "#data_file/#{assay_2_stream_2_hidden_sample.id}"
     end
   end
 

--- a/test/integration/isa_exporter_test.rb
+++ b/test/integration/isa_exporter_test.rb
@@ -195,7 +195,7 @@ class IsaExporterTest < ActionDispatch::IntegrationTest
     end
     materials = materials.map { |so| so['@id'] }
     processes = processes.flatten.map { |p| p['@id'] }
-    materials.each { |p| assert processes.include?(p) }
+materials.each { |p| assert processes.include?(p) }
   end
 
   # 23
@@ -295,7 +295,7 @@ class IsaExporterTest < ActionDispatch::IntegrationTest
   end
 
   def create_basic_isa_project
-    person = FactoryBot.create(:person, project: @project)
+    person = @current_user.person
 
     source =
       FactoryBot.create(
@@ -326,7 +326,8 @@ class IsaExporterTest < ActionDispatch::IntegrationTest
         :study,
         investigation: @investigation,
         sample_types: [source, sample_collection],
-        sops: [FactoryBot.create(:sop, policy: FactoryBot.create(:public_policy))]
+        sops: [FactoryBot.create(:sop, policy: FactoryBot.create(:public_policy))],
+        contributor: person
       )
 
     FactoryBot.create(
@@ -334,7 +335,7 @@ class IsaExporterTest < ActionDispatch::IntegrationTest
       study: study,
       sample_type: assay_sample_type,
       sop_ids: [FactoryBot.create(:sop, policy: FactoryBot.create(:public_policy)).id],
-      contributor: @current_user.person,
+      contributor: person,
       position: 0
     )
 
@@ -355,7 +356,8 @@ class IsaExporterTest < ActionDispatch::IntegrationTest
                     .sample_controlled_vocab_terms
                     .first
                     .label
-              }
+              },
+              contributor: person
 
     sample_2 =
       FactoryBot.create :sample,
@@ -368,7 +370,8 @@ class IsaExporterTest < ActionDispatch::IntegrationTest
                 'sample collection parameter value 1': 'sample collection parameter value 1',
                 'Sample Name': 'sample name',
                 'sample characteristic 1': 'sample characteristic 1'
-              }
+              },
+              contributor: person
 
     FactoryBot.create :sample,
             title: 'sample_3',
@@ -380,7 +383,8 @@ class IsaExporterTest < ActionDispatch::IntegrationTest
               'Assay 1 parameter value 1': 'Assay 1 parameter value 1',
               'Extract Name': 'Extract Name',
               'other material characteristic 1': 'other material characteristic 1'
-            }
+            },
+            contributor: person
 
     { source: source,
       sample_collection: sample_collection,

--- a/test/unit/isa_exporter_test.rb
+++ b/test/unit/isa_exporter_test.rb
@@ -2,7 +2,8 @@ require 'test_helper'
 
 class IsaExporterTest < ActionController::TestCase
   test 'find sample origin' do
-    controller = IsaExporter::Exporter.new FactoryBot.create(:investigation)
+    current_user = FactoryBot.create(:user)
+    controller = IsaExporter::Exporter.new(FactoryBot.create(:investigation), current_user)
     project = FactoryBot.create(:project)
 
     type_1 = FactoryBot.create(:simple_sample_type, project_ids: [project.id])


### PR DESCRIPTION
This PR implements the following:
- Checks whether the user has at least viewing permission to the ISA
  - A user needs viewing permission for the investigation
  - A user needs viewing permission for the studies.
  - A user needs viewing permission for all the assays in an assay stream (guarantees the linkage)
- Checks whether the user has at least viewing permission to the samples within that ISA.
  - If the user does not have the right permissions, it will hide the sample information.