### PR TITLE
Add rake upgrade task for recognising ISA JSON compliant investigations

### DIFF
--- a/lib/tasks/seek_upgrades.rake
+++ b/lib/tasks/seek_upgrades.rake
@@ -15,6 +15,7 @@ namespace :seek do
     rename_registered_sample_multiple_attribute_type
     remove_ontology_attribute_type
     db:seed:007_sample_attribute_types
+    recognise_isa_json_compliant_items
   ]
 
   # these are the tasks that are executes for each upgrade as standard, and rarely change
@@ -154,6 +155,21 @@ namespace :seek do
       end
     end
     puts " ... finished updating sample_resource_links of #{samples_updated.to_s} samples with data_file attributes"
+  end
+
+  task(recognise_isa_json_compliant_items: [:environment]) do
+    puts '... searching for ISA compliant investigations'
+    investigations_updated = 0
+    disable_authorization_checks do
+      isa_json_compliant_studies = Study.all.select { |study| study.sample_types.any? }
+      isa_json_compliant_studies.each do |study|
+        inv = study.investigation
+        inv.update(is_isa_json_compliant: true)
+        inv.save
+        investigations_updated += 1
+      end
+    end
+    puts "...Updated #{investigations_updated} investigations"
   end
 
   private


### PR DESCRIPTION
Upgrade task that sets the is_isa_json_compliant field to true of  all investigations that are linked to studies with sample types.