### PR TITLE
allow users to override URL validation when the URL check returns a 4…

### DIFF
--- a/app/views/content_blobs/examine_url/_override.html.erb
+++ b/app/views/content_blobs/examine_url/_override.html.erb
@@ -1,0 +1,19 @@
+<div class="alert alert-danger" role="alert">
+  <span class="error_icon"></span>
+  Processing the URL responded with a response code <%= @info[:code] %>. <%= @error_msg %>.
+</div>
+
+<div class="alert alert-warning" role="alert">
+  <span class="warning_icon"></span>
+  <b>Warning</b>: You are attempting to register a remote URL that may not be valid. Our system is designed to validate URLs to ensure security and functionality. Please double-check the URL for accuracy.
+  If you are certain that the URL is correct and want to proceed despite the validation warning, please check the box below to override the URL check:
+
+ <%  title = "I understand the risks and want to override URL validation." %>
+  <%=
+  content_tag(:div, class: 'checkbox') do
+    content_tag(:label, class: 'override_url_check') do
+        check_box_tag("content_blobs[][override_url_check]",'yes', false) + title.html_safe
+        end
+  end
+%>
+</div>

--- a/lib/seek/upload_handling/data_upload.rb
+++ b/lib/seek/upload_handling/data_upload.rb
@@ -144,13 +144,17 @@ module Seek
         when 'http', 'https'
           handler = Seek::DownloadHandling::HTTPHandler.new(@data_url)
           info = handler.info
-          if info[:code] == 490
-            flash.now[:error] = 'The given URL is inaccessible.'
-            return false
-          end
-          unless [200, 401, 403].include?(info[:code])
-            flash.now[:error] = "Processing the URL responded with a response code (#{info[:code]}), indicating the URL is inaccessible."
-            return false
+          if (info[:code] == 400 || 404) && blob_params[:override_url_check].present?
+            flash.now[:notice] = 'The given URL is inaccessible but you can override the url validation.'
+          else
+            if info[:code] == 490
+              flash.now[:error] = 'The given URL is inaccessible.'
+              return false
+            end
+            unless [200, 401, 403].include?(info[:code])
+              flash.now[:error] = "Processing the URL responded with a response code (#{info[:code]}), indicating the URL is inaccessible."
+              return false
+            end
           end
         when 'ftp'
           handler = Seek::DownloadHandling::FTPHandler.new(@data_url)

--- a/lib/seek/upload_handling/examine_url.rb
+++ b/lib/seek/upload_handling/examine_url.rb
@@ -30,7 +30,7 @@ module Seek
         end
 
         respond_to do |format|
-          format.html { render partial: 'content_blobs/examine_url_result', status: @type == 'error' ? 400 : 200 }
+          format.html { render partial: 'content_blobs/examine_url_result', status: ( @type == 'error'|| @type == 'override') ? 400 : 200 }
         end
       end
 
@@ -74,8 +74,10 @@ module Seek
         when 405
           @error_msg = "We can't find out information about this URL - Method not allowed response."
         when 404
+          @type = 'override'
           @error_msg = 'Nothing can be found at that URL. Please check the address and try again'
         when 400
+          @type = 'override'
           @error_msg = 'The URL appears to be invalid'
         when 490
           @error_msg = 'That URL is inaccessible. Please check the address and try again'

--- a/test/functional/content_blobs_controller_test.rb
+++ b/test/functional/content_blobs_controller_test.rb
@@ -169,7 +169,8 @@ class ContentBlobsControllerTest < ActionController::TestCase
     assert_response 400
     assert_equal 404, assigns(:info)[:code]
     assert @response.body.include?('Nothing can be found at that URL')
-    assert_equal 'error', assigns(:type)
+    assert @response.body.include?('I understand the risks and want to override URL validation')
+    assert_equal 'override', assigns(:type)
     assert assigns(:error_msg)
   end
 
@@ -192,7 +193,8 @@ class ContentBlobsControllerTest < ActionController::TestCase
     assert_response 400
     assert_equal 404, assigns(:info)[:code]
     assert @response.body.include?('Nothing can be found at that URL')
-    assert_equal 'error', assigns(:type)
+    assert @response.body.include?('I understand the risks and want to override URL validation')
+    assert_equal 'override', assigns(:type)
     assert assigns(:error_msg)
   end
 
@@ -201,7 +203,8 @@ class ContentBlobsControllerTest < ActionController::TestCase
     get :examine_url, xhr: true, params: { data_url: 'this is not a uri' }
     assert_response 400
     assert @response.body.include?('The URL appears to be invalid')
-    assert_equal 'error', assigns(:type)
+    assert @response.body.include?('I understand the risks and want to override URL validation')
+    assert_equal 'override', assigns(:type)
     assert assigns(:error_msg)
   end
 
@@ -222,6 +225,7 @@ class ContentBlobsControllerTest < ActionController::TestCase
         assert_response 400
         assert_equal 490, assigns(:info)[:code]
         assert @response.body.include?('URL is inaccessible')
+        refute @response.body.include?('I understand the risks and want to override URL validation')
         assert_equal 'error', assigns(:type)
         assert assigns(:error_msg)
       end


### PR DESCRIPTION
Allow Users to Override URL Validation for HTTP 400/404 Responses #1673
https://github.com/seek4science/seek/issues/1673