### PR TITLE
UI improvement for displaying the extended metadata 

### DIFF
--- a/app/assets/stylesheets/linked_extended_metadata.css
+++ b/app/assets/stylesheets/linked_extended_metadata.css
@@ -55,3 +55,15 @@
     padding: 0px 0px;
     border-radius: 5px;
 }
+
+#extended-metadata .panel-heading-button {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.extended_metadata-small-btn{
+    font-size: 1rem;
+    padding: 0.2rem 0.5rem;
+}
+

--- a/app/helpers/extended_metadata_helper.rb
+++ b/app/helpers/extended_metadata_helper.rb
@@ -38,7 +38,7 @@ module ExtendedMetadataHelper
       content_tag(:div, class: 'extended_metadata') do
         if attribute.linked_extended_metadata? || attribute.linked_extended_metadata_multi?
           content_tag(:span, class: 'linked_extended_metdata_display') do
-            folding_panel(attribute.label, true, id: attribute.title) do
+            folding_panel(attribute.label, false, id: attribute.title) do
               display_attribute(resource.extended_metadata, attribute, link: true)
             end
           end

--- a/app/views/extended_metadata/_extended_metadata_attribute_values.html.erb
+++ b/app/views/extended_metadata/_extended_metadata_attribute_values.html.erb
@@ -2,19 +2,21 @@
   label = 'Extended Metadata'
 %>
 <% if resource.respond_to?(:extended_metadata) && resource.extended_metadata %>
-
+  <% metadata_type = resource.extended_metadata.extended_metadata_type  %>
   <div id="extended-metadata" class="panel panel-default">
     <div class="panel-heading panel-heading-button">
       <div>
-        <%= label %> (<%= resource.extended_metadata.extended_metadata_type.title %>)
+        <%= label %> (<%= metadata_type.title %>)
       </div>
+      <% if metadata_type.extended_metadata_attributes.select{ |x|x.linked_extended_metadata? || x.linked_extended_metadata_multi? }.any? %>
       <div>
         <a href="#" class="btn btn-primary extended_metadata-small-btn" id="expandAllBtn" onclick="expandAll()">Expand All</a>
         <a href="#" class="btn btn-primary extended_metadata-small-btn" id="collapseAllBtn" onclick="collapseAll()">Collapse All</a>
       </div>
+      <% end %>
     </div>
     <div class="panel-body">
-      <% resource.extended_metadata.extended_metadata_attributes.each do |attribute| %>
+      <% metadata_type.extended_metadata_attributes.each do |attribute| %>
         <%= render_extended_metadata_value(attribute, resource) %>
       <% end %>
     </div>

--- a/app/views/extended_metadata/_extended_metadata_attribute_values.html.erb
+++ b/app/views/extended_metadata/_extended_metadata_attribute_values.html.erb
@@ -8,7 +8,7 @@
       <div>
         <%= label %> (<%= metadata_type.title %>)
       </div>
-      <% if metadata_type.extended_metadata_attributes.select{ |x|x.linked_extended_metadata? || x.linked_extended_metadata_multi? }.any? %>
+      <% if metadata_type.attributes_with_linked_extended_metadata_type.any? %>
       <div>
         <a href="#" class="btn btn-primary extended_metadata-small-btn" id="expandAllBtn" onclick="expandAll()">Expand All</a>
         <a href="#" class="btn btn-primary extended_metadata-small-btn" id="collapseAllBtn" onclick="collapseAll()">Collapse All</a>

--- a/app/views/extended_metadata/_extended_metadata_attribute_values.html.erb
+++ b/app/views/extended_metadata/_extended_metadata_attribute_values.html.erb
@@ -4,7 +4,15 @@
 <% if resource.respond_to?(:extended_metadata) && resource.extended_metadata %>
 
   <div id="extended-metadata" class="panel panel-default">
-    <div class="panel-heading"><%= label %> (<%= resource.extended_metadata.extended_metadata_type.title %>)</div>
+    <div class="panel-heading panel-heading-button">
+      <div>
+        <%= label %> (<%= resource.extended_metadata.extended_metadata_type.title %>)
+      </div>
+      <div>
+        <a href="#" class="btn btn-primary extended_metadata-small-btn" id="expandAllBtn" onclick="expandAll()">Expand All</a>
+        <a href="#" class="btn btn-primary extended_metadata-small-btn" id="collapseAllBtn" onclick="collapseAll()">Collapse All</a>
+      </div>
+    </div>
     <div class="panel-body">
       <% resource.extended_metadata.extended_metadata_attributes.each do |attribute| %>
         <%= render_extended_metadata_value(attribute, resource) %>
@@ -13,3 +21,17 @@
   </div>
   <% else %>
 <% end %>
+
+<script>
+    $j(document).ready(function() {
+        var panelcollaps = $j('#extended-metadata .panel-collapse');
+
+        window.expandAll = function() {
+            panelcollaps.addClass('in');
+        };
+
+        window.collapseAll = function() {
+            panelcollaps.removeClass('in');
+        };
+    });
+</script>

--- a/app/views/extended_metadata/_fancy_linked_extended_metadata_multi_attribute_fields.html.erb
+++ b/app/views/extended_metadata/_fancy_linked_extended_metadata_multi_attribute_fields.html.erb
@@ -19,7 +19,7 @@
       <% end %>
       <div id="<%= key.singularize %>-row">
         <div colspan="6">
-          <%= button_link_to('Add new', 'add', '#', :id => "add-row-#{prefix}") %>
+          <%= button_link_to('Add new', 'add', '#', :id => "add-row-#{prefix}", class: 'extended_metadata-small-btn') %>
         </div>
       </div>
     </div>

--- a/app/views/extended_metadata/_single_row.html.erb
+++ b/app/views/extended_metadata/_single_row.html.erb
@@ -25,7 +25,7 @@
   <div class="form-group">
     <% if allow_row_removal %>
       <div class="btn-group" data-toggle="buttons">
-        <label class="btn btn-danger">
+        <label class="btn btn-danger extended_metadata-small-btn">
           Remove
           <%= check_box_tag "#{field_name_prefix}[_destroy]", '1', false,
                             class: 'destroy-row', autocomplete: 'off',id:"#{field_name_prefix}-checkbox[_destroy]" %>


### PR DESCRIPTION
1. Expanded First Level Tree of Extended Metadata:
2. The "Expand All" and "Collapse All" buttons will now only be displayed if there are linked extended metadata types.
3. Optimized Buttons for "Add New" and "Remove":resized for a more compact and visually appealing design

https://github.com/seek4science/seek/issues/1696