### PR TITLE
Fix SVG content being previewed as text

### DIFF
--- a/lib/seek/renderers/renderer_factory.rb
+++ b/lib/seek/renderers/renderer_factory.rb
@@ -23,7 +23,7 @@ module Seek
 
       # Ordered list of Renderer classes. More generic renderers appear last.
       def renderer_instances
-        [SlideshareRenderer, YoutubeRenderer, MarkdownRenderer, NotebookRenderer, TextRenderer, PdfRenderer, ImageRenderer, BlankRenderer]
+        [SlideshareRenderer, YoutubeRenderer, MarkdownRenderer, NotebookRenderer, PdfRenderer, ImageRenderer, TextRenderer, BlankRenderer]
       end
     end
   end

--- a/test/functional/git_controller_test.rb
+++ b/test/functional/git_controller_test.rb
@@ -200,6 +200,16 @@ class GitControllerTest < ActionController::TestCase
     assert_select 'img.git-image-preview[src=?]', workflow_git_raw_path(@workflow, version: @git_version.version, path: 'diagram.png')
   end
 
+  test 'get svg file blob' do
+    @git_version.add_file('test.svg', open_fixture_file('transparent-fairdom-logo-square.svg'))
+    @git_version.save!
+    get :blob, params: { workflow_id: @workflow.id, version: @git_version.version, path: 'test.svg', format: 'html' } # Not sure why this is needed
+
+    assert_response :success
+    assert_select 'a.btn[href=?]', workflow_git_remove_file_path(@workflow, version: @git_version.version, path: 'test.svg')
+    assert_select 'img.git-image-preview[src=?]', workflow_git_raw_path(@workflow, version: @git_version.version, path: 'test.svg')
+  end
+
   test 'get raw binary file' do
     get :raw, params: { workflow_id: @workflow.id, version: @git_version.version, path: 'diagram.png' }
 

--- a/test/unit/renderers_test.rb
+++ b/test/unit/renderers_test.rb
@@ -27,6 +27,7 @@ class RenderersTest < ActiveSupport::TestCase
     assert_equal Seek::Renderers::NotebookRenderer, factory.renderer(FactoryBot.create(:jupyter_notebook_content_blob)).class
     assert_equal Seek::Renderers::TextRenderer, factory.renderer(FactoryBot.create(:txt_content_blob)).class
     assert_equal Seek::Renderers::ImageRenderer, factory.renderer(FactoryBot.create(:image_content_blob)).class
+    assert_equal Seek::Renderers::ImageRenderer, factory.renderer(FactoryBot.create(:svg_content_blob)).class
     assert_equal Seek::Renderers::BlankRenderer, factory.renderer(FactoryBot.create(:binary_content_blob)).class
   end
 

--- a/test/unit/renderers_test.rb
+++ b/test/unit/renderers_test.rb
@@ -388,9 +388,22 @@ class RenderersTest < ActiveSupport::TestCase
     assert_select 'iframe', count: 0
     assert_select '#navbar', count: 0
     assert_select 'img.git-image-preview'
+
     blob = FactoryBot.create(:txt_content_blob, asset: @asset)
     renderer = Seek::Renderers::ImageRenderer.new(blob)
     refute renderer.can_render?
+
+    @git.add_file('test.svg', open_fixture_file('transparent-fairdom-logo-square.svg'))
+    git_blob = @git.get_blob('test.svg')
+    renderer = Seek::Renderers::ImageRenderer.new(git_blob)
+    assert renderer.can_render?
+    @html = Nokogiri::HTML.parse(renderer.render)
+    assert_select 'img.git-image-preview'
+
+    @html = Nokogiri::HTML.parse(renderer.render_standalone)
+    assert_select 'iframe', count: 0
+    assert_select '#navbar', count: 0
+    assert_select 'img.git-image-preview'
   end
 
   def document_root_element


### PR DESCRIPTION
When previewing an SVG file in a workflow's git repository, it would previously display the SVG XML instead of rendering an image.