### PR TITLE
Auto approve programmes and projects in site-managed programme

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -115,6 +115,8 @@ class AdminController < ApplicationController
     Seek::Config.organisms_enabled = string_to_boolean params[:organisms_enabled]
     Seek::Config.programmes_enabled = string_to_boolean params[:programmes_enabled]
     Seek::Config.programmes_open_for_projects_enabled = string_to_boolean params[:programmes_open_for_projects_enabled]
+    Seek::Config.auto_activate_programmes = string_to_boolean params[:auto_activate_programmes]
+    Seek::Config.auto_activate_site_managed_projects = string_to_boolean params[:auto_activate_site_managed_projects]
     Seek::Config.presentations_enabled = string_to_boolean params[:presentations_enabled]
     Seek::Config.publications_enabled = string_to_boolean params[:publications_enabled]
     Seek::Config.samples_enabled = string_to_boolean params[:samples_enabled]

--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -30,7 +30,7 @@ class ProgrammesController < ApplicationController
         # also activation email is sent
         unless User.admin_logged_in?
           if Seek::Config.auto_activate_programmes
-            @programe.activate
+            @programme.activate
             Mailer.programme_activated(@programme).deliver_later if Seek::Config.email_enabled
           else
             Mailer.programme_activation_required(@programme, current_person).deliver_later if Seek::Config.email_enabled

--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -29,8 +29,11 @@ class ProgrammesController < ApplicationController
         # current person becomes the programme administrator, unless they are logged in
         # also activation email is sent
         unless User.admin_logged_in?
-          if Seek::Config.email_enabled
-            Mailer.programme_activation_required(@programme,current_person).deliver_later
+          if Seek::Config.auto_activate_programmes
+            @programe.activate
+            Mailer.programme_activated(@programme).deliver_later if Seek::Config.email_enabled
+          else
+            Mailer.programme_activation_required(@programme, current_person).deliver_later if Seek::Config.email_enabled
           end
         end
         format.html {respond_with(@programme)}

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -204,7 +204,7 @@ class ProjectsController < ApplicationController
           else
             flash[:notice] = "Thank you, your #{t('project')} has been created"
             if Seek::Config.email_enabled
-              Mailer.notify_admins_project_creation_accepted(current_person, current_person, @project).deliver_later
+              Mailer.notify_admins_project_creation_accepted(nil, current_person, @project).deliver_later
             end
             redirect_to(@project)
           end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -213,7 +213,7 @@ class ProjectsController < ApplicationController
         if Seek::Config.email_enabled
           Mailer.request_create_project_for_programme(current_user, @programme, @project.to_json, @institution.to_json, log).deliver_later
         end
-        flash.now[:notice]="Thank you, your request for a new #{t('project')} has been sent"
+        flash.now[:notice] = "Thank you, your request for a new #{t('project')} has been sent"
       else
         raise 'Invalid Programme'
       end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -75,6 +75,9 @@ class ProjectsController < ApplicationController
   end
 
   def guided_create
+    @institution = Institution.new
+    @project = Project.new
+
     respond_to do |format|
       format.html
     end
@@ -177,7 +180,7 @@ class ProjectsController < ApplicationController
 
     @institution = Institution.find_by_id(params[:institution][:id])
     if @institution.nil?
-      inst_params = params.require(:institution).permit([:id, :title, :web_page, :city, :country])
+      inst_params = params.require(:institution).permit([:title, :web_page, :city, :country])
       @institution = Institution.new(inst_params)
     end
 
@@ -190,6 +193,17 @@ class ProjectsController < ApplicationController
         log = ProjectCreationMessageLog.log_request(sender:current_person, programme:@programme, project:@project, institution:@institution)
       elsif @programme.site_managed?
         log = ProjectCreationMessageLog.log_request(sender:current_person, programme:@programme, project:@project, institution:@institution)
+        if Seek::Config.auto_activate_site_managed_projects
+          @message_log = log
+          errors = confirm_project_create_request(skip_permissions: true)
+          if errors.present?
+            flash.now[:error] = errors
+            render action: :guided_create
+          else
+            flash[:notice] = "Thank you, your #{t('project')} has been created"
+            redirect_to(@project)
+          end
+        end
         if Seek::Config.email_enabled
           Mailer.request_create_project_for_programme(current_user, @programme, @project.to_json, @institution.to_json, log).deliver_later
         end
@@ -539,15 +553,9 @@ class ProjectsController < ApplicationController
   end
 
   def respond_create_project_request
-
     requester = @message_log.sender
-    make_programme_admin = false
 
     if params['accept_request']=='1'
-
-      # @programme already populated in before_filter when checking permissions
-      make_programme_admin = @programme&.new_record?
-
       if params['institution']['id']
         @institution = Institution.find(params['institution']['id'])
       else
@@ -557,62 +565,13 @@ class ProjectsController < ApplicationController
       @project = Project.new(params.require(:project).permit([:title, :web_page, :description]))
       @project.programme = @programme
 
-      validate_error_msg = []
-
-      unless @project.valid?
-        validate_error_msg << "The #{t('project')} is invalid, #{@project.errors.full_messages.join(', ')}"
-      end
-      unless @programme.nil? || @programme.valid?
-        validate_error_msg << "The #{t('programme')} is invalid, #{@programme.errors.full_messages.join(', ')}"
-      end
-      unless @institution.valid?
-        validate_error_msg << "The #{t('institution')} is invalid, #{@institution.errors.full_messages.join(', ')}"
-      end
-
-      unless @programme&.allows_user_projects? || Institution.can_create?
-        validate_error_msg << "The #{t('institution')} cannot be created, as you do not have access rights"
-      end
-
-      unless Project.can_create?
-        validate_error_msg << "The #{t('project')} cannot be created, as you do not have access rights"
-      end
-
-      validate_error_msg = validate_error_msg.join('<br/>').html_safe
-
-      if validate_error_msg.blank?
-        @project.save!
-
-        # they are soon to become a project administrator, with permission to create
-        disable_authorization_checks { @institution.save! }
-
-        requester.add_to_project_and_institution(@project, @institution)
-        requester.is_project_administrator = true,@project
-        requester.is_programme_administrator = true, @programme if make_programme_admin
-
-        disable_authorization_checks do
-          requester.save!
-        end
-
-        if @message_log.sent_by_self?
-          @message_log.destroy
-          flash[:notice]="#{t('project')} created"
-        else
-          @message_log.respond('Accepted')
-          if Seek::Config.email_enabled
-            flash[:notice]="Request accepted and #{requester.name} added to #{t('project')} and notified"
-            Mailer.notify_user_projects_assigned(requester,[@project]).deliver_later
-            Mailer.notify_admins_project_creation_accepted(current_person, requester, @project).deliver_later
-          else
-            flash[:notice]="Request accepted and #{requester.name} added to #{t('project')}"
-          end
-        end
-
-        redirect_to(@project)
-      else
-        flash.now[:error] = validate_error_msg
+      errors = confirm_project_create_request
+      if errors.present?
+        flash.now[:error] = errors
         render action: :administer_create_project_request
+      else
+        redirect_to(@project)
       end
-
     else
       if @message_log.sent_by_self? || params['delete_request'] == '1'
         @message_log.destroy
@@ -848,5 +807,63 @@ class ProjectsController < ApplicationController
       error(error_msg, error_msg)
       return false
     end
+  end
+
+  def confirm_project_create_request(skip_permissions: false)
+    requester = @message_log.sender
+    validate_error_msg = []
+
+    unless @project.valid?
+      validate_error_msg << "The #{t('project')} is invalid, #{@project.errors.full_messages.join(', ')}"
+    end
+
+    unless @programme.nil? || @programme.valid?
+      validate_error_msg << "The #{t('programme')} is invalid, #{@programme.errors.full_messages.join(', ')}"
+    end
+
+    unless @institution.valid?
+      validate_error_msg << "The #{t('institution')} is invalid, #{@institution.errors.full_messages.join(', ')}"
+    end
+
+    unless @programme&.allows_user_projects? || skip_permissions || Institution.can_create?
+      validate_error_msg << "The #{t('institution')} cannot be created, as you do not have access rights"
+    end
+
+    unless skip_permissions || Project.can_create?
+      validate_error_msg << "The #{t('project')} cannot be created, as you do not have access rights"
+    end
+
+    validate_error_msg = validate_error_msg.join('<br/>').html_safe
+    return validate_error_msg unless validate_error_msg.blank?
+
+    disable_authorization_checks { @project.save! }
+
+    # they are soon to become a project administrator, with permission to create
+    disable_authorization_checks { @institution.save! }
+
+    requester.add_to_project_and_institution(@project, @institution)
+    requester.is_project_administrator = true, @project
+      # @programme already populated in before_filter when checking permissions
+    requester.is_programme_administrator = true, @programme if @programme&.new_record?
+
+    disable_authorization_checks do
+      requester.save!
+    end
+
+    if @message_log.sent_by_self?
+      @message_log.destroy
+      flash[:notice]="#{t('project')} created"
+    else
+      @message_log.respond('Accepted')
+      if Seek::Config.email_enabled
+        flash[:notice]="Request accepted and #{requester.name} added to #{t('project')} and notified"
+        Mailer.notify_user_projects_assigned(requester,[@project]).deliver_later
+        Mailer.notify_admins_project_creation_accepted(current_person, requester, @project).deliver_later
+      else
+        flash[:notice]="Request accepted and #{requester.name} added to #{t('project')}"
+      end
+    end
+
+    nil
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -63,6 +63,7 @@ class ProjectsController < ApplicationController
   end
 
   def guided_join
+    @institution = Institution.new
     @project = Project.find(params[:id]) if params[:id]
     respond_to do |format|
       if @project && !@project.allow_request_membership?

--- a/app/models/mailer.rb
+++ b/app/models/mailer.rb
@@ -254,10 +254,10 @@ class Mailer < ActionMailer::Base
       recipients = admins
     end
 
-    subject = "The request to create the #{t('project')}, #{@project.title}, has been APPROVED by #{@responder.name}"
+    subject = "The request to create the #{t('project')}, #{@project.title}, has been APPROVED #{@responder.nil? ? 'automatically' : "by #{@responder.name}"}"
     mail(from: Seek::Config.noreply_sender,
          to: recipients.collect(&:email_with_name),
-         reply_to: @responder.email_with_name,
+         reply_to: @responder&.email_with_name,
          subject: subject)
 
   end

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -96,12 +96,9 @@ class Programme < ApplicationRecord
     !(activation_rejection_reason.nil? || is_activated?)
   end
 
-  # callback, activates if current user is an admin or nil, otherwise it needs activating
   def activate
-    if can_activate?
-      update_attribute(:is_activated, true)
-      update_attribute(:activation_rejection_reason, nil)
-    end
+    update_attribute(:is_activated, true)
+    update_attribute(:activation_rejection_reason, nil)
   end
 
   def can_activate?(user = User.current_user)

--- a/app/models/project_creation_message_log.rb
+++ b/app/models/project_creation_message_log.rb
@@ -7,14 +7,10 @@ class ProjectCreationMessageLog < MessageLog
   # project creation requests that haven't been responded to
   scope :pending_requests, -> { pending }
 
-  def self.prepare_request(sender:, project:, institution:, programme: nil)
+  def self.log_request(sender:, project:, institution:, programme: nil)
     details = details_json(programme: programme, project: project, institution: institution)
     # FIXME: needs a subject, but can't use programme as it will save it if it is new
-    ProjectCreationMessageLog.new(subject: sender, sender: sender, details: details)
-  end
-
-  def self.log_request(sender:, project:, institution:, programme: nil)
-    prepare_request(sender: sender, project: project, institution: institution, programme: programme).tap(&:save)
+    ProjectCreationMessageLog.create(subject: sender, sender: sender, details: details)
   end
 
   # whether the person can respond to the creation request

--- a/app/models/project_creation_message_log.rb
+++ b/app/models/project_creation_message_log.rb
@@ -7,10 +7,14 @@ class ProjectCreationMessageLog < MessageLog
   # project creation requests that haven't been responded to
   scope :pending_requests, -> { pending }
 
-  def self.log_request(sender:, project:, institution:, programme: nil)
+  def self.prepare_request(sender:, project:, institution:, programme: nil)
     details = details_json(programme: programme, project: project, institution: institution)
     # FIXME: needs a subject, but can't use programme as it will save it if it is new
-    ProjectCreationMessageLog.create(subject: sender, sender: sender, details: details)
+    ProjectCreationMessageLog.new(subject: sender, sender: sender, details: details)
+  end
+
+  def self.log_request(sender:, project:, institution:, programme: nil)
+    prepare_request(sender: sender, project: project, institution: institution, programme: programme).tap(&:save)
   end
 
   # whether the person can respond to the creation request

--- a/app/views/admin/features_enabled.html.erb
+++ b/app/views/admin/features_enabled.html.erb
@@ -72,12 +72,20 @@
                                "User creation of #{t('programme').pluralize} enabled", "Controls whether standard users can create their own #{t('programme').pluralize}. If disabled only full administrators will be able to create #{t('programme').pluralize}. If enabled a full administrator is still required to allow and activate the #{t('programme')}") %>
     <% managed_programme_options = options_for_select(Programme.all.map{|p|[p.title, p.id]}, Seek::Config.managed_programme_id) %>
     <%= admin_dropdown_setting(:managed_programme_id, managed_programme_options,
-                               "Site mananaged #{t('programme')}",
+                               "Site managed #{t('programme')}",
                                "The #{t('programme')} the users can request to have a #{t('project')} created and associated with, without the need to create and manage their own",
                                include_blank:'None') %>
     <%= admin_checkbox_setting(:programmes_open_for_projects_enabled, 1, Seek::Config.programmes_open_for_projects_enabled,
                                "#{t('programme').pluralize} open for #{t(:project).pluralize} enabled",
                                "When enabled, gives the ability for individual #{t(:programme).pluralize} to be configured to allow any other registered user to create a #{t(:project)} linked to that #{t(:programme)} without requiring approval or admin rights. Use with care if open user registration is enabled, as it could allow any user to register, create a project and start adding content to that Programme.") %>
+
+    <%= admin_checkbox_setting(:auto_activate_programmes, 1, Seek::Config.auto_activate_programmes,
+                               "Automatically activate #{t('programme').pluralize}",
+                               "Activates user-created #{t('programme').pluralize} immediately without requiring administrator approval (although they are still notified if email is enabled).") %>
+
+    <%= admin_checkbox_setting(:auto_activate_site_managed_projects, 1, Seek::Config.auto_activate_site_managed_projects,
+                               "Automatically approve #{t('project').pluralize} under site managed #{t('programme')}",
+                               "Approves #{t('project')} creation requests automatically (administrators are still notified if email is enabled).") %>
   </div>
 
   <%= admin_checkbox_setting(:presentations_enabled, 1, Seek::Config.presentations_enabled,

--- a/app/views/institutions/_select_or_define.html.erb
+++ b/app/views/institutions/_select_or_define.html.erb
@@ -18,9 +18,9 @@
 
   <label class="control-label">Type the name of the <%= t('institution') %> </label><span class="required">*</span>
 
-  <%# I am setting the institution id to a junk value of `_` (if blank) to get around a bug in select2 wherein an <option>
+  <%# I am setting the institution id to a junk value of 0 (if blank) to get around a bug in select2 wherein an <option>
       with a blank `value`, that is selected when the page is loaded, does not get rendered as a "tag". %>
-  <%= objects_input('institution[id]', @institution.title.present? ? [@institution.tap { |i| i.id ||= '_' }] : [],
+  <%= objects_input('institution[id]', @institution.title.present? ? [@institution.tap { |i| i.id ||= 0 }] : [],
                     typeahead: { query_url: typeahead_institutions_path,
                                  handlebars_template:'typeahead/institution' },
                     limit: 1, allow_new: true, class: 'form-control') -%>
@@ -47,8 +47,7 @@
         $j(".institution-user-input").prop('disabled',disabled);
     }
     $j(document).ready(function () {
-
-        toggleUserInput(<%= @institution.id.present? ? 'false' : 'true' -%>);
+        toggleUserInput(<%= (@institution.id.blank? || @institution.id == 0) ? 'false' : 'true' -%>);
 
         $j('select#institution_country').on('change',function() {
             checkSubmitButtonEnabled();

--- a/app/views/institutions/_select_or_define.html.erb
+++ b/app/views/institutions/_select_or_define.html.erb
@@ -18,9 +18,9 @@
 
   <label class="control-label">Type the name of the <%= t('institution') %> </label><span class="required">*</span>
 
-  <%# I am setting the institution id to a junk value of `_` to get around a bug in select2 wherein an <option>
+  <%# I am setting the institution id to a junk value of `_` (if blank) to get around a bug in select2 wherein an <option>
       with a blank `value`, that is selected when the page is loaded, does not get rendered as a "tag". %>
-  <%= objects_input('institution[id]', @institution.title.present? ? [@institution.tap { |i| i.id = '_' }] : [],
+  <%= objects_input('institution[id]', @institution.title.present? ? [@institution.tap { |i| i.id ||= '_' }] : [],
                     typeahead: { query_url: typeahead_institutions_path,
                                  handlebars_template:'typeahead/institution' },
                     limit: 1, allow_new: true, class: 'form-control') -%>

--- a/app/views/institutions/_select_or_define.html.erb
+++ b/app/views/institutions/_select_or_define.html.erb
@@ -17,17 +17,23 @@
   </div>
 
   <label class="control-label">Type the name of the <%= t('institution') %> </label><span class="required">*</span>
-  <%= objects_input('institution[id]', [], typeahead:  {query_url: typeahead_institutions_path, handlebars_template:'typeahead/institution'}, limit:1, allow_new: true, class:'form-control') -%>
+
+  <%# I am setting the institution id to a junk value of `_` to get around a bug in select2 wherein an <option>
+      with a blank `value`, that is selected when the page is loaded, does not get rendered as a "tag". %>
+  <%= objects_input('institution[id]', @institution.title.present? ? [@institution.tap { |i| i.id = '_' }] : [],
+                    typeahead: { query_url: typeahead_institutions_path,
+                                 handlebars_template:'typeahead/institution' },
+                    limit: 1, allow_new: true, class: 'form-control') -%>
 </div>
 
-<%= hidden_field_tag 'institution[title]' %>
+<%= hidden_field_tag 'institution[title]', @institution.title %>
 
 <div class="form-group" id='additional-institution-details'>
   <label class="control-label">Website</label>
-  <%= text_field_tag('institution[web_page]','',class:'form-control institution-user-input') %>
+  <%= text_field_tag('institution[web_page]', @institution.web_page, class:'form-control institution-user-input') %>
 
   <label class="control-label">City</label>
-  <%= text_field_tag('institution[city]','',class:'form-control institution-user-input') %>
+  <%= text_field_tag('institution[city]', @institution.city, class:'form-control institution-user-input') %>
 
   <label class="control-label">Country</label>
   <%= country_select('institution','country',
@@ -42,7 +48,7 @@
     }
     $j(document).ready(function () {
 
-        toggleUserInput(true);
+        toggleUserInput(<%= @institution.id.present? ? 'false' : 'true' -%>);
 
         $j('select#institution_country').on('change',function() {
             checkSubmitButtonEnabled();

--- a/app/views/mailer/notify_admins_project_creation_accepted.text.erb
+++ b/app/views/mailer/notify_admins_project_creation_accepted.text.erb
@@ -1,6 +1,6 @@
 Hi,
 
-The request to create a <%= t('project') %> has been responded to and approved by <%= @responder.name %>.
+The request to create a <%= t('project') %> has been responded to and approved <%= @responder.nil? ? 'automatically' : "by #{@responder.name}" %>.
 
 The <%= t('project') %> created is '<%= @project.title %>' ( <%= project_url(@project) %> ), and was originally requested by
 '<%= @requester.name %>' ( <%= person_url(@requester) %> ).

--- a/app/views/projects/guided_create.html.erb
+++ b/app/views/projects/guided_create.html.erb
@@ -16,11 +16,11 @@
         </div>
 
         <%= label_tag :project_title, "Title" %><span class="required">*</span>
-        <%= text_field_tag 'project[title]', '', class: 'form-control' %>
-        <%= label_tag :project_title, "Description" %>
-        <%= text_area_tag 'project[description]', '', rows:2, class: 'form-control' %>
-        <%= label_tag :project_title, "Web page" %>
-        <%= text_field_tag 'project[web_page]', '', class: 'form-control' %>
+        <%= text_field_tag 'project[title]', @project.title, class: 'form-control' %>
+        <%= label_tag :project_description, "Description" %>
+        <%= text_area_tag 'project[description]', @project.description, rows:2, class: 'form-control' %>
+        <%= label_tag :project_web_page, "Web page" %>
+        <%= text_field_tag 'project[web_page]', @project.web_page, class: 'form-control' %>
 
       <% end %>  
       

--- a/app/views/projects/guided_create.html.erb
+++ b/app/views/projects/guided_create.html.erb
@@ -64,6 +64,8 @@
              }
              checkSubmitButtonEnabled();
          });
+
+        $j('input#managed_programme').change(); // Trigger initial state on page load
        <% end %>
 
        <% if Seek::ProjectFormProgrammeOptions.creation_allowed? && Seek::ProjectFormProgrammeOptions.programme_dropdown? %>
@@ -83,6 +85,7 @@
             }
             checkSubmitButtonEnabled();
         });
+        $j('input#new_programme').change(); // Trigger initial state on page load
        <% end %>
 
        $j('input#programme_title').on('input',function() {

--- a/app/views/projects/guided_create/_managed_programme_checkbox.html.erb
+++ b/app/views/projects/guided_create/_managed_programme_checkbox.html.erb
@@ -7,6 +7,6 @@
   it. To have one created, then please provide the name. You will be able to provide additional details, if you wish, once it has been created.
 </div>
 <label>
-  <%= check_box_tag :managed_programme, '1', true %>
+  <%= check_box_tag :managed_programme, '1', @programme.nil? || @programme.site_managed? %>
   <%= "#{Seek::Config.instance_admins_name} managed #{t('programme')}?" %>
 </label>

--- a/app/views/projects/guided_create/_programme_details.html.erb
+++ b/app/views/projects/guided_create/_programme_details.html.erb
@@ -1,11 +1,8 @@
-<% if Seek::ProjectFormProgrammeOptions.creation_allowed_only? %>
-  <div id='programme-details'>
-<% else %>
-  <div id='programme-details' style="display:none;">
-<% end %>
-<div class="help-block">
-  Specify a title for a new <%= t('programme') %>, which your new <%= t('project') %> will be associated with.
-</div>
-<%= label_tag :programme_title, "Title" %><span class="required">*</span>
-<%= text_field_tag 'programme[title]', '', class: 'form-control' %>
+<% show = Seek::ProjectFormProgrammeOptions.creation_allowed_only? || (@programme && !@programme.site_managed?) %>
+<div id='programme-details'<%= 'style="display:none;"' unless show -%>>
+  <div class="help-block">
+    Specify a title for a new <%= t('programme') %>, which your new <%= t('project') %> will be associated with.
+  </div>
+  <%= label_tag :programme_title, "Title" %><span class="required">*</span>
+  <%= text_field_tag 'programme[title]', @programme&.title, class: 'form-control' %>
 </div>

--- a/app/views/projects/guided_create/_programme_dropdown.html.erb
+++ b/app/views/projects/guided_create/_programme_dropdown.html.erb
@@ -3,7 +3,8 @@
 </div>
 <% if !admin_logged_in? && Programme.site_managed_programme.present? %>
   <div class="help-block">
-    You can also choose the <%= "#{Seek::Config.instance_admins_name} managed #{t('programme')}" %>, <%= link_to Programme.site_managed_programme.title, Programme.site_managed_programme %>, and if so you will need to wait for approval.
+    You can also choose the <%= "#{Seek::Config.instance_admins_name} managed #{t('programme')}" %>,
+    <%= link_to Programme.site_managed_programme.title, Programme.site_managed_programme %><%= ', and if so you will need to wait for approval' unless Seek::Config.auto_activate_site_managed_projects -%>.
   </div>
 <% end %>
 
@@ -16,7 +17,7 @@
   end
 %>
 
-<%= select_tag :programme_id,options_from_collection_for_select(programmes,:id, :title), class: 'form-control' %>
+<%= select_tag :programme_id, options_from_collection_for_select(programmes, :id, :title, @programme&.id), class: 'form-control' %>
 
 <% if Seek::ProjectFormProgrammeOptions.creation_allowed? %>
   <div class="help-block">

--- a/app/views/projects/guided_create/_programme_dropdown.html.erb
+++ b/app/views/projects/guided_create/_programme_dropdown.html.erb
@@ -24,7 +24,7 @@
     Alternatively you can choose to create a new <%= t('programme') %>, which your new <%= t('project') %> will be associated with.
   </div>
   <label>
-    <%= check_box_tag :new_programme, '1', false %>
+    <%= check_box_tag :new_programme, '1', @programme && !@programme.site_managed? %>
     <%= "Create a new #{t('programme')}?" %>
   </label>
 <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -73,5 +73,6 @@ module SEEK
 
     config.active_record.belongs_to_required_by_default = false
     config.action_mailer.delivery_job = 'ActionMailer::MailDeliveryJob' # Can remove after updating defaults
+    config.action_mailer.preview_path = "#{Rails.root}/test/mailers/previews" # For some reason it is looking in spec/ by default
   end
 end

--- a/lib/seek/config_setting_attributes.yml
+++ b/lib/seek/config_setting_attributes.yml
@@ -255,3 +255,5 @@ galaxy_tool_sources:
 metadata_license:
 regular_job_offset:
   convert: :to_i
+auto_activate_programmes:
+auto_activate_site_managed_projects:

--- a/test/functional/programmes_controller_test.rb
+++ b/test/functional/programmes_controller_test.rb
@@ -161,6 +161,7 @@ class ProgrammesControllerTest < ActionController::TestCase
     assert person2.is_programme_administrator?(prog)
     assert person2.is_programme_administrator_of_any_programme?
     assert person2.has_role?('programme_administrator')
+    refute assigns(:programme).is_activated?
   end
 
   test 'admin sets themself as programme administrator at creation' do
@@ -935,6 +936,25 @@ class ProgrammesControllerTest < ActionController::TestCase
       get :index
       assert_redirected_to root_path
       assert flash[:error].include?('disabled')
+    end
+  end
+
+  test 'automatically activate programme if setting enabled' do
+    with_config_value(:auto_activate_programmes, true) do
+      creator = FactoryBot.create(:person)
+      refute creator.is_admin?
+      login_as(creator)
+      assert_difference('Role.count', 1) do # Should include creator
+        assert_difference('Programme.count', 1) do
+          post :create, params: { programme: { title: 'programme xxxyxxx2' } }
+        end
+      end
+
+      assert prog = assigns(:programme)
+      assert assigns(:programme).is_activated?
+      assert creator.is_programme_administrator?(prog)
+      assert creator.is_programme_administrator_of_any_programme?
+      assert creator.has_role?('programme_administrator')
     end
   end
 end

--- a/test/functional/projects_controller_test.rb
+++ b/test/functional/projects_controller_test.rb
@@ -3679,7 +3679,7 @@ class ProjectsControllerTest < ActionController::TestCase
 
     put :update, params: { id: project.id, project: { topic_annotations: ['Chemistry', 'Sample collections'] } }
 
-    assert_equal ['http://edamontology.org/topic_3314','http://edamontology.org/topic_3277'], assigns(:project).topic_annotations
+    assert_equal ['http://edamontology.org/topic_3314','http://edamontology.org/topic_3277'].sort, assigns(:project).topic_annotations.sort
 
   end
 

--- a/test/functional/projects_controller_test.rb
+++ b/test/functional/projects_controller_test.rb
@@ -3870,30 +3870,21 @@ class ProjectsControllerTest < ActionController::TestCase
   private
 
   def check_project(project)
-    assert project.investigations.size == 2
-    check_investigation_0(project.investigations[0])
-    check_investigation_1(project.investigations[1])
-  end
+    assert_equal 2, project.investigations.count
 
-  def check_investigation_0(investigation)
-    assert investigation.title == "Select host and product"
-    assert investigation.studies.size == 4
-  end
+    investigation1 = project.investigations.detect { |i| i.title == 'Select host and product' }
+    assert investigation1
+    assert 4, investigation1.studies.count
 
-  def check_investigation_1(investigation)
-    assert investigation.title == "Design"
-    assert investigation.studies.size == 1
-    check_study_1_0(investigation.studies[0])
-  end
+    investigation2 = project.investigations.detect { |i| i.title == 'Design' }
+    assert investigation2
+    assert 1, investigation2.studies.count
 
-  def check_study_1_0(study)
+    study = investigation2.studies.first
     assert study.title == "Receive input from select host and products step"
-    assert study.assays.size == 2
-    check_assay_1_0_1(study.assays[1])
-  end
+    assert_equal 2, study.assays.count
 
-  def check_assay_1_0_1(assay)
-    assert assay.title == "Obtain SBML models for production hosts"
+    assert study.assays.detect { |a| a.title == 'Obtain SBML models for production hosts' }
   end
 
   def valid_project

--- a/test/mailers/previews/mailer_preview.rb
+++ b/test/mailers/previews/mailer_preview.rb
@@ -1,0 +1,9 @@
+class MailerPreview < ActionMailer::Preview
+  def project_creation_request_auto_accepted
+    Mailer.notify_admins_project_creation_accepted(nil, Person.last, Project.first)
+  end
+
+  def project_creation_request_accepted
+    Mailer.notify_admins_project_creation_accepted(Person.first, Person.last, Project.first)
+  end
+end

--- a/test/unit/programme_test.rb
+++ b/test/unit/programme_test.rb
@@ -346,17 +346,6 @@ class ProgrammeTest < ActiveSupport::TestCase
     prog.is_activated = false
     disable_authorization_checks { prog.save! }
 
-    # no current user
-    prog.activate
-    refute prog.is_activated?
-
-    # normal user
-    User.current_user = FactoryBot.create(:person).user
-    prog.activate
-    refute prog.is_activated?
-
-    # admin
-    User.current_user = FactoryBot.create(:admin).user
     prog.activate
     assert prog.is_activated?
 


### PR DESCRIPTION
Adds admin settings to:
* automatically activate programmes.
* automatically approve project creation requests in site-managed programme.

(also adds mailer previews in development environment: http://localhost:3000/rails/mailers)