### PR TITLE
update to the order items are dequeued from the AuthLookupUpdateQueue - by priority then id

### DIFF
--- a/app/models/concerns/resource_queue.rb
+++ b/app/models/concerns/resource_queue.rb
@@ -12,10 +12,8 @@ module ResourceQueue
     end
 
     def prioritized
-      # including item_type in the order, encourages assets to be processed before users
-      #  (since they are much quicker, in the case of auth lookup processing), due to the happy coincidence that User
-      #  falls last alphabetically. Its not that important if a new authorized type is added after User in the future.
-      order(:priority, :item_type, :id)
+      # order by priority first, but then by id to make sure items come of the queue in the order they were added
+      order(:priority, :id)
     end
 
     def enqueue(*items, priority: DEFAULT_PRIORITY, queue_job: true)

--- a/lib/tasks/seek_dev.rake
+++ b/lib/tasks/seek_dev.rake
@@ -4,7 +4,6 @@ require 'rubygems'
 require 'rake'
 require 'active_record/fixtures'
 require 'benchmark'
-#require 'ruby-prof'
 
 include SysMODB::SpreadsheetExtractor
 

--- a/test/unit/permissions/auth_lookup_update_queue_test.rb
+++ b/test/unit/permissions/auth_lookup_update_queue_test.rb
@@ -296,20 +296,20 @@ class AuthLookupUpdateQueueTest < ActiveSupport::TestCase
   end
 
   test 'dequeue' do
-    df = FactoryBot.create(:data_file)
+    df1 = FactoryBot.create(:data_file)
     df2 = FactoryBot.create(:data_file)
     df3 = FactoryBot.create(:data_file)
-    user = df.contributor.user
+    user = df1.contributor.user
 
     AuthLookupUpdateQueue.destroy_all
 
-    AuthLookupUpdateQueue.enqueue(df3, priority: 1)
-    AuthLookupUpdateQueue.enqueue(df2, priority: 3)
-    AuthLookupUpdateQueue.enqueue(user, df, priority: 2)
+    AuthLookupUpdateQueue.enqueue(df1, priority: 1)
+    AuthLookupUpdateQueue.enqueue(user, df2, priority: 2)
+    AuthLookupUpdateQueue.enqueue(df3, priority: 3)
 
     assert_difference('AuthLookupUpdateQueue.count', -4) do
       items = AuthLookupUpdateQueue.dequeue(4)
-      assert_equal [df3, df, user, df2], items, "should be ordered by priority, type, then ID"
+      assert_equal [df1, user, df2, df3], items, "should be ordered by priority, then ID"
     end
 
     FactoryBot.create_list(:document, 10)


### PR DESCRIPTION
no longer order by `item_type`, so that items come of the queue in the order they arrived according to priority

where User was usefully ending up at the end of the list of items pulled, this is no longer required since if the item is a User a new `UserAuthLookupUpdateJob` is trigged anyway