### PR TITLE
performance improvements when doing update_lookup_table_for_all_users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -178,10 +178,10 @@ group :development do
   gem 'web-console', '>= 4.1.0'
   gem 'rack-mini-profiler', '~> 2.0'
   gem 'listen', '~> 3.3'
+  gem 'ruby-prof'
 end
 
 group :test do
-  gem 'ruby-prof'
   gem 'test-prof'
   gem 'rails-perftest'
   gem 'minitest', '~> 5.14'

--- a/lib/tasks/seek_dev.rake
+++ b/lib/tasks/seek_dev.rake
@@ -4,7 +4,7 @@ require 'rubygems'
 require 'rake'
 require 'active_record/fixtures'
 require 'benchmark'
-require 'ruby-prof'
+#require 'ruby-prof'
 
 include SysMODB::SpreadsheetExtractor
 


### PR DESCRIPTION
improvements at the database, in particular for delete_all or batch_update.
through testing it was found much quicker to do in a large single, ordered DESC using `in_batches`

in a large `sample_auth_lookup ` table for `sample.update_lookup_table_for_all_users` improvements went from 45-46s to 2-4s depending on whether .prepare was doing `delete_all/import` of `batch_update`