### PR TITLE
Fix the select2 in the controlled vocab modal

### DIFF
--- a/app/assets/javascripts/controlled_vocabs.js.erb
+++ b/app/assets/javascripts/controlled_vocabs.js.erb
@@ -30,14 +30,20 @@ var SampleTypeControlledVocab = {
         initialise_rich_text_editors(".rich-text-edit");            
     },
 
+    copyBlankModalForm: function() {
+        // first destroy any select2 elements, which won't survive being cloned. They will be initialised again when reset
+        $j('#cv-modal select[data-role="seek-objectsinput"]').select2('destroy');
+        SampleTypeControlledVocab.blankControlledVocabModelForm=$j('#cv-modal').clone();
+    },
+
     //resets the modal
     resetModalControlledVocabForm: function () {
         $j('#cv-modal').remove();
         $j('#modal-dialogues').append(SampleTypeControlledVocab.blankControlledVocabModelForm.clone());
         CVTerms.init();
+        ObjectsInput.init();
         SampleTypeControlledVocab.bindNewControlledVocabShowEvent();
         SampleTypeControlledVocab.initialise_deferred_rich_editor_modal();
-        
     },    
 
     //selected CV item changed

--- a/app/views/isa_studies/_sample_types_form.html.erb
+++ b/app/views/isa_studies/_sample_types_form.html.erb
@@ -77,7 +77,7 @@
 <script>
     //used to hold the element Id that needs updating after creating a new CV
     $j(document).ready(function () {
-        SampleTypeControlledVocab.blankControlledVocabModelForm=$j('#cv-modal').clone();
+        SampleTypeControlledVocab.copyBlankModalForm();
         SampleTypeControlledVocab.resetModalControlledVocabForm();
         // Make rows sortable
         SampleTypes.bindSortable("#<%=attribute_table_id%>");

--- a/app/views/sample_types/_form.html.erb
+++ b/app/views/sample_types/_form.html.erb
@@ -89,7 +89,7 @@
 <script>
     //used to hold the element Id that needs updating after creating a new CV
     $j(document).ready(function () {
-        SampleTypeControlledVocab.blankControlledVocabModelForm=$j('#cv-modal').clone();
+        SampleTypeControlledVocab.copyBlankModalForm();
         SampleTypeControlledVocab.resetModalControlledVocabForm();
         // Make rows sortable
         SampleTypes.bindSortable();

--- a/app/views/templates/_form.html.erb
+++ b/app/views/templates/_form.html.erb
@@ -104,7 +104,7 @@
 <script>
     //used to hold the element Id that needs updating after creating a new CV
     $j(document).ready(function() {
-        SampleTypeControlledVocab.blankControlledVocabModelForm = $j('#cv-modal').clone();
+        SampleTypeControlledVocab.copyBlankModalForm();
         SampleTypeControlledVocab.resetModalControlledVocabForm();
         //Make rows sortable
         SampleTypes.bindSortable();


### PR DESCRIPTION
Problem was being caused by the modal dialogue being cloned from a blank template, leading to the events being lost.

Fixed by first destroying the select2's within the modal, and then initializing with `ObjectsInput.init()` when the form is reset and readded to the page.