### PR TITLE
fix for use of controlled vocabularies without attributes

### DIFF
--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -6,9 +6,8 @@ module SamplesHelper
     attribute_form_element(attribute, resource.get_attribute_value(attribute.title), element_name, element_class)
   end
 
-  def controlled_vocab_form_field(attribute, element_name, values, limit = 1)
+  def controlled_vocab_form_field(sample_controlled_vocab, element_name, values, allow_new = false, limit = 1)
 
-    sample_controlled_vocab = attribute.sample_controlled_vocab
     scv_id = sample_controlled_vocab.id
     object_struct = Struct.new(:id, :title)
     existing_objects = Array(values).collect do |value|
@@ -33,13 +32,13 @@ module SamplesHelper
     objects_input(element_name, existing_objects,
                   typeahead: typeahead,
                   limit: limit,
-                  allow_new: attribute.allow_cv_free_text?,
+                  allow_new: allow_new,
                   class: 'form-control')
 
   end
 
-  def controlled_vocab_list_form_field(attribute, element_name, values)
-    controlled_vocab_form_field(attribute, element_name, values, nil)
+  def controlled_vocab_list_form_field(sample_controlled_vocab, element_name, values, allow_new)
+    controlled_vocab_form_field(sample_controlled_vocab, element_name, values, allow_new, nil)
   end
 
   def linked_extended_metadata_multi_form_field(attribute, value, element_name, element_class)
@@ -341,9 +340,9 @@ module SamplesHelper
                                                    :title, value.try(:[], 'id'))
       select_tag(element_name, options, include_blank: !attribute.required?, class: "form-control #{element_class}")
     when Seek::Samples::BaseType::CV
-      controlled_vocab_form_field attribute, element_name, value
+      controlled_vocab_form_field attribute.sample_controlled_vocab, element_name, value, attribute.allow_cv_free_text?
     when Seek::Samples::BaseType::CV_LIST
-      controlled_vocab_list_form_field attribute, element_name, value
+      controlled_vocab_list_form_field attribute.sample_controlled_vocab, element_name, value, attribute.allow_cv_free_text?
     when Seek::Samples::BaseType::SEEK_SAMPLE
       sample_form_field attribute, element_name, value
     when Seek::Samples::BaseType::SEEK_SAMPLE_MULTI

--- a/test/functional/data_files_controller_test.rb
+++ b/test/functional/data_files_controller_test.rb
@@ -3499,6 +3499,23 @@ class DataFilesControllerTest < ActionController::TestCase
     assert_equal [good_assay],data_file.assays
   end
 
+  test 'provide metadata with controlled vocabs' do
+    FactoryBot.create(:data_formats_controlled_vocab)
+    FactoryBot.create(:data_types_controlled_vocab)
+    df = FactoryBot.build(:data_file, content_blob:FactoryBot.create(:txt_content_blob))
+    refute_nil df.content_blob
+    assay_to_be_created = FactoryBot.build(:assay,title:'new assay')
+    session[:processed_datafile]=df
+    session[:processed_assay]=assay_to_be_created
+
+    get :provide_metadata
+
+    assert_response :success
+
+    assert_select 'input+select#data_file_data_type_annotations'
+    assert_select 'input+select#data_file_data_format_annotations'
+  end
+
   test 'create assay should be checked with new assay containing title' do
     df = FactoryBot.build(:data_file, content_blob:FactoryBot.create(:txt_content_blob))
     refute_nil df.content_blob


### PR DESCRIPTION
revert tying the controlled vocab form fields directly to a sample attribute, but back to just the controlled vocab. This is because it is used in cases such as the data file forms separately from samples.

The error wasn't picked up by tests as it relied on the relevant controlled vocabs being in the database. A new test has been added to cover this:

* Fix addresses a bug introduced as part of #1659 

