### PR TITLE
Fix dynamic table in default view

### DIFF
--- a/app/assets/javascripts/single_page/dynamic_table.js.erb
+++ b/app/assets/javascripts/single_page/dynamic_table.js.erb
@@ -83,7 +83,7 @@ const handleSelect = (e) => {
           if (cellData == "#HIDDEN") $j(td).addClass("disabled");
         };
 				// Changes the id header to an instance id
-        if (c.title == "id") c.title = instanceName + " id";
+        if (c.title == "id") c.title = window.instanceName + " id";
       });
       // Retrieve the column index of the multi-input cells (select2 items)
       // if column has a multi-input cell, it adds the index to the t array (=accumulator)

--- a/app/views/isa_assays/_assay_design.html.erb
+++ b/app/views/isa_assays/_assay_design.html.erb
@@ -42,6 +42,7 @@
 	</p>
 <% end %>
 <script>
+	window.instanceName = "<%= Seek::Config.instance_name %>";
 	async function loadDynamicTableFromDefaultView(element) {
 		await loadItemDetails(`/assays/${id}`, { view: "default" });
 	}

--- a/app/views/isa_studies/_study_design.html.erb
+++ b/app/views/isa_studies/_study_design.html.erb
@@ -49,6 +49,7 @@
 <% end %>
 
 <script>
+	window.instanceName = "<%= Seek::Config.instance_name %>";
 	async function loadDynamicTableFromDefaultView(element) {
 		await loadItemDetails(`/studies/${id}`, { view: "default" });
 	}

--- a/app/views/single_pages/show.html.erb
+++ b/app/views/single_pages/show.html.erb
@@ -67,7 +67,7 @@
 
 <script type="text/javascript">
     var selectedItem = {type:"",id:""}, pid, uid, projectDefaultPolicy, dynamicTableDataPath
-    const instanceName = "<%= Seek::Config.instance_name %>";
+    window.instanceName = "<%= Seek::Config.instance_name %>";
 
 		$j(document).ready(function() {
 			  $j("#content .container-fluid").removeClass("container-fluid").addClass("container-fluid-single-page")


### PR DESCRIPTION
Tiny bugfix for the dynamic table in default view:
The dynamic tables didn't render in default view because the `instanceName` variable was not declared in default view of a study or assay.

The variable `instanceName` in the javascript was moved to the `window` and declared in:
- Single_pages/show
- assay_design
- study_design