### PR TITLE
remember that the external search has been checked #1712

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -37,6 +37,7 @@ class SearchController < ApplicationController
     end
 
     if search_params[:include_external_search] == '1'
+      @include_external_search = true
       @external_results = Seek::ExternalSearch.instance.external_search(downcase_query, @search_type&.downcase)
     end
 

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -18,6 +18,9 @@ class SearchControllerTest < ActionController::TestCase
         assert_select '.list_item_title a[href=?]', document_path(doc)
       end
     end
+
+    refute assigns(:include_external_search)
+    assert_select 'div#advanced-search input#include_external_search[type=checkbox]:not(checked)'
   end
 
   test 'search result order retained' do
@@ -174,5 +177,23 @@ class SearchControllerTest < ActionController::TestCase
     assert_select '#resources-shown-count', count:0
     assert_select '#more-results', count: 0
 
+  end
+
+  test 'remember external search' do
+    FactoryBot.create(:model, policy: FactoryBot.create(:public_policy))
+
+    VCR.use_cassette('biomodels/search') do
+      with_config_value(:external_search_enabled, true) do
+        Model.stub(:solr_cache, -> (q) { Model.pluck(:id).last(3) }) do
+          get :index, params: { q: 'yeast', include_external_search: '1' }
+        end
+      end
+    end
+
+    assert_equal 1, assigns(:results)['Model'].count
+    assert_equal 25, assigns(:external_results).count
+
+    assert assigns(:include_external_search)
+    assert_select 'div#advanced-search input#include_external_search[type=checkbox][checked=checked]'
   end
 end

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -184,7 +184,7 @@ class SearchControllerTest < ActionController::TestCase
 
     VCR.use_cassette('biomodels/search') do
       with_config_value(:external_search_enabled, true) do
-        Model.stub(:solr_cache, -> (q) { Model.pluck(:id).last(3) }) do
+        Model.stub(:solr_cache, -> (q) { Model.pluck(:id).last(1) }) do
           get :index, params: { q: 'yeast', include_external_search: '1' }
         end
       end


### PR DESCRIPTION
fix to make sure the external search checkbox is remembered between searches.
There was an old flag used for the checkbox that was no longer being set.