### PR TITLE
Import projects from Data Management Plan files

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -762,7 +762,7 @@ class ProjectsController < ApplicationController
         @institution = Institution.new(params.require(:institution).permit([:title, :web_page, :city, :country]))
       end
 
-      @project = Project.new(params.require(:project).permit([:title, :web_page, :description, :start_date, :end_date]))
+      @project = Project.new(params.require(:project).permit([:title, :web_page, :description]))
       @project.programme = @programme
 
       people_params = params.permit(people: [:first_name, :last_name, :email])

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -461,6 +461,14 @@ module ApplicationHelper
     end.present?
   end
 
+  def pending_project_importation_request?
+    return false unless admin_logged_in? || programme_administrator_logged_in?
+
+    ProjectImportationMessageLog.pending_requests.detect do |log|
+      log.can_respond_project_importation_request?(User.current_user)
+    end.present?
+  end
+
   def pending_project_join_request?
     return false unless project_administrator_logged_in?
     return false if ProjectMembershipMessageLog.pending.count == 0

--- a/app/models/mailer.rb
+++ b/app/models/mailer.rb
@@ -229,7 +229,7 @@ class Mailer < ActionMailer::Base
     @requester = user.person
     @institution = Institution.new(JSON.parse(institution_json))
     @project = Project.new(JSON.parse(project_json))
-    @people = people_json.map { |person_json| Person.new(JSON.parse(person_json)) }
+    @people = JSON.parse(people_json).map { |person| Person.new(person) }
     @message_log = message_log
 
     mail(from: Seek::Config.noreply_sender,
@@ -245,7 +245,7 @@ class Mailer < ActionMailer::Base
     @requester = user.person
     @institution = Institution.new(JSON.parse(institution_json))
     @project = Project.new(JSON.parse(project_json))
-    @people = people_json.map { |person_json| Person.new(JSON.parse(person_json)) }
+    @people = JSON.parse(people_json).map { |person| Person.new(person) }
     @message_log = message_log
     mail(from: Seek::Config.noreply_sender,
          to: admin_emails,
@@ -258,7 +258,7 @@ class Mailer < ActionMailer::Base
     @requester = user.person
     @institution = Institution.new(JSON.parse(institution_json))
     @project = Project.new(JSON.parse(project_json))
-    @people = people_json.map { |person_json| Person.new(JSON.parse(person_json)) }
+    @people = JSON.parse(people_json).map { |person| Person.new(person) }
     @message_log = message_log
     mail(from: Seek::Config.noreply_sender,
          to: admin_emails,

--- a/app/models/mailer.rb
+++ b/app/models/mailer.rb
@@ -222,6 +222,51 @@ class Mailer < ActionMailer::Base
          template_name: :request_create_project_for_programme)
   end
 
+  def request_import_project_for_programme(user, programme, project_json, institution_json, people_json, message_log)
+    @admins = programme.programme_administrators
+    @admins |= admins if programme.site_managed?
+    @programme = programme
+    @requester = user.person
+    @institution = Institution.new(JSON.parse(institution_json))
+    @project = Project.new(JSON.parse(project_json))
+    @people = people_json.map { |person_json| Person.new(JSON.parse(person_json)) }
+    @message_log = message_log
+
+    mail(from: Seek::Config.noreply_sender,
+         to: @admins.collect(&:email_with_name),
+         reply_to: @requester.email_with_name,
+         subject: "NEW #{t('project')} request from #{@requester.name} for your #{t('programme')}: #{@project.title}")
+
+  end
+
+  def request_import_project_and_programme(user, programme_json, project_json, institution_json, people_json, message_log)
+    @admins = admins
+    @programme = Programme.new(JSON.parse(programme_json))
+    @requester = user.person
+    @institution = Institution.new(JSON.parse(institution_json))
+    @project = Project.new(JSON.parse(project_json))
+    @people = people_json.map { |person_json| Person.new(JSON.parse(person_json)) }
+    @message_log = message_log
+    mail(from: Seek::Config.noreply_sender,
+         to: admin_emails,
+         reply_to: @requester.email_with_name,
+         subject: "New #{t('project')} and #{t('programme')} request from #{@requester.name}: #{@project.title}")
+  end
+
+  def request_import_project(user, project_json, institution_json, people_json, message_log)
+    @admins = admins
+    @requester = user.person
+    @institution = Institution.new(JSON.parse(institution_json))
+    @project = Project.new(JSON.parse(project_json))
+    @people = people_json.map { |person_json| Person.new(JSON.parse(person_json)) }
+    @message_log = message_log
+    mail(from: Seek::Config.noreply_sender,
+         to: admin_emails,
+         reply_to: @requester.email_with_name,
+         subject: "New #{t('project')} request from #{@requester.name}: #{@project.title}",
+         template_name: :request_import_project_for_programme)
+  end
+
   def join_project_rejected(requester, project, comments)
     @requester = requester
     @project = project

--- a/app/models/message_log.rb
+++ b/app/models/message_log.rb
@@ -7,7 +7,8 @@ class MessageLog < ApplicationRecord
     contact_request: 2,
     programme_creation_request: 3, # no longer used
     project_creation_request: 4,
-    activation_email: 5
+    activation_email: 5,
+    project_importation_request: 6
   }
 
   belongs_to :subject, polymorphic: true

--- a/app/models/project_importation_message_log.rb
+++ b/app/models/project_importation_message_log.rb
@@ -4,7 +4,7 @@ class ProjectImportationMessageLog < MessageLog
   
     default_scope { where(message_type: :project_importation_request) }
   
-    # project creation requests that haven't been responded to
+    # project importation requests that haven't been responded to
     scope :pending_requests, -> { pending }
   
     def self.log_request(sender:, people:, project:, institution:, programme: nil)

--- a/app/models/project_importation_message_log.rb
+++ b/app/models/project_importation_message_log.rb
@@ -1,0 +1,35 @@
+# Message logs related to Project importation requests
+class ProjectImportationMessageLog < MessageLog
+    include Seek::ProjectMessageLogDetails
+  
+    default_scope { where(message_type: :project_importation_request) }
+  
+    # project creation requests that haven't been responded to
+    scope :pending_requests, -> { pending }
+  
+    def self.log_request(sender:, people:, project:, institution:, programme: nil)
+      details = details_json(programme: programme, project: project, institution: institution, people: people)
+      # FIXME: needs a subject, but can't use programme as it will save it if it is new
+      ProjectImportationMessageLog.create(subject: sender, sender: sender, details: details)
+    end
+  
+    # whether the person can respond to the importation request
+    # TODO: this will be refactored into a more general method
+    def can_respond_project_importation_request?(user_or_person)
+      return false unless project_importation_request?
+      return false if user_or_person.nil?
+  
+      person = user_or_person.person
+  
+      programme = parsed_details.programme
+  
+      return person.is_admin? if programme.blank?
+  
+      if programme.id.nil?
+        person.is_admin?
+      else
+        (person.is_admin? && programme.site_managed?) || person.is_programme_administrator?(programme) || programme.allows_user_projects?
+      end
+    end
+  end
+  

--- a/app/views/layouts/_pending_events_warnings.html.erb
+++ b/app/views/layouts/_pending_events_warnings.html.erb
@@ -18,6 +18,13 @@
     </div>
   <% end %>
 
+    <% if pending_project_importation_request? %>
+    <div id='pending-project-importation-warning' class="alert alert-danger text-center">
+      There are pending <%= t('project') %> importation requests
+      - <%= link_to('Full List', project_importation_requests_projects_path) %>
+    </div>
+  <% end %>
+
   <% if pending_project_join_request? %>
     <div id='pending-project-join-warning' class="alert alert-danger text-center">
       There are pending join requests for <%= t('project').pluralize %> you administer

--- a/app/views/mailer/request_import_project_and_programme.text.erb
+++ b/app/views/mailer/request_import_project_and_programme.text.erb
@@ -1,21 +1,21 @@
 
 Hi <%= @admins.collect{|o| o.name}.join(", ") -%>,
 
-<% if @programme %>
+The <%= Seek::Config.instance_name %> user <%= "#{@requester.name} (#{person_url(@requester)})" %>, has requested a new <%= t('programme') %> and <%= t('project')  %>.
 
-  The <%= Seek::Config.instance_name %> user <%= "#{@requester.name} (#{person_url(@requester)})" %>, has requested a new <%= t('project')  %> is imported within your <%= t('programme') %>.
-
-  The <%= t('programme') %> is <%= "#{@programme.title} (#{programme_url(@programme)})" %>
-
-<% else %>
-
-  The <%= Seek::Config.instance_name %> user <%= "#{@requester.name} (#{person_url(@requester)})" %>, has requested a new <%= t('project')  %> is imported.
-
-<% end %>
-
+They provided the following details about the <%= t('programme') %>
+  <%= t('programme') %> title: '<%= @programme.title %>'
 
 They provided the following details about the <%= t('project') %>
-  <%= t('project') %> title: '<%= @project.title %>'
+<%
+  title = @project.title.blank? ? 'No title provided' : @project.title
+  web_page = @project.web_page.blank? ? 'No web page provided' : @project.web_page
+  description = @project.description.blank? ? 'No description provided' : @project.description
+
+%>
+  <%= t('project') %> title: '<%= title %>'
+  <%= t('project') %> description: '<%= description %>'
+  <%= t('project') %> web_page: '<%= web_page %>'
 
 <% if @institution.id.nil? %>
   <%
@@ -29,7 +29,7 @@ They provided the following details about their <%= t('institution') %>:
   <%= t('institution') %> web page: '<%= web_page %>'
   <%= t('institution') %> country: '<%= country %>'
 <% else %>
-They indicated that they are associated with the existing <%= "#{@institution.title} (#{institution_url(@institution)})" %>
+They indicated that they are associated with the existing <%= t('institution') %> <%= "#{@institution.title} (#{institution_url(@institution)})" %>
 <% end %>
 
 <% if Array(@people).length > 0 %>

--- a/app/views/mailer/request_import_project_for_programme.text.erb
+++ b/app/views/mailer/request_import_project_for_programme.text.erb
@@ -1,0 +1,56 @@
+
+Hi <%= @admins.collect{|o| o.name}.join(", ") -%>,
+
+<% if @programme %>
+
+  The <%= Seek::Config.instance_name %> user <%= "#{@requester.name} (#{person_url(@requester)})" %>, has requested a new <%= t('project')  %> is imported within your <%= t('programme') %>.
+
+  The <%= t('programme') %> is <%= "#{@programme.title} (#{programme_url(@programme)})" %>
+
+<% else %>
+
+  The <%= Seek::Config.instance_name %> user <%= "#{@requester.name} (#{person_url(@requester)})" %>, has requested a new <%= t('project')  %> is imported.
+
+<% end %>
+
+
+They provided the following details about the <%= t('project') %>
+  <%= t('project') %> title: '<%= @project.title %>'
+
+<% if @institution.id.nil? %>
+  <%
+    title = @institution.title.blank? ? 'No title provided' : @institution.title
+    web_page = @institution.web_page.blank? ? 'No web page provided' : @institution.web_page
+    country = @institution.country.blank? ? 'No country provided' : CountryCodes.country(@institution.country)
+
+  %>
+They provided the following details about their <%= t('institution') %>:
+  <%= t('institution') %> title: '<%= title %>'
+  <%= t('institution') %> web page: '<%= web_page %>'
+  <%= t('institution') %> country: '<%= country %>'
+<% else %>
+They indicated that they are associated with the existing <%= "#{@institution.title} (#{institution_url(@institution)})" %>
+<% end %>
+
+<% if @people %>
+They provided the following details about the <%= t('people') %> associated with the project:
+  <% @people do |person| %>
+    Name: <% person.first_name %>, Email: <% person.email %>
+  <% end %>
+<% end %>
+These people will be associated with the project through the selected institution.
+
+<% unless @comments.blank? -%>
+<%=@requester.first_name.capitalize -%> also provided some additional details about the request:
+
+  "<%= sanitize(@comments) -%>"
+
+<% end -%>
+
+You can quickly accept or reject this request by going to <%= administer_create_project_request_projects_url(message_log_id:@message_log.id) %>.
+
+You can reply to <%= @requester.first_name.capitalize -%> by replying to this email.
+
+This is an automated email.
+
+- <%= Seek::Config.instance_admins_name %> Team

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -2,6 +2,10 @@
 
 <%= f.error_messages %>
 
+<div class="help-block">
+  A project may also be <a href="./guided_import">imported</a> from a Data Management Plan (DMP) file.
+</div>
+
 <div class="form-group">
   <%= f.label :title, class: 'required' -%>
   <%= f.text_field :title, :class=>"form-control"-%>

--- a/app/views/projects/administer_import_project_request.html.erb
+++ b/app/views/projects/administer_import_project_request.html.erb
@@ -1,0 +1,203 @@
+<div>
+  <%= form_tag respond_import_project_request_projects_path do %>
+
+    <%= hidden_field_tag :message_log_id,@message_log.id %>
+
+    <div class="panel panel-default">
+      <div class="panel-body">
+
+        <% unless @message_log.sent_by_self? %>
+          <div>
+            The user <%= link_to(@message_log.sender.title, @message_log.sender) %> has requested to import a <%= t('project') %>
+          </div>
+        <% end %>
+
+        <% if Seek::Config.programmes_enabled && @programme %>
+          <div class="panel panel-default">
+            <div class="panel-heading">
+              <%= t('programme') %>
+            </div>
+            <div class="panel-body">
+              <% if @programme.new_record? %>
+                They have requested a new <%= t('programme') %>, with the following:
+                <div class="form-group">
+                  <%= label_tag 'Title' %><span class="required">*</span>
+                  <%= text_field_tag 'programme[title]',@programme.title, class:'form-control' %>
+                </div>
+              <% else %>
+                It will be associated with the <%= t('programme') %>, <%= link_to @programme.title,@programme %>, which you administer.
+                <%= hidden_field_tag 'programme[id]',@programme.id %>
+              <% end %>
+            </div>
+
+          </div>
+        <% end %>
+
+        <div class="panel panel-default">
+          <div class="panel-heading">
+            <%= t('project') %>
+          </div>
+          <div class="panel-body">
+            <div>
+              The <%= t('project') %> details provided are as follows:
+              <div class="form-group">
+                <%= label_tag 'Title' %><span class="required">*</span>
+                <%= text_field_tag 'project[title]',@project.title, class:'form-control' %>
+
+                <%= label_tag 'Description' %>
+                <%= text_field_tag 'project[description]',@project.description, class:'form-control' %>
+
+                <%= label_tag 'Website' %>
+                <%= text_field_tag 'project[web_page]',@project.web_page, class:'form-control' %>
+              </div>
+            </div>
+          </div>
+
+        </div>
+
+        <div class="panel panel-default">
+          <div class="panel-heading">
+            <%= t('institution') %>
+          </div>
+          <div class="panel-body">
+            <% if @institution.new_record? %>
+              <div>
+                They have requested a new <%= t('institution') %>, and provided the following details.
+                Please edit or complete if and where you feel necessary.
+                <div class="form-group">
+                  <%= label_tag 'Title' %><span class="required">*</span>
+                  <%= text_field_tag 'institution[title]',@institution.title, class:'form-control' %>
+
+                  <%= label_tag 'Website' %>
+                  <%= text_field_tag 'institution[web_page]',@institution.web_page, class:'form-control' %>
+
+                  <%= label_tag 'City' %>
+                  <%= text_field_tag 'institution[city]',@institution.city, class:'form-control' %>
+
+                  <%= label_tag 'Country' %>
+                  <%= country_select 'institution', 'country', { include_blank: 'Select a country' }, {class:'form-control'} %>
+                </div>
+              </div>
+            <% else %>
+              <div>
+                They wish to be associated with <%= link_to(@institution.title, @institution) %>
+              </div>
+              <%= hidden_field_tag 'institution[id]',@institution.id %>
+            <% end %>
+          </div>
+        </div>
+
+        <% if @people.length() > 0 %>
+          <div class="panel panel-default">
+            <div class="panel-heading">
+              <%= t('people') %>
+            </div>
+            <div class="panel-body">
+              <div>
+                They have requested to create the following users if they do not exist:
+                <ul class="list-group">
+                  <% @people.each do |person| %>
+                    <li class="list-group-item">
+                      <%= person.name %> (<%= person.email %>)
+                      <%= hidden_field_tag 'people[][first_name]', person.first_name %>
+                      <%= hidden_field_tag 'people[][last_name]', person.last_name %>
+                      <%= hidden_field_tag 'people[][email]', person.email %>
+                    </li>
+                  <% end %>
+                </ul>
+                These users will be associated with the <%= t('project') %> through the selected <%= t('institution') %>.
+              </div>
+            </div>
+          </div>
+        <% end %>
+
+        <% if @message_log.sent_by_self? %>
+          <span style="display:none">
+            <%= check_box_tag 'accept_request','1',true %>
+          </span>
+          <%= submit_tag('Create', class: 'btn btn-success',id:'submit-button') %>
+          <%= submit_tag('Cancel', class: 'btn btn-default',id:'cancel-button') %>
+
+        <% else %>
+          <div>
+            <label>
+              <%= check_box_tag 'accept_request','1',true %>
+              Accept this request
+            </label>
+          </div>
+
+          <div id='reject-details-block' style="display:none;">
+
+            <%= label_tag "Reasons for rejection" %>
+            <div class="help-block">
+              Provide details why it was rejected. Note that this will be forwarded onto to the requester.
+            </div>
+            <%= text_area_tag 'reject_details','',class:'form-control' %>
+          </div>
+
+          <%= submit_tag('Accept', class: 'btn btn-success',id:'submit-button') %>
+          <span style="display:none">
+            <%= check_box_tag 'delete_request','1',false %>
+          </span>
+          <%= submit_tag('Delete without response', class: 'btn btn-danger',id:'delete-button', style:'display:none;') %>
+
+        <% end %>
+
+
+      </div>
+    </div>
+
+  <% end %>
+</div>
+
+<script type=application/javascript>
+
+
+    function submitButtonStatus() {
+        if ($j('input#accept_request').is(':checked')) {
+            $j('#submit-button').val('Accept');
+            $j('#submit-button').addClass('btn-success').removeClass('btn-danger');
+            $j('#delete-button').hide();
+        }
+        else {
+            $j('#submit-button').val('Reject');
+            $j('#submit-button').addClass('btn-danger').removeClass('btn-success');
+            $j('#delete-button').show();
+        }
+    }
+
+    function rejectDetailsStatus() {
+        if ($j('input#accept_request').is(':checked')) {
+            $j('#reject-details-block').hide();
+        }
+        else {
+            $j('#reject-details-block').show();
+        }
+    }
+
+    $j(document).ready(function () {
+        <% if @message_log.sent_by_self? %>
+          $j('#cancel-button').on('click',function() {
+              $j('input#accept_request').prop( "checked", false );
+          });
+        <% else %>
+          $j('input#accept_request').on('change',function() {
+              submitButtonStatus();
+              rejectDetailsStatus();
+          });
+          submitButtonStatus();
+          rejectDetailsStatus();
+        <% end %>
+
+        $j('input#delete-button').on('click', function() {
+            if (confirm("Are you sure? This will permanently delete the request, and the requester won't be notified")) {
+                $j('input#accept_request').prop( "checked", false );
+                $j('input#delete_request').prop( "checked", true );
+            }
+            else {
+                return false;
+            }
+        });
+    });
+
+</script>

--- a/app/views/projects/guided_create.html.erb
+++ b/app/views/projects/guided_create.html.erb
@@ -12,7 +12,7 @@
         
         <div class="help-block">
           Please provide some basic details about the <%= t('project') %> that will be created. You will be able to update and add additional
-          information once it has been created.
+          information once it has been created. You may also <a href="./guided_import">import</a> a project from a Data Management Plan (DMP) file.
         </div>
 
         <%= label_tag :project_title, "Title" %><span class="required">*</span>

--- a/app/views/projects/guided_import.html.erb
+++ b/app/views/projects/guided_import.html.erb
@@ -1,0 +1,93 @@
+<%= index_and_new_help_icon controller_name %>
+
+<%= notice %>
+
+<%= form_tag request_import_projects_path, multipart: true do %>
+  <div class="row">
+    <div  style="margin:auto;width:70%;">
+
+      <% if Seek::ProjectFormProgrammeOptions.show_programme_box? %>
+        <%= render partial: 'projects/guided_create/programme_box' %>
+      <% end %>
+
+      <%= panel(t(:project)) do %>
+
+        <div class="help-block">
+          Please upload a Data Management Plan detailing a <%= t('project') %> that will be created. The DMP must conform to the RDA DMP Common Standard. You will be able to update and add additional
+          information once it has been created.
+        </div>
+
+        <%= label_tag :project_dmp, "DMP" %><span class="required">*</span>
+        <%= file_field_tag 'project[dmp]', accept: '.json', class: 'upload' %>
+
+      <% end %>
+
+
+      <%= panel(t(:institution)) do %>
+        <div class="form-group">
+          <%= render partial: 'institutions/select_or_define' %>
+        </div>
+      <% end %>
+
+      <%= submit_tag('Submit', class: 'btn btn-primary', id: 'submit-button', disabled: true) %>
+    </div>
+  </div>
+<% end %>
+
+
+<script type=application/javascript>
+
+    function checkSubmitButtonEnabled() {
+        var progEnabled = <%= Seek::ProjectFormProgrammeOptions.show_programme_box? %>;
+        var enabled = $j('select#institution_id').val()
+            && !progEnabled || ($j('#programme_id').val() || $j('input#programme_title').val())
+            && $j('input#project_dmp').val()
+            && $j('input#institution_title').val();
+        $j('#submit-button').prop('disabled', !enabled);
+    }
+
+    $j(document).ready(function () {
+
+        <% if Seek::ProjectFormProgrammeOptions.managed_checkbox? %>
+            $j('input#managed_programme').on('change', function() {
+                if ($j('input#managed_programme:checked').length == 0) {
+                    $j('#programme-details').show();
+                    $j('#programme_id').val('');
+                }
+                else {
+                    $j('#programme_id').val('<%= Programme.site_managed_programme.id %>');
+                    $j('#programme-details').hide();
+                    $j('input#programme_title').val('');
+                }
+                checkSubmitButtonEnabled();
+            });
+        <% end %>
+
+        <% if Seek::ProjectFormProgrammeOptions.creation_allowed? && Seek::ProjectFormProgrammeOptions.programme_dropdown? %>
+            $j('input#new_programme').on('change', function() {
+                if ($j('input#new_programme:checked').length == 1) {
+                    $j('#programme-details').show();
+                    $j('select#programme_id').prop('disabled',true);
+                    $j('select#programme_id').attr('name','disabled-programme_id');
+                    $j('select#programme_id').attr('id','disabled-programme_id');
+                }
+                else {
+                    $j('#programme-details').hide();
+                    $j('input#programme_title').val('');
+                    $j('select#disabled-programme_id').attr('name','programme_id');
+                    $j('select#disabled-programme_id').attr('id','programme_id');
+                    $j('select#programme_id').prop('disabled',false);
+                }
+                checkSubmitButtonEnabled();
+            });
+        <% end %>
+
+        $j('input#programme_title').on('input',function() {
+            checkSubmitButtonEnabled();
+        });
+
+        $j('input#project_dmp').on('input', function() {
+            checkSubmitButtonEnabled();
+        });
+    });
+</script>

--- a/app/views/projects/project_importation_requests.html.erb
+++ b/app/views/projects/project_importation_requests.html.erb
@@ -1,0 +1,24 @@
+<h1><%= @requests.count %> Pending <%= t('project') %> importation <%= "request".pluralize(@requests.count) %></h1>
+
+<table id='project-import-requests' class='table table-bordered table-hover'>
+  <thead>
+  <tr>
+    <th>Requester</th>
+    <th><%= t('project') %> name</th>
+    <th>Date requested</th>
+    <th></th>
+  </tr>
+  </thead>
+  <tbody>
+  <% @requests.select(&:sender).each do |request| %>
+    <tr>
+      <td><%= link_to(request.sender.title, request.sender) %></td>
+      <td><%= JSON.parse(request.details)['project']['title'] %></td>
+      <td><%= date_as_string(request.created_at, true)  %></td>
+      <td class="text-center">
+        <%= link_to('Respond', administer_import_project_request_projects_path(message_log_id: request.id),class:'btn btn-primary') %>
+      </td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/projects/request_import.html.erb
+++ b/app/views/projects/request_import.html.erb
@@ -1,0 +1,71 @@
+<div class="row">
+  <div style="width:70%;margin:auto">
+    <div class="panel panel-default">
+      <div class="panel-body">
+        <% if @programme %>
+          <% if @programme.id.nil? %>
+            <%
+              mail_recipients = "#{Seek::Config.instance_name} administrators"
+              to_be_created = "#{t('programme')} and #{t('project')}"
+            %>
+            <p>
+              You have requested for a new <%= t('programme') %>, and a <%= t('project') %> to be created within it.
+            </p>
+            <p>
+              You will become an administrator of both the <%= t('programme') %> and <%= t('project') %>
+            </p>
+            <p>
+              You have described the new <%= t('programme') %> with the following details:
+            <ul>
+              <li><strong>Title:</strong> <%= text_or_not_specified(@programme.title) %></li>
+            </ul>
+            </p>
+          <% else %>
+            <%
+              mail_recipients = t('project_administrator').pluralize
+              to_be_created = "#{t('project')}"
+            %>
+            <p>
+              You have requested for a <%= t('project') %> to be created within a <%= Seek::Config.instance_admins_name %>
+              managed <%= t('programme') %>.
+            </p>
+          <% end %>
+        <% end %>
+
+        <p style="padding-top: 1em;">
+          You have described the new <%= t('project') %> with the following details:
+        <ul>
+          <li><strong>Title:</strong> <%= text_or_not_specified(@project.title) %></li>
+          <li><strong>Description:</strong> <%= text_or_not_specified(@project.description) %></li>
+          <li><strong>Web page:</strong> <%= text_or_not_specified(@project.web_page, external_link: true) %></li>
+        </ul>
+        </p>
+
+        <p style="padding-top: 1em;">
+          <% if @institution.id.nil? %>
+            You have described a new <%= t('institution') %> with the following details:
+          <ul>
+            <li><strong>Title:</strong> <%= text_or_not_specified(@institution.title) %></li>
+            <li><strong>Web page:</strong> <%= text_or_not_specified(@institution.web_page, external_link: true) -%>
+            </li>
+            <li><strong>City:</strong><%= text_or_not_specified(@institution.city) -%></li>
+            <li><strong>Country:</strong> <%= country_text_or_not_specified @institution.country -%></li>
+          </ul>
+        <% else %>
+          You have indicated that you are associated with <%= link_to(@institution.title, @institution) %>
+        <% end %>
+        </p>
+
+      </div>
+    </div>
+  </div>
+</div>
+
+<% if Seek::Config.email_enabled %>
+  <p class="text-center">
+    <strong>
+    An email has been sent to the <%= mail_recipients %> and you will receive an email when the <%= to_be_created %> has been created,
+    or an email about why your request was declined.
+    </strong>
+  </p>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -318,12 +318,17 @@ SEEK::Application.routes.draw do
       get :request_institutions
       get :guided_join
       get :guided_create
+      get :guided_import
       post :request_join
       post :request_create
+      post :request_import
       get :administer_create_project_request
+      get :administer_import_project_request
       post :respond_create_project_request
+      post :respond_import_project_request
       get :project_join_requests
       get :project_creation_requests
+      get :project_importation_requests
       get  :typeahead
     end
     member do
@@ -737,7 +742,7 @@ SEEK::Application.routes.draw do
       post :template_attributes
     end
     collection do
-      post :filter_isa_tags_by_level
+post :filter_isa_tags_by_level
       get :task_status
       get :default_templates
       post :populate_template

--- a/lib/seek/project_message_log_details.rb
+++ b/lib/seek/project_message_log_details.rb
@@ -1,5 +1,5 @@
 module Seek
-  # handles processing the details about a log related to a project create or join
+  # handles processing the details about a log related to a project create, import or join
   # request. The details are logged as JSON and this class handles the generation and parsing of the
   # JSON
   module ProjectMessageLogDetails
@@ -7,12 +7,13 @@ module Seek
 
     # Encapsulates the message details, provind the project, programme, institution and comments
     class Details
-      attr_reader :project, :programme, :institution, :comments
+      attr_reader :project, :programme, :institution, :people, :comments
 
-      def initialize(project:, programme:, institution:, comments:)
+      def initialize(project:, programme:, institution:, people:, comments:)
         @project = project
         @programme = programme
         @institution = institution
+        @people = people
         @comments = comments
       end
     end
@@ -26,6 +27,7 @@ module Seek
     REQUIRED_ATTRIBUTES = {
       Project => %w[id title description web_page programme_id],
       Institution => %w[id title city country web_page],
+      Person => %w[id first_name last_name email],
       Programme => %w[id title description]
     }.freeze
 
@@ -37,6 +39,7 @@ module Seek
         project: find_instance_from_json(details_json, Project),
         programme: find_instance_from_json(details_json, Programme),
         institution: find_instance_from_json(details_json, Institution),
+        people: details_json['people']&.map { |person_details| find_instance_from_json({ 'person' => person_details }, Person) },
         comments: details_json['comments']
       )
     end
@@ -55,11 +58,12 @@ module Seek
     end
 
     module ClassMethods
-      def details_json(programme: nil, project: nil, institution: nil, comments: nil)
+      def details_json(programme: nil, project: nil, institution: nil, people: nil, comments: nil)
         details = {}
         details[:institution] = institution.attributes.slice(*REQUIRED_ATTRIBUTES[Institution]) if institution
         details[:project] = project.attributes.slice(*REQUIRED_ATTRIBUTES[Project]) if project
         details[:programme] = programme.attributes.slice(*REQUIRED_ATTRIBUTES[Programme]) if programme
+        details[:people] = people.map { |person| person.attributes.slice(*REQUIRED_ATTRIBUTES[Person]) } if people
         details[:comments] = comments if comments
 
         details.to_json

--- a/test/fixtures/files/dmp.json
+++ b/test/fixtures/files/dmp.json
@@ -1,0 +1,89 @@
+{
+    "dmp": {
+      "contact": {
+        "contact_id": {
+          "identifier": "test",
+          "type": "orcid"
+        },
+        "mbox": "user@test.com",
+        "name": "Test User"
+      },
+      "contributor": [
+        {
+          "contributor_id": {
+            "identifier": "test",
+            "type": "orcid"
+          },
+          "mbox": "user@test.com",
+          "name": "Test User",
+          "role": ["contact person", "data steward", "supervisor"]
+        },
+        {
+          "contributor_id": {
+            "identifier": "test",
+            "type": "orcid"
+          },
+          "mbox": "user2@test.com",
+          "name": "Another Test User",
+          "role": ["data steward"]
+        }
+      ],
+      "created": "2023-09-24T17:14:32Z",
+      "dataset": [
+        {
+          "dataset_id": {
+            "identifier": "a",
+            "type": "other"
+          },
+          "description": "a",
+          "distribution": [
+            {
+              "data_access": "open",
+              "license": [
+                {
+                  "license_ref": "https://creativecommons.org/publicdomain/zero/1.0/",
+                  "start_date": "2023-09-18"
+                }
+              ],
+              "title": "a"
+            }
+          ],
+          "personal_data": "yes",
+          "sensitive_data": "yes",
+          "title": "a"
+        }
+      ],
+      "description": "This maDMP has been created using Data Stewardship Wizard (DSW, ds-wizard.org) and is based on knowledge model Life Sciences DSW Knowledge Model (dsw:lifesciences:2.6.2). The questionnaire used for this DMP is identified by UUID \"04efb18f-5bb2-42fc-9ca4-3f4d28f2118f\" within https://dsw-test.elixir.no DSW instance.",
+      "dmp_id": {
+        "identifier": "https://dsw-test.elixir.no/questionnaires/04efb18f-5bb2-42fc-9ca4-3f4d28f2118f",
+        "type": "url"
+      },
+      "ethical_issues_description": "We will collect data connected to a person, i.e. \"personal data\".",
+      "ethical_issues_exist": "yes",
+      "language": "eng",
+      "modified": "2023-09-24T17:14:32Z",
+      "project": [
+        {
+          "description": "description",
+          "end": "2023-10-19",
+          "funding": [
+            {
+              "funder_id": {
+                "identifier": "test",
+                "type": "url"
+              },
+              "funding_status": "planned",
+              "grant_id": {
+                "identifier": "test",
+                "type": "other"
+              }
+            }
+          ],
+          "start": "2023-09-19",
+          "title": "The Project"
+        }
+      ],
+      "title": "The DMP"
+    }
+  }
+  

--- a/test/functional/projects_controller_test.rb
+++ b/test/functional/projects_controller_test.rb
@@ -2182,6 +2182,214 @@ class ProjectsControllerTest < ActionController::TestCase
     end
   end
 
+  test 'request import project with site managed programme' do
+    FactoryBot.create(:admin)
+    person = FactoryBot.create(:person_not_in_project)
+    programme = FactoryBot.create(:programme)
+
+    prog_admin = FactoryBot.create(:person)
+    prog_admin.is_programme_administrator = true, programme
+    prog_admin.save!
+    another_prog_admin = FactoryBot.create(:person)
+    another_prog_admin.is_programme_administrator = true, programme
+    another_prog_admin.save!
+    programme.reload
+    assert_equal 2, programme.programme_administrators.count
+
+    institution = FactoryBot.create(:institution)
+
+    refute programme.programme_administrators.select(&:is_admin?).any?
+    login_as(person)
+    with_config_value(:managed_programme_id, programme.id) do
+      params = {
+          programme_id: programme.id,
+          project: {dmp: fixture_file_upload('dmp.json', 'application/json')},
+          institution: { id: [institution.id] }
+      }
+      assert_enqueued_emails(1) do
+        assert_difference('ProjectImportationMessageLog.count') do
+          post :request_import, params: params
+        end
+      end
+
+      assert_response :success
+      assert flash[:notice]
+      log = ProjectImportationMessageLog.last
+      details = log.parsed_details
+      assert_equal institution.title, details.institution.title
+      assert_equal institution.id, details.institution.id
+      assert_equal institution.country, details.institution.country
+      assert_equal programme.title, details.programme.title
+      assert_equal programme.id, details.programme.id
+      assert_equal 'description', details.project.description
+      assert_equal 'The Project', details.project.title
+
+      assert_equal 2, details.people.length
+      assert details.people.any? { |p| p.first_name == 'Test' && p.last_name == 'User' && p.email == 'user@test.com' }
+      assert details.people.any? { |p| p.first_name == 'Another' && p.last_name == 'User' && p.email == 'user2@test.com' }
+    end
+  end
+
+  test 'request import project with own administered programme' do
+    person = FactoryBot.create(:programme_administrator)
+    programme = person.programmes.first
+    institution = FactoryBot.create(:institution)
+    login_as(person)
+    with_config_value(:managed_programme_id, nil) do
+      params = {
+        programme_id: programme.id,
+        project: {dmp: fixture_file_upload('dmp.json', 'application/json')},
+        institution: {id: [institution.id]}
+      }
+      assert_enqueued_emails(0) do
+        assert_difference('ProjectImportationMessageLog.count',1) do
+          post :request_import, params: params
+        end
+      end
+      log = ProjectImportationMessageLog.last
+      assert_redirected_to administer_import_project_request_projects_path(message_log_id:log.id)
+
+      details = log.parsed_details
+      assert_equal institution.title, details.institution.title
+      assert_equal institution.id, details.institution.id
+      assert_equal institution.country, details.institution.country
+      assert_equal programme.title, details.programme.title
+      assert_equal programme.id, details.programme.id
+
+      assert_equal 'description', details.project.description
+      assert_equal 'The Project', details.project.title
+
+      assert_equal 2, details.people.length
+      assert details.people.any? { |p| p.first_name == 'Test' && p.last_name == 'User' && p.email == 'user@test.com' }
+      assert details.people.any? { |p| p.first_name == 'Another' && p.last_name == 'User' && p.email == 'user2@test.com' }
+    end
+  end
+
+  test 'request import project as admin but no programme' do
+    person = FactoryBot.create(:admin)
+
+    institution = FactoryBot.create(:institution)
+    login_as(person)
+    with_config_value(:managed_programme_id, nil) do
+      params = {
+        project: {dmp: fixture_file_upload('dmp.json', 'application/json')},
+        institution: {id: [institution.id]}
+      }
+      assert_enqueued_emails(0) do
+        assert_difference('ProjectImportationMessageLog.count',1) do
+          with_config_value(:programmes_enabled, false) do
+            post :request_import, params: params
+          end
+        end
+      end
+      log = ProjectImportationMessageLog.last
+      assert_redirected_to administer_import_project_request_projects_path(message_log_id:log.id)
+
+      details = log.parsed_details
+      assert_equal institution.title, details.institution.title
+      assert_equal institution.id, details.institution.id
+      assert_equal institution.country, details.institution.country
+
+      assert_equal 'description', details.project.description
+      assert_equal 'The Project', details.project.title
+
+      assert_equal 2, details.people.length
+      assert details.people.any? { |p| p.first_name == 'Test' && p.last_name == 'User' && p.email == 'user@test.com' }
+      assert details.people.any? { |p| p.first_name == 'Another' && p.last_name == 'User' && p.email == 'user2@test.com' }
+    end
+  end
+
+  test 'request import project with new programme and institution' do
+    FactoryBot.create(:admin)
+    person = FactoryBot.create(:person_not_in_project)
+    programme = FactoryBot.create(:programme)
+    assert Person.admins.count > 1
+    login_as(person)
+    with_config_value(:managed_programme_id, programme.id) do
+      params = {
+        project: {dmp: fixture_file_upload('dmp.json', 'application/json')},
+          institution: {id: ['the inst'], title: 'the inst', web_page: 'the page', city: 'London', country: 'GB'},
+          programme_id: '',
+          programme: {title: 'the prog'}
+      }
+      assert_enqueued_emails(1) do
+        assert_difference('ProjectImportationMessageLog.count') do
+          assert_no_difference('Institution.count') do
+            assert_no_difference('Project.count') do
+              assert_no_difference('Programme.count') do
+                post :request_import, params: params
+              end
+            end
+          end
+        end
+      end
+
+      assert_response :success
+      assert flash[:notice]
+      log = ProjectImportationMessageLog.last
+      details = log.parsed_details
+
+      assert_equal 'GB',details.institution.country
+      assert_equal 'London',details.institution.city
+      assert_equal 'the page',details.institution.web_page
+      assert_equal 'the inst',details.institution.title
+      assert_nil details.institution.id
+
+      assert_equal 'description', details.project.description
+      assert_equal 'The Project', details.project.title
+      assert_nil  details.project.id
+
+      assert_equal 'the prog',details.programme.title
+      assert_nil details.programme.id
+
+      assert_equal 2, details.people.length
+      assert details.people.any? { |p| p.first_name == 'Test' && p.last_name == 'User' && p.email == 'user@test.com' }
+      assert details.people.any? { |p| p.first_name == 'Another' && p.last_name == 'User' && p.email == 'user2@test.com' }
+    end
+  end
+
+  test 'request import project without programmes' do
+    person = FactoryBot.create(:person_not_in_project)
+
+    login_as(person)
+    with_config_value(:programmes_enabled, false) do
+      params = {
+        project: {dmp: fixture_file_upload('dmp.json', 'application/json')},
+        institution: {id: ['the inst'], title:'the inst',web_page:'the page',city:'London',country:'GB'}
+      }
+      assert_enqueued_emails(1) do
+        assert_difference('ProjectImportationMessageLog.count') do
+          assert_no_difference('Institution.count') do
+            assert_no_difference('Project.count') do
+              post :request_import, params: params
+            end
+          end
+        end
+      end
+
+      assert_response :success
+      assert flash[:notice]
+      log = ProjectImportationMessageLog.last
+      details = log.parsed_details
+
+      assert_equal 'GB',details.institution.country
+      assert_equal 'London',details.institution.city
+      assert_equal 'the page',details.institution.web_page
+      assert_equal 'the inst',details.institution.title
+      assert_nil details.institution.id
+
+      assert_equal 'description', details.project.description
+      assert_equal 'The Project', details.project.title
+      assert_nil  details.project.id
+
+      assert_nil details.programme
+
+      assert_equal 2, details.people.length
+      assert details.people.any? { |p| p.first_name == 'Test' && p.last_name == 'User' && p.email == 'user@test.com' }
+      assert details.people.any? { |p| p.first_name == 'Another' && p.last_name == 'User' && p.email == 'user2@test.com' }
+    end
+  end
+
   test 'administer join request' do
     person = FactoryBot.create(:project_administrator)
     project = person.projects.first
@@ -3257,6 +3465,770 @@ class ProjectsControllerTest < ActionController::TestCase
 
   end
 
+  test 'administer import request project with new programme and institution' do
+    person = FactoryBot.create(:admin)
+    login_as(person)
+    project = Project.new(title:'new project')
+    programme = Programme.new(title:'new programme')
+    institution = Institution.new(title:'my institution')
+    people = FactoryBot.create_list(:person, 3)
+    log = ProjectImportationMessageLog.log_request(sender:FactoryBot.create(:person), programme:programme, project:project, institution:institution, people:people)
+    get :administer_import_project_request, params:{message_log_id:log.id}
+    assert_response :success
+  end
+
+  test 'administer import project request, message log deleted' do
+    person = FactoryBot.create(:admin)
+    login_as(person)
+    id = (MessageLog.last&.id || 0) + 1
+    get :administer_import_project_request, params:{message_log_id:id}
+    assert_redirected_to :root
+    refute_nil flash[:error]
+    assert_match /deleted/i, flash[:error]
+  end
+
+  test 'administer import request project with institution already created' do
+    # when a new institution when requested, but it has then been created before the request is handled
+    person = FactoryBot.create(:admin)
+    login_as(person)
+    project = Project.new(title:'new project')
+    programme = Programme.new(title:'new programme')
+    institution = Institution.new(title:'my institution')
+    people = FactoryBot.create_list(:person, 3)
+    log = ProjectImportationMessageLog.log_request(sender:FactoryBot.create(:person), programme:programme, project:project, institution:institution, people:people)
+    created_inst = FactoryBot.create(:institution,title:'my institution')
+    get :administer_import_project_request, params:{message_log_id:log.id}
+    assert_response :success
+
+    assert_select 'input#institution_title', count: 0
+    assert_select 'input#institution_id', value: created_inst.id, count: 1
+  end
+
+  test 'admininister import request can be accessed by programme admin' do
+    person = FactoryBot.create(:programme_administrator)
+    login_as(person)
+    project = Project.new(title:'new project')
+    programme = person.programmes.first
+    institution = Institution.new(title:'my institution')
+    people = FactoryBot.create_list(:person, 3)
+    log = ProjectImportationMessageLog.log_request(sender:FactoryBot.create(:person), programme:programme, project:project, institution:institution, people:people)
+    get :administer_import_project_request, params:{message_log_id:log.id}
+    assert_response :success
+
+    another_person = FactoryBot.create(:programme_administrator)
+    login_as(another_person)
+    get :administer_import_project_request, params:{message_log_id:log.id}
+    assert_redirected_to :root
+    refute_nil flash[:error]
+  end
+
+  test 'admininister import request cannot be accessed by a different programme admin' do
+    person = FactoryBot.create(:programme_administrator)
+    another_person = FactoryBot.create(:programme_administrator)
+    login_as(another_person)
+
+    project = Project.new(title:'new project')
+    programme = person.programmes.first
+    institution = Institution.new(title:'my institution')
+    people = FactoryBot.create_list(:person, 3)
+    log = ProjectImportationMessageLog.log_request(sender:FactoryBot.create(:person), programme:programme, project:project, institution:institution, people:people)
+    get :administer_import_project_request, params:{message_log_id:log.id}
+
+    assert_redirected_to :root
+    refute_nil flash[:error]
+  end
+
+  test 'administer import request can be accessed by site admin for new programme' do
+    person = FactoryBot.create(:admin)
+    login_as(person)
+    project = Project.new(title:'new project')
+    programme = Programme.new(title:'new programme')
+    institution = Institution.new(title:'my institution')
+    people = FactoryBot.create_list(:person, 3)
+    log = ProjectImportationMessageLog.log_request(sender:FactoryBot.create(:person), programme:programme, project:project, institution:institution, people:people)
+    get :administer_import_project_request, params:{message_log_id:log.id}
+    assert_response :success
+  end
+
+  test 'administer import request cannot be accessed by none site admin for new programme' do
+    person = FactoryBot.create(:programme_administrator)
+    login_as(person)
+    project = Project.new(title:'new project')
+    programme = Programme.new(title:'new programme')
+    institution = Institution.new(title:'my institution')
+    people = FactoryBot.create_list(:person, 3)
+    log = ProjectImportationMessageLog.log_request(sender:FactoryBot.create(:person), programme:programme, project:project, institution:institution, people:people)
+    get :administer_import_project_request, params:{message_log_id:log.id}
+
+    assert_redirected_to :root
+    refute_nil flash[:error]
+  end
+
+  test 'respond import project request - new programme and institution' do
+    person = FactoryBot.create(:admin)
+    login_as(person)
+    project = Project.new(title:'new project',web_page:'my new project')
+    programme = Programme.new(title:'new programme')
+    institution = Institution.new({title:'institution', country:'DE'})
+    people = FactoryBot.create_list(:person, 3)
+    requester = FactoryBot.create(:person)
+    log = ProjectImportationMessageLog.log_request(sender:requester, programme:programme, project:project, institution:institution, people:people)
+    params = {
+        message_log_id:log.id,
+        accept_request: '1',
+        project:{
+            title:'new project updated',
+            web_page:'http://proj.org'
+        },
+        programme:{
+            title:'new programme updated'
+        },
+        institution:{
+            title:'new institution updated',
+            city:'Paris',
+            country:'FR'
+        },
+        people: people.map { |p| {first_name: p.first_name, last_name: p.last_name, email: p.email} }
+    }
+
+    assert_enqueued_emails(2) do
+      assert_difference('Programme.count') do
+        assert_difference('Project.count') do
+          assert_difference('Institution.count') do
+            assert_difference('GroupMembership.count', 4) do
+              assert_difference('WorkGroup.count') do
+                post :respond_import_project_request, params:params
+              end
+            end
+          end
+        end
+      end
+    end
+
+    project = Project.last
+    programme = Programme.last
+    institution = Institution.last
+    people = Person.last(3)
+    requester.reload
+
+    assert_redirected_to(project_path(project))
+    assert_equal "Request accepted and #{log.sender.name} added to Project and notified",flash[:notice]
+
+    assert_equal 'new project updated', project.title
+    assert_equal 'new programme updated', programme.title
+    assert_equal 'new institution updated', institution.title
+
+    assert_includes programme.projects,project
+    assert_includes project.people, requester
+    people.each { |p| assert_includes project.people, p }
+    assert_includes project.institutions, institution
+    assert_includes programme.programme_administrators, requester
+    assert_includes project.project_administrators, requester
+
+    assert_equal WorkGroup.last, requester.work_groups.last
+    assert_equal institution, requester.work_groups.last.institution
+    assert_equal project, requester.work_groups.last.project
+
+    log.reload
+    assert log.responded?
+    assert_equal 'Accepted',log.response
+
+  end
+
+  test 'respond import project request - new programme requires site admin' do
+    person = FactoryBot.create(:programme_administrator)
+    login_as(person)
+    project = Project.new(title:'new project',web_page:'my new project')
+    programme = Programme.new(title:'new programme')
+    institution = Institution.new({title:'institution', country:'DE'})
+    people = FactoryBot.create_list(:person, 3)
+    requester = FactoryBot.create(:person)
+    log = ProjectImportationMessageLog.log_request(sender:requester, programme:programme, project:project, institution:institution, people:people)
+    params = {
+        message_log_id:log.id,
+        accept_request: '1',
+        project:{
+            title:'new project updated',
+            web_page:'http://proj.org'
+        },
+        programme:{
+            title:'new programme updated'
+        },
+        institution:{
+            title:'new institution updated',
+            city:'Paris',
+            country:'FR'
+        },
+        people: people.map { |p| {first_name: p.first_name, last_name: p.last_name, email: p.email} }
+    }
+
+    assert_enqueued_emails(0) do
+      assert_no_difference('Programme.count') do
+        assert_no_difference('Project.count') do
+          assert_no_difference('Institution.count') do
+            assert_no_difference('GroupMembership.count') do
+              post :respond_import_project_request, params:params
+            end
+          end
+        end
+      end
+    end
+
+    assert_redirected_to :root
+    refute_nil flash[:error]
+
+    log.reload
+    refute log.responded?
+  end
+
+  test 'respond import project request - programme open for projects (disabled)' do
+    person = FactoryBot.create(:person)
+    login_as(person)
+    project = Project.new(title:'new project',web_page:'my new project')
+    programme = FactoryBot.create(:programme, open_for_projects: true)
+    institution = Institution.new({title:'institution', country:'DE'})
+    people = FactoryBot.create_list(:person, 3)
+    log = ProjectImportationMessageLog.log_request(sender: person, programme:programme, project:project, institution:institution, people:people)
+    params = {
+      message_log_id:log.id,
+      accept_request: '1',
+      project:{
+        title:'new project',
+        web_page:'http://proj.org'
+      },
+      programme:{
+        id: programme.id
+      },
+      institution:{
+        title:'new institution',
+        city:'Paris',
+        country:'FR'
+      },
+      people: people.map { |p| {first_name: p.first_name, last_name: p.last_name, email: p.email} }
+    }
+
+    assert_no_enqueued_emails do
+      assert_no_difference('Programme.count') do
+        assert_no_difference('Project.count') do
+          assert_no_difference('Institution.count') do
+            assert_no_difference('GroupMembership.count') do
+              assert_no_difference('WorkGroup.count') do
+                with_config_value(:programmes_open_for_projects_enabled, false) do
+                  post :respond_import_project_request, params:params
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+
+    assert_redirected_to :root
+    refute_nil flash[:error]
+
+    log.reload
+    refute log.responded?
+
+  end
+
+  test 'respond import project request - new programme and institution, project invalid' do
+    person = FactoryBot.create(:admin)
+    login_as(person)
+    project = Project.new(title:'new project',web_page:'my new project')
+    programme = Programme.new(title:'new programme')
+    institution = Institution.new({title:'institution', country:'DE'})
+    people = FactoryBot.create_list(:person, 3)
+    requester = FactoryBot.create(:person)
+    log = ProjectImportationMessageLog.log_request(sender:requester, programme:programme, project:project, institution:institution, people:people)
+    params = {
+        message_log_id:log.id,
+        accept_request: '1',
+        project:{
+            title:''
+        },
+        programme:{
+            title:'new programme updated'
+        },
+        institution:{
+            title:'new institution updated',
+            city:'Paris',
+            country:'FR'
+        },
+        people: people.map { |p| {first_name: p.first_name, last_name: p.last_name, email: p.email} }
+    }
+
+    assert_enqueued_emails(0) do
+      assert_no_difference('Programme.count') do
+        assert_no_difference('Project.count') do
+          assert_no_difference('Institution.count') do
+            assert_no_difference('GroupMembership.count') do
+              post :respond_import_project_request, params:params
+            end
+          end
+        end
+      end
+    end
+
+    assert_equal "The Project is invalid, Title can't be blank",flash[:error]
+
+    log.reload
+    refute log.responded?
+
+  end
+
+
+  test 'respond import project request - new programme and institution, programme and institution invalid' do
+    person = FactoryBot.create(:admin)
+    duplicate_institution=FactoryBot.create(:institution)
+    login_as(person)
+    project = Project.new(title:'new project',web_page:'my new project')
+    programme = Programme.new(title:'new programme')
+    institution = Institution.new({title:'institution', country:'DE'})
+    people = FactoryBot.create_list(:person, 3)
+    requester = FactoryBot.create(:person)
+    log = ProjectImportationMessageLog.log_request(sender:requester, programme:programme, project:project, institution:institution, people:people)
+    params = {
+        message_log_id:log.id,
+        accept_request: '1',
+        project:{
+            title:'a valid project'
+        },
+        programme:{
+            title:''
+        },
+        institution:{
+            title:duplicate_institution.title,
+            city:'Paris',
+            country:'FR'
+        },
+        people: people.map { |p| {first_name: p.first_name, last_name: p.last_name, email: p.email} }
+    }
+
+    assert_enqueued_emails(0) do
+      assert_no_difference('Programme.count') do
+        assert_no_difference('Project.count') do
+          assert_no_difference('Institution.count') do
+            assert_no_difference('GroupMembership.count') do
+              assert_no_difference('WorkGroup.count') do
+                post :respond_import_project_request, params:params
+              end
+            end
+          end
+        end
+      end
+    end
+
+    assert_equal "The Programme is invalid, Title can't be blank<br/>The Institution is invalid, Title has already been taken",flash[:error]
+
+    log.reload
+    refute log.responded?
+  end
+
+  test 'respond import project request - existing programme and institution' do
+    person = FactoryBot.create(:programme_administrator)
+    programme = person.programmes.first
+    institution = FactoryBot.create(:institution)
+    login_as(person)
+    project = Project.new(title:'new project',web_page:'my new project')
+    people = FactoryBot.create_list(:person, 3)
+    requester = FactoryBot.create(:person)
+    log = ProjectImportationMessageLog.log_request(sender:requester, programme:programme, project:project, institution:institution, people:people)
+    params = {
+        message_log_id:log.id,
+        accept_request: '1',
+        project:{
+            title:'new project',
+            web_page:'http://proj.org'
+        },
+        programme:{
+            id:programme.id
+        },
+        institution:{
+            id:institution.id
+        },
+        people: people.map { |p| {first_name: p.first_name, last_name: p.last_name, email: p.email} }
+    }
+
+    assert_enqueued_emails(2) do
+      assert_no_difference('Programme.count') do
+        assert_difference('Project.count') do
+          assert_no_difference('Institution.count') do
+            assert_difference('GroupMembership.count', 4) do
+              post :respond_import_project_request, params:params
+            end
+          end
+        end
+      end
+    end
+
+    project = Project.last
+    people = Person.last(3)
+    programme.reload
+
+    assert_redirected_to(project_path(project))
+    assert_equal "Request accepted and #{log.sender.name} added to Project and notified",flash[:notice]
+
+    assert_includes programme.projects,project
+    assert_includes project.people, requester
+    people.each { |p| assert_includes project.people, p }
+    assert_includes project.institutions, institution
+    refute_includes programme.programme_administrators, requester
+    assert_includes project.project_administrators, requester
+
+    log.reload
+    assert log.responded?
+    assert_equal 'Accepted',log.response
+
+  end
+
+  test 'respond import project request as the same user' do
+    person = FactoryBot.create(:programme_administrator)
+    programme = person.programmes.first
+    institution = FactoryBot.create(:institution)
+    login_as(person)
+    project = Project.new(title:'new project',web_page:'my new project')
+    people = FactoryBot.create_list(:person, 3)
+    requester = person
+    log = ProjectImportationMessageLog.log_request(sender:requester, programme:programme, project:project, institution:institution, people:people)
+    assert log.sent_by_self?
+    params = {
+      message_log_id:log.id,
+      accept_request: '1',
+      project:{
+        title:'new project',
+        web_page:'http://proj.org'
+      },
+      programme:{
+        id:programme.id
+      },
+      institution:{
+        id:institution.id
+      },
+      people: people.map { |p| {first_name: p.first_name, last_name: p.last_name, email: p.email} }
+    }
+
+    assert_enqueued_emails(0) do
+      assert_no_difference('Programme.count') do
+        assert_difference('Project.count') do
+          assert_no_difference('Institution.count') do
+            assert_difference('GroupMembership.count', 4) do
+              assert_difference('ProjectImportationMessageLog.count',-1) do
+                post :respond_import_project_request, params:params
+              end
+            end
+          end
+        end
+      end
+    end
+
+    project = Project.last
+    people = Person.last(3)
+    programme.reload
+
+    assert_redirected_to(project_path(project))
+    assert_equal "Project created",flash[:notice]
+
+    assert_includes programme.projects,project
+    assert_includes project.people, requester
+    people.each { |p| assert_includes project.people, p }
+    assert_includes project.institutions, institution
+    assert_includes project.project_administrators, requester
+
+  end
+
+  test 'respond import project request as the same user - cancel' do
+    person = FactoryBot.create(:programme_administrator)
+    programme = person.programmes.first
+    institution = FactoryBot.create(:institution)
+    login_as(person)
+    project = Project.new(title:'new project',web_page:'my new project')
+    people = FactoryBot.create_list(:person, 3)
+    requester = person
+    log = ProjectImportationMessageLog.log_request(sender:requester, programme:programme, project:project, institution:institution, people:people)
+    assert log.sent_by_self?
+    params = {
+      message_log_id:log.id,
+      project:{
+        title:'new project',
+        web_page:'http://proj.org'
+      },
+      programme:{
+        id:programme.id
+      },
+      institution:{
+        id:institution.id
+      },
+      people: people.map { |p| {first_name: p.first_name, last_name: p.last_name, email: p.email} }
+    }
+
+    assert_enqueued_emails(0) do
+      assert_no_difference('Programme.count') do
+        assert_no_difference('Project.count') do
+          assert_no_difference('Institution.count') do
+            assert_no_difference('GroupMembership.count') do
+              assert_difference('ProjectImportationMessageLog.count',-1) do
+                post :respond_import_project_request, params:params
+              end
+            end
+          end
+        end
+      end
+    end
+
+    assert_redirected_to :root
+    assert_equal "Project creation cancelled",flash[:notice]
+  end
+
+  test 'respond import project request - delete' do
+    person = FactoryBot.create(:programme_administrator)
+    programme = person.programmes.first
+    institution = FactoryBot.create(:institution)
+    login_as(person)
+    project = Project.new(title: 'new project', web_page: 'my new project')
+    people = FactoryBot.create_list(:person, 3)
+    requester = FactoryBot.create(:person)
+    log = ProjectImportationMessageLog.log_request(sender: requester, programme: programme, project: project, institution: institution, people: people)
+    refute log.sent_by_self?
+    params = {
+      message_log_id:log.id,
+      project:{
+        title:'new project',
+        web_page:'http://proj.org'
+      },
+      programme:{
+        id:programme.id
+      },
+      institution:{
+        id:institution.id
+      },
+      people: people.map { |p| {first_name: p.first_name, last_name: p.last_name, email: p.email} },
+      delete_request: '1'
+    }
+
+    assert_enqueued_emails(0) do
+      assert_no_difference('Programme.count') do
+        assert_no_difference('Project.count') do
+          assert_no_difference('Institution.count') do
+            assert_no_difference('GroupMembership.count') do
+              assert_difference('ProjectImportationMessageLog.count',-1) do
+                post :respond_import_project_request, params:params
+              end
+            end
+          end
+        end
+      end
+    end
+
+    assert_redirected_to :root
+    assert_equal "Project creation cancelled",flash[:notice]
+  end
+
+  test 'respond import project request - cannot delete without rights' do
+    person = FactoryBot.create(:person)
+    programme = FactoryBot.create(:programme)
+    institution = FactoryBot.create(:institution)
+    login_as(person)
+    project = Project.new(title: 'new project', web_page: 'my new project')
+    people = FactoryBot.create_list(:person, 3)
+    requester = FactoryBot.create(:person)
+    log = ProjectImportationMessageLog.log_request(sender: requester, programme: programme, project: project, institution: institution, people: people)
+    refute log.sent_by_self?
+    refute programme.can_manage?
+    params = {
+      message_log_id:log.id,
+      project:{
+        title:'new project',
+        web_page:'http://proj.org'
+      },
+      programme:{
+        id:programme.id
+      },
+      institution:{
+        id:institution.id
+      },
+      people: people.map { |p| {first_name: p.first_name, last_name: p.last_name, email: p.email} },
+      delete_request: '1'
+    }
+
+    assert_enqueued_emails(0) do
+      assert_no_difference('Programme.count') do
+        assert_no_difference('Project.count') do
+          assert_no_difference('Institution.count') do
+            assert_no_difference('GroupMembership.count') do
+              assert_no_difference('ProjectCreationMessageLog.count') do
+                post :respond_import_project_request, params:params
+              end
+            end
+          end
+        end
+      end
+    end
+
+    assert_redirected_to :root
+    refute_nil flash[:error]
+  end
+
+  test 'respond import project request - existing programme need prog admin rights' do
+    person = FactoryBot.create(:programme_administrator)
+    another_admin = FactoryBot.create(:programme_administrator)
+    programme = person.programmes.first
+    institution = FactoryBot.create(:institution)
+    login_as(another_admin)
+    project = Project.new(title:'new project',web_page:'my new project')
+    people = FactoryBot.create_list(:person, 3)
+    requester = FactoryBot.create(:person)
+    log = ProjectImportationMessageLog.log_request(sender:requester, programme:programme, project:project, institution:institution, people:people)
+    params = {
+        message_log_id:log.id,
+        accept_request: '1',
+        project:{
+            title:'new project',
+            web_page:'http://proj.org'
+        },
+        programme:{
+            id:programme.id
+        },
+        institution:{
+            id:institution.id
+        },
+        people: people.map { |p| {first_name: p.first_name, last_name: p.last_name, email: p.email} }
+    }
+
+    assert_enqueued_emails(0) do
+      assert_no_difference('Programme.count') do
+        assert_no_difference('Project.count') do
+          assert_no_difference('Institution.count') do
+            assert_no_difference('GroupMembership.count') do
+              post :respond_import_project_request, params:params
+            end
+          end
+        end
+      end
+    end
+
+    assert_redirected_to :root
+    refute_nil flash[:error]
+
+    log.reload
+    refute log.responded?
+
+
+  end
+
+  test 'respond import project request - rejected' do
+    person = FactoryBot.create(:programme_administrator)
+    programme = person.programmes.first
+    institution = FactoryBot.create(:institution)
+    login_as(person)
+    project = Project.new(title:'new project',web_page:'my new project')
+    people = FactoryBot.create_list(:person, 3)
+    requester = FactoryBot.create(:person)
+    log = ProjectImportationMessageLog.log_request(sender:requester, programme:programme, project:project, institution:institution, people:people)
+    params = {
+        message_log_id:log.id,
+        reject_details:'not very good',
+        project:{
+            title:'new project',
+            web_page:'http://proj.org'
+        },
+        programme:{
+            id:programme.id
+        },
+        institution:{
+            id:institution.id
+        },
+        people: people.map { |p| {first_name: p.first_name, last_name: p.last_name, email: p.email} }
+    }
+
+    assert_enqueued_emails(2) do
+      assert_no_difference('Programme.count') do
+        assert_no_difference('Project.count') do
+          assert_no_difference('Institution.count') do
+            assert_no_difference('GroupMembership.count') do
+              post :respond_import_project_request, params:params
+            end
+          end
+        end
+      end
+    end
+
+    assert_redirected_to(root_path)
+    assert_equal "Request rejected and #{log.sender.name} has been notified",flash[:notice]
+
+    refute_includes programme.programme_administrators, requester
+
+    log.reload
+    assert log.responded?
+    assert_equal 'not very good',log.response
+
+  end
+
+  test 'respond import project request - programmes disabled' do
+    person = FactoryBot.create(:admin)
+    login_as(person)
+    project = Project.new(title:'new project',web_page:'my new project')
+    institution = Institution.new({title:'institution', country:'DE'})
+    people = FactoryBot.create_list(:person, 3)
+    requester = FactoryBot.create(:person)
+    log = ProjectImportationMessageLog.log_request(sender:requester, project:project, institution:institution, people:people)
+    params = {
+      message_log_id:log.id,
+      accept_request: '1',
+      project:{
+        title:'new project updated',
+        web_page:'http://proj.org'
+      },
+      institution:{
+        title:'new institution updated',
+        city:'Paris',
+        country:'FR'
+      },
+      people: people.map { |p| {first_name: p.first_name, last_name: p.last_name, email: p.email} }
+    }
+
+    assert_enqueued_emails(2) do
+      assert_no_difference('Programme.count') do
+        assert_difference('Project.count') do
+          assert_difference('Institution.count') do
+            assert_difference('GroupMembership.count', 4) do
+              assert_difference('WorkGroup.count') do
+                with_config_value(:programmes_enabled, false) do
+                  post :respond_import_project_request, params:params
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+
+    project = Project.last
+    institution = Institution.last
+    people = Person.last(3)
+    requester.reload
+
+    assert_redirected_to(project_path(project))
+    assert_equal "Request accepted and #{log.sender.name} added to Project and notified",flash[:notice]
+
+    assert_equal 'new project updated', project.title
+    assert_nil project.programme
+    assert_equal 'new institution updated', institution.title
+
+    assert_includes project.people, requester
+    people.each { |p| assert_includes project.people, p }
+    assert_includes project.institutions, institution
+    assert_includes project.project_administrators, requester
+
+    assert_equal WorkGroup.last, requester.work_groups.last
+    assert_equal institution, requester.work_groups.last.institution
+    assert_equal project, requester.work_groups.last.project
+
+    log.reload
+    assert log.responded?
+    assert_equal 'Accepted',log.response
+
+  end
+
   test 'project join request' do
     person1 = FactoryBot.create(:project_administrator)
     person2 = FactoryBot.create(:project_administrator)
@@ -3379,6 +4351,74 @@ class ProjectsControllerTest < ActionController::TestCase
       assert_select "a[href=?]", person_path(person), text: person.title, count: 0
       assert_select "a[href=?]", administer_create_project_request_projects_path(message_log_id: log_new_programme.id), count: 0
       assert_select "a[href=?]", administer_create_project_request_projects_path(message_log_id: log_existing_programme.id), count: 0
+    end
+  end
+
+  test "project importation requests" do
+    admin = FactoryBot.create(:admin)
+    prog_admin = FactoryBot.create(:programme_administrator)
+    programme = prog_admin.programmes.first
+    person = FactoryBot.create(:person)
+    institution = FactoryBot.create(:institution)
+    project = Project.new(title: "new")
+    people = FactoryBot.create_list(:person, 3)
+
+    log_existing_programme = ProjectImportationMessageLog.log_request(sender:person, programme:programme, project:project, institution:institution, people:people)
+    log_new_programme = ProjectImportationMessageLog.log_request(sender:person, programme:Programme.new(title: "new"), project:project, institution:institution, people:people)
+
+    # no user
+    logout
+    get :project_importation_requests
+    assert_redirected_to :login
+    refute_nil flash[:error]
+
+    login_as(prog_admin)
+    get :project_importation_requests
+    assert_response :success
+
+    assert_select "h1", text: /1 pending project importation/i
+    assert_select "table#project-import-requests" do
+      assert_select "tbody tr", count: 1
+      assert_select "a[href=?]", person_path(person), text: person.title
+      assert_select "a[href=?]", administer_import_project_request_projects_path(message_log_id: log_existing_programme.id)
+      assert_select "a[href=?]", administer_import_project_request_projects_path(message_log_id: log_new_programme.id), count: 0
+    end
+
+    login_as(admin)
+    get :project_importation_requests
+    assert_response :success
+
+    assert_select "h1", text: /1 pending project importation/i
+    assert_select "table#project-import-requests" do
+      assert_select "tbody tr", count: 1
+      assert_select "a[href=?]", person_path(person), text: person.title
+      assert_select "a[href=?]", administer_import_project_request_projects_path(message_log_id: log_new_programme.id)
+      assert_select "a[href=?]", administer_import_project_request_projects_path(message_log_id: log_existing_programme.id), count: 0
+    end
+
+    with_config_value(:managed_programme_id, programme.id) do
+      get :project_importation_requests
+      assert_response :success
+
+      assert_select "h1", text: /2 pending project importation/i
+      assert_select "table#project-import-requests" do
+        assert_select "tbody tr", count: 2
+        assert_select "a[href=?]", person_path(person), text: person.title, count: 2
+        assert_select "a[href=?]", administer_import_project_request_projects_path(message_log_id: log_new_programme.id)
+        assert_select "a[href=?]", administer_import_project_request_projects_path(message_log_id: log_existing_programme.id)
+      end
+    end
+
+    login_as(person)
+    get :project_importation_requests
+    assert_response :success
+
+    assert_select "h1", text: /0 pending project importation/i
+    assert_select "table#project-import-requests" do
+      assert_select "tbody tr", count: 0
+      assert_select "a[href=?]", person_path(person), text: person.title, count: 0
+      assert_select "a[href=?]", administer_import_project_request_projects_path(message_log_id: log_new_programme.id), count: 0
+      assert_select "a[href=?]", administer_import_project_request_projects_path(message_log_id: log_existing_programme.id), count: 0
     end
   end
 

--- a/test/unit/mailer_test.rb
+++ b/test/unit/mailer_test.rb
@@ -401,6 +401,56 @@ class MailerTest < ActionMailer::TestCase
     end
   end
 
+  test 'request import project for programme' do
+    with_config_value(:instance_name, 'SEEK EMAIL TEST') do
+      with_config_value(:site_base_host, 'https://securefred.com:1337') do
+        programme_admin = FactoryBot.create(:programme_administrator)
+        programme = programme_admin.programmes.first
+        refute_empty programme.programme_administrators
+        project = Project.new(title:'My lovely project')
+        institution = FactoryBot.create(:institution)
+        people = FactoryBot.create_list(:person, 3)
+        sender = FactoryBot.create(:person)
+        log = ProjectImportationMessageLog.log_request(sender:sender, programme:programme, project:project, institution:institution, people:people)
+        email = Mailer.request_import_project_for_programme(sender.user, programme, project.to_json, institution.to_json, people.to_json,log)
+        refute_nil email
+        refute_nil email.body
+        assert_equal [programme_admin.email],email.to
+      end
+    end
+  end
+
+  test 'request import project' do
+    with_config_value(:instance_name, 'SEEK EMAIL TEST') do
+      with_config_value(:site_base_host, 'https://securefred.com:1337') do
+        project = Project.new(title:'My lovely project')
+        institution = FactoryBot.create(:institution)
+        people = FactoryBot.create_list(:person, 3)
+        sender = FactoryBot.create(:person)
+        log = ProjectImportationMessageLog.log_request(sender:sender, project:project, institution:institution, people:people)
+        email = Mailer.request_import_project(sender.user, project.to_json, institution.to_json, people.to_json,log)
+        refute_nil email
+        refute_nil email.body
+      end
+    end
+  end
+
+  test 'request import project and programme' do
+    with_config_value(:instance_name, 'SEEK EMAIL TEST') do
+      with_config_value(:site_base_host, 'https://securefred.com:1337') do
+        institution = Institution.new({title:'My lovely institution', web_page:'http://inst.org', country:'DE'})
+        project = Project.new(title:'My lovely project')
+        programme = Programme.new(title:'My lovely programme')
+        people = FactoryBot.create_list(:person, 3)
+        sender = FactoryBot.create(:person)
+        log = ProjectImportationMessageLog.log_request(sender:sender, programme:programme, project:project, institution:institution, people:people)
+        email = Mailer.request_import_project_and_programme(sender.user, programme.to_json, project.to_json, institution.to_json, people.to_json,log)
+        refute_nil email
+        refute_nil email.body        
+      end
+    end
+  end
+
   test 'join project rejected' do
     project = FactoryBot.create(:project,title:'project to join')
     requester = FactoryBot.create(:person)


### PR DESCRIPTION
Adds a workflow for importing projects from Data Management Plan files that follow the RDA DMP Common Standard. This format is used by e.g. ELIXIR's Data Stewardship Wizard, and it would greatly simplify the process of publishing projects from there to a SEEK instance if it could be done by a simple file upload rather than by manually entering the data.

This solution reads the data about a project from a DMP file, and this is used to create a new project. All contributors to the project are also read from the file, and user accounts are created and added as members of the newly created project.
The option to import a project is currently only presented to the user on both the "new project" and "guided create" pages. It is not accessible through the main navbar.