### PR TITLE
fix to controlled_vocab_annotation_form fields to allow multiple items

### DIFF
--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -6,7 +6,7 @@ module SamplesHelper
     attribute_form_element(attribute, resource.get_attribute_value(attribute.title), element_name, element_class)
   end
 
-  def controlled_vocab_form_field(sample_controlled_vocab, element_name, values, allow_new = false, limit = 1)
+  def controlled_vocab_form_field(sample_controlled_vocab, element_name, values, allow_new, limit = 1)
 
     scv_id = sample_controlled_vocab.id
     object_struct = Struct.new(:id, :title)

--- a/app/views/assets/_controlled_vocab_annotations_form_property.html.erb
+++ b/app/views/assets/_controlled_vocab_annotations_form_property.html.erb
@@ -11,6 +11,6 @@
 <% if vocab %>
   <div class="form-group">
     <label><%= title -%></label>
-    <%= controlled_vocab_form_field(vocab, "#{resource.class.model_name.singular}[#{param_key}]", values, 10 ) -%>
+    <%= controlled_vocab_form_field(vocab, "#{resource.class.model_name.singular}[#{param_key}]", values, false, 10 ) -%>
   </div>
 <% end %>

--- a/test/functional/data_files_controller_test.rb
+++ b/test/functional/data_files_controller_test.rb
@@ -3644,8 +3644,8 @@ class DataFilesControllerTest < ActionController::TestCase
 
     assert_response :success
 
-    assert_select 'input+select#data_file_data_type_annotations'
-    assert_select 'input+select#data_file_data_format_annotations'
+    assert_select 'input+select#data_file_data_type_annotations[data-tags-limit=10]'
+    assert_select 'input+select#data_file_data_format_annotations[data-tags-limit=10]'
   end
 
   test 'create assay should be checked with new assay containing title' do


### PR DESCRIPTION
This is the field where they are used with Samples, for data file type and formats and workflow operation and topic annotations

* Fix for #1686 