### PR TITLE
Fix rake task

### DIFF
--- a/lib/tasks/seek_upgrades.rake
+++ b/lib/tasks/seek_upgrades.rake
@@ -161,15 +161,19 @@ namespace :seek do
     puts '... searching for ISA compliant investigations'
     investigations_updated = 0
     disable_authorization_checks do
-      isa_json_compliant_studies = Study.all.select { |study| study.sample_types.any? }
-      isa_json_compliant_studies.each do |study|
-        inv = study.investigation
-        inv.update(is_isa_json_compliant: true)
-        inv.save
+      investigations_to_update = Study.joins(:investigation)
+                                      .where('investigations.is_isa_json_compliant = ?', false)
+                                      .select { |study| study.sample_types.any? }
+                                      .map(&:investigation)
+                                      .compact
+                                      .uniq
+
+      investigations_to_update.each do |inv|
+        inv.update_column(:is_isa_json_compliant, true)
         investigations_updated += 1
       end
     end
-    puts "...Updated #{investigations_updated} investigations"
+    puts "...Updated #{investigations_updated.to_s} investigations"
   end
 
   private


### PR DESCRIPTION
A more efficient and repeatable for rake task in [this PR](https://github.com/seek4science/seek/pull/1716#pullrequestreview-1813338199):

- Only updates investigations that are not ISA JSON compliant to start with
- Updates the investigation only once in case of multiple studies
- Usage of `update_column` instead of `update` to avoid going unnecessarily through the whole ActiveRecord lifecycle.