### PR TITLE
Support for more than 1 root uri when creating a controlled vocabulary

### DIFF
--- a/app/assets/javascripts/controlled_vocabs.js.erb
+++ b/app/assets/javascripts/controlled_vocabs.js.erb
@@ -137,7 +137,7 @@ CVTerms = {
             dataType: "html",
             data: {
                 source_ontology_id: $j('select#sample_controlled_vocab_source_ontology').val(),
-                root_uri: $j('#sample_controlled_vocab_ols_root_term_uris').val(),
+                root_uris: $j('#sample_controlled_vocab_ols_root_term_uris').val(),
                 include_root_term: $j('#include_root_term:checked').val()
             },
             success: function (resp) {

--- a/app/assets/javascripts/controlled_vocabs.js.erb
+++ b/app/assets/javascripts/controlled_vocabs.js.erb
@@ -137,7 +137,7 @@ CVTerms = {
             dataType: "html",
             data: {
                 source_ontology_id: $j('select#sample_controlled_vocab_source_ontology').val(),
-                root_uri: $j('#sample_controlled_vocab_ols_root_term_uri').val(),
+                root_uri: $j('#sample_controlled_vocab_ols_root_term_uris').val(),
                 include_root_term: $j('#include_root_term:checked').val()
             },
             success: function (resp) {
@@ -179,7 +179,7 @@ CVTerms = {
         $j('select#sample_controlled_vocab_source_ontology').on('change', function () {
             var selected = this.selectedOptions[0];
             if (selected.value == "") {
-                $j('#sample_controlled_vocab_ols_root_term_uri').val('');
+                $j('#sample_controlled_vocab_ols_root_term_uris').val('');
                 $j('#ontology-root-uri').hide();
             } else {
                 $j('#ontology-root-uri').show();

--- a/app/controllers/sample_controlled_vocabs_controller.rb
+++ b/app/controllers/sample_controlled_vocabs_controller.rb
@@ -92,10 +92,13 @@ class SampleControlledVocabsController < ApplicationController
       root_uri = params[:root_uri]
 
       raise 'No root URI provided' if root_uri.blank?
-
+      @terms = []
       client = Ebi::OlsClient.new
-      @terms = client.all_descendants(source_ontology, root_uri)
-      @terms.reject! { |t| t[:iri] == root_uri } unless params[:include_root_term] == '1'
+      root_uri.split(',').collect(&:strip).each do |uri|
+        terms = client.all_descendants(source_ontology, uri)
+        terms.reject! { |t| t[:iri] == uri } unless params[:include_root_term] == '1'
+        @terms = @terms | terms
+      end
       error_msg = "There are no descendant terms to populate the list." unless @terms.present?
     rescue StandardError => e
       error_msg = e.message

--- a/app/controllers/sample_controlled_vocabs_controller.rb
+++ b/app/controllers/sample_controlled_vocabs_controller.rb
@@ -89,12 +89,12 @@ class SampleControlledVocabsController < ApplicationController
     error_msg = nil
     begin
       source_ontology = params[:source_ontology_id]
-      root_uri = params[:root_uri]
+      root_uris = params[:root_uris]
 
-      raise 'No root URI provided' if root_uri.blank?
+      raise 'No root URI provided' if root_uris.blank?
       @terms = []
       client = Ebi::OlsClient.new
-      root_uri.split(',').collect(&:strip).each do |uri|
+      root_uris.split(',').collect(&:strip).reject(&:blank?).each do |uri|
         terms = client.all_descendants(source_ontology, uri)
         terms.reject! { |t| t[:iri] == uri } unless params[:include_root_term] == '1'
         @terms = @terms | terms

--- a/app/controllers/sample_controlled_vocabs_controller.rb
+++ b/app/controllers/sample_controlled_vocabs_controller.rb
@@ -132,7 +132,7 @@ class SampleControlledVocabsController < ApplicationController
   private
 
   def cv_params
-    params.require(:sample_controlled_vocab).permit(:title, :description, :group, :source_ontology, :ols_root_term_uri,
+    params.require(:sample_controlled_vocab).permit(:title, :description, :group, :source_ontology, :ols_root_term_uris,
                                                     :required, :short_name,
                                                     { sample_controlled_vocab_terms_attributes: %i[id _destroy label
                                                                                                    iri parent_iri] })

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -283,9 +283,11 @@ module SamplesHelper
     link_to(link,link,target: :_blank)
   end
 
-  def ols_root_term_link(ols_id, term_uri)
-    ols_link = "#{Ebi::OlsClient::ROOT_URL}/ontologies/#{ols_id}/terms?iri=#{term_uri}"
-    link_to(term_uri, ols_link, target: :_blank)
+  def ols_root_term_link(ols_id, term_uris)
+    term_uris.split(',').collect(&:strip).collect do |uri|
+      ols_link = "#{Ebi::OlsClient::ROOT_URL}/ontologies/#{ols_id}/terms?iri=#{uri}"
+      link_to(uri, ols_link, target: :_blank)
+    end.join(', ').html_safe
   end
 
   def get_extra_info(sample)

--- a/app/models/sample_controlled_vocab.rb
+++ b/app/models/sample_controlled_vocab.rb
@@ -13,7 +13,7 @@ class SampleControlledVocab < ApplicationRecord
   has_many :samples, through: :sample_types
   belongs_to :repository_standard, inverse_of: :sample_controlled_vocabs
 
-  auto_strip_attributes :ols_root_term_uri
+  auto_strip_attributes :ols_root_term_uris
 
   validates :title, presence: true, uniqueness: true
   validates :key, uniqueness: { allow_blank: true }
@@ -57,19 +57,19 @@ class SampleControlledVocab < ApplicationRecord
 
   # whether the controlled vocab is linked to an ontology
   def ontology_based?
-    source_ontology.present? && ols_root_term_uri.present?
+    source_ontology.present? && ols_root_term_uris.present?
   end
 
   def validate_ols_root_term_uris
-    return if self.ols_root_term_uri.blank?
-    uris = self.ols_root_term_uri.split(',').collect(&:strip)
+    return if self.ols_root_term_uris.blank?
+    uris = self.ols_root_term_uris.split(',').collect(&:strip)
     uris.each do |uri|
       unless valid_url?(uri)
-        errors.add(:ols_root_term_uri, "invalid URI - #{uri}")
+        errors.add(:ols_root_term_uris, "invalid URI - #{uri}")
         return false
       end
     end
-    self.ols_root_term_uri = uris.join(', ')
+    self.ols_root_term_uris = uris.join(', ')
   end
 
   private

--- a/app/models/sample_controlled_vocab.rb
+++ b/app/models/sample_controlled_vocab.rb
@@ -62,7 +62,7 @@ class SampleControlledVocab < ApplicationRecord
 
   def validate_ols_root_term_uris
     return if self.ols_root_term_uris.blank?
-    uris = self.ols_root_term_uris.split(',').collect(&:strip)
+    uris = self.ols_root_term_uris.split(',').collect(&:strip).reject(&:blank?)
     uris.each do |uri|
       unless valid_url?(uri)
         errors.add(:ols_root_term_uris, "invalid URI - #{uri}")

--- a/app/serializers/sample_controlled_vocab_serializer.rb
+++ b/app/serializers/sample_controlled_vocab_serializer.rb
@@ -1,5 +1,5 @@
 class SampleControlledVocabSerializer < BaseSerializer
-  attributes :title, :description, :source_ontology, :ols_root_term_uri, :short_name
+  attributes :title, :description, :source_ontology, :ols_root_term_uris, :short_name
   attributes :sample_controlled_vocab_terms_attributes
   
   has_many :sample_controlled_vocab_terms

--- a/app/views/sample_controlled_vocabs/_form.html.erb
+++ b/app/views/sample_controlled_vocabs/_form.html.erb
@@ -42,7 +42,7 @@
         </div>
         <div>
           <label>Root term</label>
-          <%= f.text_field :ols_root_term_uri, :class => 'form-control', :placeholder => 'e.g. http://www.ebi.ac.uk/efo/EFO_0000635' %>
+          <%= f.text_field :ols_root_term_uris, :class => 'form-control', :placeholder => 'e.g. http://www.ebi.ac.uk/efo/EFO_0000635' %>
         </div>
 
         <div class="checkbox">

--- a/app/views/sample_controlled_vocabs/_form.html.erb
+++ b/app/views/sample_controlled_vocabs/_form.html.erb
@@ -39,17 +39,19 @@
           You have selected the <a id="selected-ols-link" href="" target="_blank"></a> ontology,
           click the link to browse on the Ontology Lookup Service in another tab and find the suitable root term URI.
           You should then copy that URI into the field below.
+          If you wish to include terms from more than one root, then add the URI's separated by a comma (,).
         </div>
+
         <div>
-          <label>Root term</label>
+          <label>Root terms</label>
           <%= f.text_field :ols_root_term_uris, :class => 'form-control', :placeholder => 'e.g. http://www.ebi.ac.uk/efo/EFO_0000635' %>
         </div>
 
         <div class="checkbox">
           <label>
             <%= check_box_tag(:include_root_term, '1', false, name: nil, autocomplete: 'off') %>
-            <strong>Include root term?</strong>
-            <p class="help-block">If checked, the selected root term will be included in the list of options. Otherwise, only children of the root term will be included.</p>
+            <strong>Include root terms?</strong>
+            <p class="help-block">If checked, the selected roots term will be included in the list of options. Otherwise, only children of the root terms will be included.</p>
           </label>
         </div>
 

--- a/app/views/sample_controlled_vocabs/_term_form_row_disabled.html.erb
+++ b/app/views/sample_controlled_vocabs/_term_form_row_disabled.html.erb
@@ -1,4 +1,12 @@
-<tr class="sample-cv-term" data-index="<%= index %>">
+<%
+  new_term ||= false
+  row_class = 'sample-cv-term'
+  # will be marked in green, and also the javascript will immediately remove rather than mark for removal
+  if new_term
+    row_class+=' success'
+  end
+%>
+<tr class="<%= row_class %>" data-index="<%= index %>">
   <td>
     <%= hidden_field_tag "sample_controlled_vocab[sample_controlled_vocab_terms_attributes][#{index}][label]", term.label  %>
     <div class='disabled-cv-field form-control'><%= term.label %></div>

--- a/app/views/sample_controlled_vocabs/fetch_ols_terms_html.html.erb
+++ b/app/views/sample_controlled_vocabs/fetch_ols_terms_html.html.erb
@@ -1,5 +1,5 @@
 <% @terms.each_with_index do |term, index| %>
 
-  <%= render partial: 'sample_controlled_vocabs/term_form_row_disabled', locals: { index: index, term: OpenStruct.new(term)} %>
+  <%= render partial: 'sample_controlled_vocabs/term_form_row_disabled', locals: { index: index, term: OpenStruct.new(term), new_term: true} %>
 
 <% end %>

--- a/app/views/sample_controlled_vocabs/show.html.erb
+++ b/app/views/sample_controlled_vocabs/show.html.erb
@@ -11,7 +11,7 @@
   </p>
   <p>
     <strong>Root URI:</strong>
-    <%= ols_root_term_link(@sample_controlled_vocab.source_ontology,@sample_controlled_vocab.ols_root_term_uri) %>
+    <%= ols_root_term_link(@sample_controlled_vocab.source_ontology,@sample_controlled_vocab.ols_root_term_uris) %>
   </p>
 <% end %>
 

--- a/app/views/sample_controlled_vocabs/show.html.erb
+++ b/app/views/sample_controlled_vocabs/show.html.erb
@@ -10,7 +10,7 @@
     <%= ols_ontology_link(@sample_controlled_vocab.source_ontology) %>
   </p>
   <p>
-    <strong>Root URI:</strong>
+    <strong>Root URIs:</strong>
     <%= ols_root_term_link(@sample_controlled_vocab.source_ontology,@sample_controlled_vocab.ols_root_term_uris) %>
   </p>
 <% end %>

--- a/config/default_data/data-annotations-controlled-vocab.json
+++ b/config/default_data/data-annotations-controlled-vocab.json
@@ -1,7 +1,7 @@
 {
     "title": "Data types",
     "description": "Data types, used for annotating. Describes information that is that can be processed by dedicated computational tools that can use the data as input or produce it as output. Initially seeded from the EDAM ontology",
-    "ols_root_term_uri": "http://edamontology.org/data_0006",
+    "ols_root_term_uris": "http://edamontology.org/data_0006",
     "source_ontology": "edam",
     "terms": [
   {

--- a/config/default_data/format-annotations-controlled-vocab.json
+++ b/config/default_data/format-annotations-controlled-vocab.json
@@ -1,7 +1,7 @@
 {
     "title": "Data Formats",
     "description": "Data formats, used for annotating. Describes a defined way or layout of representing and structuring data in a computer file, blob, string, message, or elsewhere. Initially seeded from the EDAM ontology.",
-    "ols_root_term_uri": "http://edamontology.org/format_1915",
+    "ols_root_term_uris": "http://edamontology.org/format_1915",
     "source_ontology": "edam",
     "terms": [
 	{

--- a/config/default_data/operation-annotations-controlled-vocab.json
+++ b/config/default_data/operation-annotations-controlled-vocab.json
@@ -1,7 +1,7 @@
 {
   "title": "Operations",
   "description": "Operations, used for annotating. Describes a function that can take place over some inputs to produce an output. Initially seeded from the EDAM ontology",
-  "ols_root_term_uri": "http://edamontology.org/operation_0004",
+  "ols_root_term_uris": "http://edamontology.org/operation_0004",
   "source_ontology": "edam",
   "terms": [
     {

--- a/config/default_data/topics-annotations-controlled-vocab.json
+++ b/config/default_data/topics-annotations-controlled-vocab.json
@@ -1,7 +1,7 @@
 {
   "title": "Topics",
   "description": "Topics, used for annotating. Describes the domain, field of interest, of study, application, work, data, or technology. Initially seeded from the EDAM ontology.",
-  "ols_root_term_uri": "http://edamontology.org/topic_0003",
+  "ols_root_term_uris": "http://edamontology.org/topic_0003",
   "source_ontology": "edam",
   "terms": [
     {

--- a/db/migrate/20240206132054_change_controlled_vocab_root_term_uri.rb
+++ b/db/migrate/20240206132054_change_controlled_vocab_root_term_uri.rb
@@ -1,0 +1,5 @@
+class ChangeControlledVocabRootTermUri < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :sample_controlled_vocabs, :ols_root_term_uri, :ols_root_term_uris
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_01_12_141513) do
+ActiveRecord::Schema.define(version: 2024_02_06_132054) do
 
   create_table "activity_logs", id: :integer, force: :cascade do |t|
     t.string "action"
@@ -1747,7 +1747,7 @@ ActiveRecord::Schema.define(version: 2024_01_12_141513) do
     t.datetime "updated_at", null: false
     t.string "first_letter", limit: 1
     t.string "source_ontology"
-    t.string "ols_root_term_uri"
+    t.string "ols_root_term_uris"
     t.string "short_name"
     t.string "key"
     t.integer "template_id"

--- a/db/seeds/011_topics_controlled_vocab.seeds.rb
+++ b/db/seeds/011_topics_controlled_vocab.seeds.rb
@@ -8,7 +8,7 @@ unless vocab = SampleControlledVocab::SystemVocabs.vocab_for_property(:topics)
                                     key: SampleControlledVocab::SystemVocabs.database_key_for_property(:topics),
                                     description: data[:description],
                                     source_ontology: data[:source_ontology],
-                                    ols_root_term_uri: data[:ols_root_term_uri])
+                                    ols_root_term_uris: data[:ols_root_term_uris])
   data[:terms].each do |term|
     vocab.sample_controlled_vocab_terms << SampleControlledVocabTerm.new(label: term[:label], iri: term[:iri], parent_iri: term[:parent_iri])
   end

--- a/db/seeds/012_operations_controlled_vocab.seeds.rb
+++ b/db/seeds/012_operations_controlled_vocab.seeds.rb
@@ -7,7 +7,7 @@ unless vocab = SampleControlledVocab::SystemVocabs.vocab_for_property(:operation
                                     key: SampleControlledVocab::SystemVocabs.database_key_for_property(:operations),
                                     description: data[:description],
                                     source_ontology: data[:source_ontology],
-                                    ols_root_term_uri: data[:ols_root_term_uri])
+                                    ols_root_term_uris: data[:ols_root_term_uris])
   data[:terms].each do |term|
     vocab.sample_controlled_vocab_terms << SampleControlledVocabTerm.new(label: term[:label], iri: term[:iri], parent_iri: term[:parent_iri])
   end

--- a/db/seeds/013_formats_controlled_vocab.seeds.rb
+++ b/db/seeds/013_formats_controlled_vocab.seeds.rb
@@ -7,7 +7,7 @@ unless vocab = SampleControlledVocab::SystemVocabs.vocab_for_property(:data_form
                                     key: SampleControlledVocab::SystemVocabs.database_key_for_property(:data_formats),
                                     description: data[:description],
                                     source_ontology: data[:source_ontology],
-                                    ols_root_term_uri: data[:ols_root_term_uri])
+                                    ols_root_term_uris: data[:ols_root_term_uris])
   data[:terms].each do |term|
     vocab.sample_controlled_vocab_terms << SampleControlledVocabTerm.new(label: term[:label], iri: term[:iri], parent_iri: term[:parent_iri])
   end

--- a/db/seeds/014_data_controlled_vocab.seeds.rb
+++ b/db/seeds/014_data_controlled_vocab.seeds.rb
@@ -7,7 +7,7 @@ unless vocab = SampleControlledVocab::SystemVocabs.vocab_for_property(:data_type
                                     key: SampleControlledVocab::SystemVocabs.database_key_for_property(:data_types),
                                     description: data[:description],
                                     source_ontology: data[:source_ontology],
-                                    ols_root_term_uri: data[:ols_root_term_uri])
+                                    ols_root_term_uris: data[:ols_root_term_uris])
   data[:terms].each do |term|
     vocab.sample_controlled_vocab_terms << SampleControlledVocabTerm.new(label: term[:label], iri: term[:iri], parent_iri: term[:parent_iri])
   end

--- a/lib/isa_exporter.rb
+++ b/lib/isa_exporter.rb
@@ -725,7 +725,7 @@ module IsaExporter
           if vocab_term
             sample_attribute.sample_controlled_vocab.sample_controlled_vocab_terms.find_by_label(label)&.iri
           else
-            sample_attribute.sample_controlled_vocab.ols_root_term_uri
+            sample_attribute.sample_controlled_vocab.ols_root_term_uris
           end
       end
       term_accession = iri || ''

--- a/lib/seek/isa_templates/template_extractor.rb
+++ b/lib/seek/isa_templates/template_extractor.rb
@@ -46,7 +46,7 @@ module Seek
                       {
                         title: attribute['name'],
                         source_ontology: is_ontology ? attribute['ontology']['name'] : nil,
-                        ols_root_term_uri: is_ontology ? attribute['ontology']['rootTermURI'] : nil
+                        ols_root_term_uris: is_ontology ? attribute['ontology']['rootTermURI'] : nil
                       }
                     )
                 end

--- a/lib/tasks/seek_dev.rake
+++ b/lib/tasks/seek_dev.rake
@@ -53,7 +53,7 @@ namespace :seek_dev do
 
   task(:dump_controlled_vocab, [:id] => :environment) do |_t, args|
     vocab = SampleControlledVocab.find(args.id)
-    json = { title: vocab.title, description: vocab.description, ols_root_term_uri: vocab.ols_root_term_uri,
+    json = { title: vocab.title, description: vocab.description, ols_root_term_uris: vocab.ols_root_term_uris,
              source_ontology: vocab.source_ontology, terms: [] }
     vocab.sample_controlled_vocab_terms.each do |term|
       json[:terms] << { label: term.label, iri: term.iri, parent_iri: term.parent_iri }

--- a/public/api/examples/sampleControlledVocabPatch.json
+++ b/public/api/examples/sampleControlledVocabPatch.json
@@ -6,7 +6,7 @@
       "title": "new title",
       "description": "new description",
       "source_ontology": "new source ontology",
-      "ols_root_term_uri": "http://new-uri.org",
+      "ols_root_term_uris": "http://new-uri.org",
       "short_name": "new short name",
       "sample_controlled_vocab_terms_attributes": [
         {

--- a/public/api/examples/sampleControlledVocabPatchResponse.json
+++ b/public/api/examples/sampleControlledVocabPatchResponse.json
@@ -6,7 +6,7 @@
       "title": "new title",
       "description": "new description",
       "source_ontology": "new source ontology",
-      "ols_root_term_uri": "http://new-uri.org",
+      "ols_root_term_uris": "http://new-uri.org",
       "short_name": "new short name",
       "sample_controlled_vocab_terms_attributes": [
         {

--- a/public/api/examples/sampleControlledVocabPost.json
+++ b/public/api/examples/sampleControlledVocabPost.json
@@ -5,7 +5,7 @@
       "title": "New Vocab Max",
       "description": "some description",
       "source_ontology": "EFO",
-      "ols_root_term_uri": null,
+      "ols_root_term_uris": null,
       "short_name": "short_name",
       "sample_controlled_vocab_terms_attributes": [
         {

--- a/public/api/examples/sampleControlledVocabPostResponse.json
+++ b/public/api/examples/sampleControlledVocabPostResponse.json
@@ -6,7 +6,7 @@
       "title": "New Vocab Max",
       "description": "some description",
       "source_ontology": "EFO",
-      "ols_root_term_uri": null,
+      "ols_root_term_uris": null,
       "short_name": "short_name",
       "sample_controlled_vocab_terms_attributes": [
         {

--- a/test/factories/sample_attribute_types.rb
+++ b/test/factories/sample_attribute_types.rb
@@ -129,7 +129,7 @@ FactoryBot.define do
   
   factory(:ontology_sample_controlled_vocab, parent: :sample_controlled_vocab) do
     source_ontology { 'http://ontology.org' }
-    ols_root_term_uri { 'http://ontology.org/#parent' }
+    ols_root_term_uris { 'http://ontology.org/#parent' }
     after(:build) do |vocab|
       vocab.sample_controlled_vocab_terms << FactoryBot.build(:sample_controlled_vocab_term, label: 'Parent',iri:'http://ontology.org/#parent',parent_iri:'')
       vocab.sample_controlled_vocab_terms << FactoryBot.build(:sample_controlled_vocab_term, label: 'Mother',iri:'http://ontology.org/#mother',parent_iri:'http://ontology.org/#parent')
@@ -139,7 +139,7 @@ FactoryBot.define do
   
   factory(:topics_controlled_vocab, parent: :sample_controlled_vocab) do
     title { 'Topics' }
-    ols_root_term_uri { 'http://edamontology.org/topic_0003' }
+    ols_root_term_uris { 'http://edamontology.org/topic_0003' }
     key { SampleControlledVocab::SystemVocabs.database_key_for_property(:topics) }
     source_ontology { 'edam' }
     after(:build) do |vocab|
@@ -152,7 +152,7 @@ FactoryBot.define do
   
   factory(:operations_controlled_vocab, parent: :sample_controlled_vocab) do
     title { 'Operations' }
-    ols_root_term_uri { 'http://edamontology.org/operation_0004' }
+    ols_root_term_uris { 'http://edamontology.org/operation_0004' }
     key { SampleControlledVocab::SystemVocabs.database_key_for_property(:operations) }
     source_ontology { 'edam' }
     after(:build) do |vocab|
@@ -165,7 +165,7 @@ FactoryBot.define do
   
   factory(:data_types_controlled_vocab, parent: :sample_controlled_vocab) do
     title { 'Data' }
-    ols_root_term_uri { 'http://edamontology.org/data_0006' }
+    ols_root_term_uris { 'http://edamontology.org/data_0006' }
     key { SampleControlledVocab::SystemVocabs.database_key_for_property(:data_types) }
     source_ontology { 'edam' }
     after(:build) do |vocab|
@@ -176,7 +176,7 @@ FactoryBot.define do
   
   factory(:data_formats_controlled_vocab, parent: :sample_controlled_vocab) do
     title { 'Formats' }
-    ols_root_term_uri { 'http://edamontology.org/format_1915' }
+    ols_root_term_uris { 'http://edamontology.org/format_1915' }
     key { SampleControlledVocab::SystemVocabs.database_key_for_property(:data_formats) }
     source_ontology { 'edam' }
     after(:build) do |vocab|
@@ -188,7 +188,7 @@ FactoryBot.define do
   factory(:efo_ontology, class: SampleControlledVocab) do
     sequence(:title) { |n| "EFO ontology #{n}" }
     source_ontology { 'EFO' }
-    ols_root_term_uri { 'http://www.ebi.ac.uk/efo/EFO_0000635' }
+    ols_root_term_uris { 'http://www.ebi.ac.uk/efo/EFO_0000635' }
     after(:build) do |vocab|
       vocab.sample_controlled_vocab_terms << FactoryBot.build(:sample_controlled_vocab_term, label: 'anatomical entity')
       vocab.sample_controlled_vocab_terms << FactoryBot.build(:sample_controlled_vocab_term, label: 'retroperitoneal space')
@@ -199,7 +199,7 @@ FactoryBot.define do
   factory(:obi_ontology, class: SampleControlledVocab) do
     sequence(:title) { |n| "OBI ontology #{n}" }
     source_ontology { 'OBI' }
-    ols_root_term_uri { 'http://purl.obolibrary.org/obo/OBI_0000094' }
+    ols_root_term_uris { 'http://purl.obolibrary.org/obo/OBI_0000094' }
     after(:build) do |vocab|
       vocab.sample_controlled_vocab_terms << FactoryBot.build(:sample_controlled_vocab_term, label: 'dissection')
       vocab.sample_controlled_vocab_terms << FactoryBot.build(:sample_controlled_vocab_term, label: 'enzymatic cleavage')

--- a/test/fixtures/json/requests/patch_max_sample_controlled_vocab.json.erb
+++ b/test/fixtures/json/requests/patch_max_sample_controlled_vocab.json.erb
@@ -6,7 +6,7 @@
       "title": "new title",
       "description": "new description",
       "source_ontology": "new source ontology",
-      "ols_root_term_uri": "http://new-uri.org",
+      "ols_root_term_uris": "http://new-uri.org",
       "short_name": "new short name",
       "sample_controlled_vocab_terms_attributes": [
         {

--- a/test/fixtures/json/requests/post_max_sample_controlled_vocab.json.erb
+++ b/test/fixtures/json/requests/post_max_sample_controlled_vocab.json.erb
@@ -5,7 +5,7 @@
       "title": "New Vocab Max",
       "description": "some description",
       "source_ontology": "EFO",
-      "ols_root_term_uri": null,
+      "ols_root_term_uris": null,
       "short_name": "short_name",
       "sample_controlled_vocab_terms_attributes": [
         {

--- a/test/fixtures/json/responses/get_max_sample_controlled_vocab.json.erb
+++ b/test/fixtures/json/responses/get_max_sample_controlled_vocab.json.erb
@@ -6,7 +6,7 @@
       "title": "Organism",
       "description": "Description for organism",
       "source_ontology": "EFO",
-      "ols_root_term_uri": "",
+      "ols_root_term_uris": "",
       "short_name": "organism",
       "sample_controlled_vocab_terms_attributes": [
         {

--- a/test/fixtures/json/responses/get_min_sample_controlled_vocab.json.erb
+++ b/test/fixtures/json/responses/get_min_sample_controlled_vocab.json.erb
@@ -6,7 +6,7 @@
       "title": "Organism",
       "description": null,
       "source_ontology": null,
-      "ols_root_term_uri": null,
+      "ols_root_term_uris": null,
       "short_name": null,
       "sample_controlled_vocab_terms_attributes": null,
       "repository_standard": null

--- a/test/functional/sample_controlled_vocabs_controller_test.rb
+++ b/test/functional/sample_controlled_vocabs_controller_test.rb
@@ -306,6 +306,29 @@ class SampleControlledVocabsControllerTest < ActionController::TestCase
     assert_select 'input[type=hidden]#sample_controlled_vocab_sample_controlled_vocab_terms_attributes_3_label[value=?]','trichome papilla'
   end
 
+  test 'create with root uris' do
+    login_as(FactoryBot.create(:project_administrator))
+    assert_difference('SampleControlledVocab.count') do
+      assert_difference('SampleControlledVocabTerm.count', 2) do
+        post :create, params: { sample_controlled_vocab: { title: 'plant_cell_papilla and haustorium', description: 'multiple root uris',
+                                                           ols_root_term_uri: 'http://purl.obolibrary.org/obo/GO_0090395,   http://purl.obolibrary.org/obo/GO_0085035',
+                                                           sample_controlled_vocab_terms_attributes: {
+                                                             '0' => { label: 'plant cell papilla', iri:'http://purl.obolibrary.org/obo/GO_0090395', parent_iri:'', _destroy: '0' },
+                                                             '1' => { label: 'haustorium', iri:'http://purl.obolibrary.org/obo/GO_0085035', parent_iri:'', _destroy: '0' }
+                                                           }
+        } }
+      end
+    end
+    assert cv = assigns(:sample_controlled_vocab)
+    assert_redirected_to sample_controlled_vocab_path(cv)
+    assert_equal 'plant_cell_papilla and haustorium', cv.title
+    assert_equal 'multiple root uris', cv.description
+    assert_equal 2, cv.sample_controlled_vocab_terms.count
+    assert_equal ['plant cell papilla','haustorium'], cv.labels
+    assert_equal ['http://purl.obolibrary.org/obo/GO_0090395','http://purl.obolibrary.org/obo/GO_0085035'], cv.sample_controlled_vocab_terms.collect(&:iri)
+    assert_equal 'http://purl.obolibrary.org/obo/GO_0090395, http://purl.obolibrary.org/obo/GO_0085035', cv.ols_root_term_uri
+  end
+
   test 'fetch ols terms as HTML with multiple root uris and root term included' do
     person = FactoryBot.create(:person)
     login_as(person)

--- a/test/functional/sample_controlled_vocabs_controller_test.rb
+++ b/test/functional/sample_controlled_vocabs_controller_test.rb
@@ -311,7 +311,7 @@ class SampleControlledVocabsControllerTest < ActionController::TestCase
     assert_difference('SampleControlledVocab.count') do
       assert_difference('SampleControlledVocabTerm.count', 2) do
         post :create, params: { sample_controlled_vocab: { title: 'plant_cell_papilla and haustorium', description: 'multiple root uris',
-                                                           ols_root_term_uri: 'http://purl.obolibrary.org/obo/GO_0090395,   http://purl.obolibrary.org/obo/GO_0085035',
+                                                           ols_root_term_uris: 'http://purl.obolibrary.org/obo/GO_0090395,   http://purl.obolibrary.org/obo/GO_0085035',
                                                            sample_controlled_vocab_terms_attributes: {
                                                              '0' => { label: 'plant cell papilla', iri:'http://purl.obolibrary.org/obo/GO_0090395', parent_iri:'', _destroy: '0' },
                                                              '1' => { label: 'haustorium', iri:'http://purl.obolibrary.org/obo/GO_0085035', parent_iri:'', _destroy: '0' }
@@ -326,7 +326,7 @@ class SampleControlledVocabsControllerTest < ActionController::TestCase
     assert_equal 2, cv.sample_controlled_vocab_terms.count
     assert_equal ['plant cell papilla','haustorium'], cv.labels
     assert_equal ['http://purl.obolibrary.org/obo/GO_0090395','http://purl.obolibrary.org/obo/GO_0085035'], cv.sample_controlled_vocab_terms.collect(&:iri)
-    assert_equal 'http://purl.obolibrary.org/obo/GO_0090395, http://purl.obolibrary.org/obo/GO_0085035', cv.ols_root_term_uri
+    assert_equal 'http://purl.obolibrary.org/obo/GO_0090395, http://purl.obolibrary.org/obo/GO_0085035', cv.ols_root_term_uris
   end
 
   test 'fetch ols terms as HTML with multiple root uris and root term included' do

--- a/test/functional/sample_controlled_vocabs_controller_test.rb
+++ b/test/functional/sample_controlled_vocabs_controller_test.rb
@@ -273,7 +273,7 @@ class SampleControlledVocabsControllerTest < ActionController::TestCase
     login_as(person)
     VCR.use_cassette('ols/fetch_obo_bad_term') do
       get :fetch_ols_terms_html, params: { source_ontology_id: 'go',
-                                      root_uri: 'http://purl.obolibrary.org/obo/banana',
+                                      root_uris: 'http://purl.obolibrary.org/obo/banana',
                                       include_root_term: '1' }
 
       assert_response :unprocessable_entity
@@ -286,7 +286,7 @@ class SampleControlledVocabsControllerTest < ActionController::TestCase
     login_as(person)
     VCR.use_cassette('ols/fetch_obo_plant_cell_papilla') do
       get :fetch_ols_terms_html, params: { source_ontology_id: 'go',
-                                           root_uri: 'http://purl.obolibrary.org/obo/GO_0090395',
+                                           root_uris: 'http://purl.obolibrary.org/obo/GO_0090395',
                                            include_root_term: '1' }
     end
 
@@ -335,7 +335,7 @@ class SampleControlledVocabsControllerTest < ActionController::TestCase
     VCR.use_cassette('ols/fetch_obo_plant_cell_papilla') do
       VCR.use_cassette('ols/fetch_obo_haustorium') do
         get :fetch_ols_terms_html, params: { source_ontology_id: 'go',
-                                             root_uri: 'http://purl.obolibrary.org/obo/GO_0090395, http://purl.obolibrary.org/obo/GO_0085035',
+                                             root_uris: 'http://purl.obolibrary.org/obo/GO_0090395, http://purl.obolibrary.org/obo/GO_0085035',
                                              include_root_term: '1' }
         end
     end
@@ -370,7 +370,7 @@ class SampleControlledVocabsControllerTest < ActionController::TestCase
     VCR.use_cassette('ols/fetch_obo_plant_cell_papilla') do
       VCR.use_cassette('ols/fetch_obo_haustorium') do
         get :fetch_ols_terms_html, params: { source_ontology_id: 'go',
-                                             root_uri: 'http://purl.obolibrary.org/obo/GO_0090395, http://purl.obolibrary.org/obo/GO_0085035',
+                                             root_uris: 'http://purl.obolibrary.org/obo/GO_0090395, http://purl.obolibrary.org/obo/GO_0085035',
                                              include_root_term: '0' }
       end
     end
@@ -394,12 +394,28 @@ class SampleControlledVocabsControllerTest < ActionController::TestCase
 
   end
 
+  test 'fetch ols terms as HTML with multiple root uris forgiving of trailing comma' do
+    person = FactoryBot.create(:person)
+    login_as(person)
+    VCR.use_cassette('ols/fetch_obo_plant_cell_papilla') do
+      VCR.use_cassette('ols/fetch_obo_haustorium') do
+        get :fetch_ols_terms_html, params: { source_ontology_id: 'go',
+                                             root_uris: 'http://purl.obolibrary.org/obo/GO_0090395, http://purl.obolibrary.org/obo/GO_0085035,  ',
+                                             include_root_term: '0' }
+      end
+    end
+
+    assert_response :success
+    assert_select 'tr.sample-cv-term', count: 4
+  end
+
+
   test 'fetch ols terms as HTML without root term included' do
     person = FactoryBot.create(:person)
     login_as(person)
     VCR.use_cassette('ols/fetch_obo_plant_cell_papilla') do
       get :fetch_ols_terms_html, params: { source_ontology_id: 'go',
-                                      root_uri: 'http://purl.obolibrary.org/obo/GO_0090395' }
+                                      root_uris: 'http://purl.obolibrary.org/obo/GO_0090395' }
     end
     assert_response :success
     assert_select 'tr.sample-cv-term', count: 3

--- a/test/functional/sample_controlled_vocabs_controller_test.rb
+++ b/test/functional/sample_controlled_vocabs_controller_test.rb
@@ -306,6 +306,71 @@ class SampleControlledVocabsControllerTest < ActionController::TestCase
     assert_select 'input[type=hidden]#sample_controlled_vocab_sample_controlled_vocab_terms_attributes_3_label[value=?]','trichome papilla'
   end
 
+  test 'fetch ols terms as HTML with multiple root uris and root term included' do
+    person = FactoryBot.create(:person)
+    login_as(person)
+    VCR.use_cassette('ols/fetch_obo_plant_cell_papilla') do
+      VCR.use_cassette('ols/fetch_obo_haustorium') do
+        get :fetch_ols_terms_html, params: { source_ontology_id: 'go',
+                                             root_uri: 'http://purl.obolibrary.org/obo/GO_0090395, http://purl.obolibrary.org/obo/GO_0085035',
+                                             include_root_term: '1' }
+        end
+    end
+
+    assert_response :success
+    assert_select 'tr.sample-cv-term', count: 6
+    assert_select 'input[type=hidden]#sample_controlled_vocab_sample_controlled_vocab_terms_attributes_0_iri[value=?]','http://purl.obolibrary.org/obo/GO_0090395'
+    assert_select 'input[type=hidden]#sample_controlled_vocab_sample_controlled_vocab_terms_attributes_0_parent_iri:not([value])'
+    assert_select 'input[type=hidden]#sample_controlled_vocab_sample_controlled_vocab_terms_attributes_0_label[value=?]','plant cell papilla'
+    assert_select 'input[type=hidden]#sample_controlled_vocab_sample_controlled_vocab_terms_attributes_1_iri[value=?]','http://purl.obolibrary.org/obo/GO_0090397'
+    assert_select 'input[type=hidden]#sample_controlled_vocab_sample_controlled_vocab_terms_attributes_1_parent_iri[value=?]','http://purl.obolibrary.org/obo/GO_0090395'
+    assert_select 'input[type=hidden]#sample_controlled_vocab_sample_controlled_vocab_terms_attributes_1_label[value=?]','stigma papilla'
+    assert_select 'input[type=hidden]#sample_controlled_vocab_sample_controlled_vocab_terms_attributes_2_iri[value=?]','http://purl.obolibrary.org/obo/GO_0090396'
+    assert_select 'input[type=hidden]#sample_controlled_vocab_sample_controlled_vocab_terms_attributes_2_parent_iri[value=?]','http://purl.obolibrary.org/obo/GO_0090395'
+    assert_select 'input[type=hidden]#sample_controlled_vocab_sample_controlled_vocab_terms_attributes_2_label[value=?]','leaf papilla'
+    assert_select 'input[type=hidden]#sample_controlled_vocab_sample_controlled_vocab_terms_attributes_3_iri[value=?]','http://purl.obolibrary.org/obo/GO_0090705'
+    assert_select 'input[type=hidden]#sample_controlled_vocab_sample_controlled_vocab_terms_attributes_3_parent_iri[value=?]','http://purl.obolibrary.org/obo/GO_0090395'
+    assert_select 'input[type=hidden]#sample_controlled_vocab_sample_controlled_vocab_terms_attributes_3_label[value=?]','trichome papilla'
+
+    assert_select 'input[type=hidden]#sample_controlled_vocab_sample_controlled_vocab_terms_attributes_4_iri[value=?]','http://purl.obolibrary.org/obo/GO_0085035'
+    assert_select 'input[type=hidden]#sample_controlled_vocab_sample_controlled_vocab_terms_attributes_4_parent_iri:not([value])'
+    assert_select 'input[type=hidden]#sample_controlled_vocab_sample_controlled_vocab_terms_attributes_4_label[value=?]','haustorium'
+    assert_select 'input[type=hidden]#sample_controlled_vocab_sample_controlled_vocab_terms_attributes_5_iri[value=?]','http://purl.obolibrary.org/obo/GO_0085041'
+    assert_select 'input[type=hidden]#sample_controlled_vocab_sample_controlled_vocab_terms_attributes_5_parent_iri[value=?]','http://purl.obolibrary.org/obo/GO_0085035'
+    assert_select 'input[type=hidden]#sample_controlled_vocab_sample_controlled_vocab_terms_attributes_5_label[value=?]','arbuscule'
+
+  end
+
+  test 'fetch ols terms as HTML with multiple root uris and no root term included' do
+    person = FactoryBot.create(:person)
+    login_as(person)
+    VCR.use_cassette('ols/fetch_obo_plant_cell_papilla') do
+      VCR.use_cassette('ols/fetch_obo_haustorium') do
+        get :fetch_ols_terms_html, params: { source_ontology_id: 'go',
+                                             root_uri: 'http://purl.obolibrary.org/obo/GO_0090395, http://purl.obolibrary.org/obo/GO_0085035',
+                                             include_root_term: '0' }
+      end
+    end
+
+    assert_response :success
+    assert_select 'tr.sample-cv-term', count: 4
+
+    assert_select 'input[type=hidden]#sample_controlled_vocab_sample_controlled_vocab_terms_attributes_0_iri[value=?]','http://purl.obolibrary.org/obo/GO_0090397'
+    assert_select 'input[type=hidden]#sample_controlled_vocab_sample_controlled_vocab_terms_attributes_0_parent_iri[value=?]','http://purl.obolibrary.org/obo/GO_0090395'
+    assert_select 'input[type=hidden]#sample_controlled_vocab_sample_controlled_vocab_terms_attributes_0_label[value=?]','stigma papilla'
+    assert_select 'input[type=hidden]#sample_controlled_vocab_sample_controlled_vocab_terms_attributes_1_iri[value=?]','http://purl.obolibrary.org/obo/GO_0090396'
+    assert_select 'input[type=hidden]#sample_controlled_vocab_sample_controlled_vocab_terms_attributes_1_parent_iri[value=?]','http://purl.obolibrary.org/obo/GO_0090395'
+    assert_select 'input[type=hidden]#sample_controlled_vocab_sample_controlled_vocab_terms_attributes_1_label[value=?]','leaf papilla'
+    assert_select 'input[type=hidden]#sample_controlled_vocab_sample_controlled_vocab_terms_attributes_2_iri[value=?]','http://purl.obolibrary.org/obo/GO_0090705'
+    assert_select 'input[type=hidden]#sample_controlled_vocab_sample_controlled_vocab_terms_attributes_2_parent_iri[value=?]','http://purl.obolibrary.org/obo/GO_0090395'
+    assert_select 'input[type=hidden]#sample_controlled_vocab_sample_controlled_vocab_terms_attributes_2_label[value=?]','trichome papilla'
+
+    assert_select 'input[type=hidden]#sample_controlled_vocab_sample_controlled_vocab_terms_attributes_3_iri[value=?]','http://purl.obolibrary.org/obo/GO_0085041'
+    assert_select 'input[type=hidden]#sample_controlled_vocab_sample_controlled_vocab_terms_attributes_3_parent_iri[value=?]','http://purl.obolibrary.org/obo/GO_0085035'
+    assert_select 'input[type=hidden]#sample_controlled_vocab_sample_controlled_vocab_terms_attributes_3_label[value=?]','arbuscule'
+
+  end
+
   test 'fetch ols terms as HTML without root term included' do
     person = FactoryBot.create(:person)
     login_as(person)

--- a/test/integration/api/sample_controlled_vocab_api_test.rb
+++ b/test/integration/api/sample_controlled_vocab_api_test.rb
@@ -9,7 +9,7 @@ class SampleControlledVocabApiTest < ActionDispatch::IntegrationTest
     login_as(FactoryBot.create(:project_administrator))
 
     @sample_controlled_vocab = SampleControlledVocab.new({ title:"a title", description:"some description",
-                                                           source_ontology: "EFO", ols_root_term_uri: "http://a_uri",
+                                                           source_ontology: "EFO", ols_root_term_uris: "http://a_uri",
                                                            short_name: "short_name" })
                                                            
     @sample_controlled_vocab_term = SampleControlledVocabTerm.new({ label: "organism", iri: "http://some_iri",

--- a/test/unit/sample_controlled_vocab_test.rb
+++ b/test/unit/sample_controlled_vocab_test.rb
@@ -55,6 +55,10 @@ class SampleControlledVocabTest < ActiveSupport::TestCase
     vocab.ols_root_term_uris = 'http://purl.obolibrary.org/obo/GO_0090395, '
     assert vocab.valid?
     assert_equal 'http://purl.obolibrary.org/obo/GO_0090395', vocab.ols_root_term_uris
+
+    vocab.ols_root_term_uris = 'http://purl.obolibrary.org/obo/GO_0090395, http://purl.obolibrary.org/obo/GO_0085035,  '
+    assert vocab.valid?
+    assert_equal 'http://purl.obolibrary.org/obo/GO_0090395, http://purl.obolibrary.org/obo/GO_0085035', vocab.ols_root_term_uris
   end
 
   test 'validate unique key' do

--- a/test/unit/sample_controlled_vocab_test.rb
+++ b/test/unit/sample_controlled_vocab_test.rb
@@ -35,6 +35,28 @@ class SampleControlledVocabTest < ActiveSupport::TestCase
     end
   end
 
+  test 'validate ols ols_root_term_uris' do
+    vocab = SampleControlledVocab.new(title: 'multiple uris')
+    assert vocab.valid?
+
+    vocab.ols_root_term_uri = 'http://purl.obolibrary.org/obo/GO_0090395'
+    assert vocab.valid?
+    vocab.ols_root_term_uri = 'wibble'
+    refute vocab.valid?
+
+    vocab.ols_root_term_uri = 'http://purl.obolibrary.org/obo/GO_0090395, http://purl.obolibrary.org/obo/GO_0085035'
+    assert vocab.valid?
+    vocab.ols_root_term_uri = 'http://purl.obolibrary.org/obo/GO_0090395, http://purl.obolibrary.org/obo/GO_0085035,   http://purl.obolibrary.org/obo/GO_0090396'
+    assert vocab.valid?
+    assert_equal 'http://purl.obolibrary.org/obo/GO_0090395, http://purl.obolibrary.org/obo/GO_0085035, http://purl.obolibrary.org/obo/GO_0090396', vocab.ols_root_term_uri
+    vocab.ols_root_term_uri = 'http://purl.obolibrary.org/obo/GO_0090395, wibble'
+    refute vocab.valid?
+
+    vocab.ols_root_term_uri = 'http://purl.obolibrary.org/obo/GO_0090395, '
+    assert vocab.valid?
+    assert_equal 'http://purl.obolibrary.org/obo/GO_0090395', vocab.ols_root_term_uri
+  end
+
   test 'validate unique key' do
     User.with_current_user(FactoryBot.create(:project_administrator).user) do
       SampleControlledVocab.create(title: 'no key')

--- a/test/unit/sample_controlled_vocab_test.rb
+++ b/test/unit/sample_controlled_vocab_test.rb
@@ -39,22 +39,22 @@ class SampleControlledVocabTest < ActiveSupport::TestCase
     vocab = SampleControlledVocab.new(title: 'multiple uris')
     assert vocab.valid?
 
-    vocab.ols_root_term_uri = 'http://purl.obolibrary.org/obo/GO_0090395'
+    vocab.ols_root_term_uris = 'http://purl.obolibrary.org/obo/GO_0090395'
     assert vocab.valid?
-    vocab.ols_root_term_uri = 'wibble'
+    vocab.ols_root_term_uris = 'wibble'
     refute vocab.valid?
 
-    vocab.ols_root_term_uri = 'http://purl.obolibrary.org/obo/GO_0090395, http://purl.obolibrary.org/obo/GO_0085035'
+    vocab.ols_root_term_uris = 'http://purl.obolibrary.org/obo/GO_0090395, http://purl.obolibrary.org/obo/GO_0085035'
     assert vocab.valid?
-    vocab.ols_root_term_uri = 'http://purl.obolibrary.org/obo/GO_0090395, http://purl.obolibrary.org/obo/GO_0085035,   http://purl.obolibrary.org/obo/GO_0090396'
+    vocab.ols_root_term_uris = 'http://purl.obolibrary.org/obo/GO_0090395, http://purl.obolibrary.org/obo/GO_0085035,   http://purl.obolibrary.org/obo/GO_0090396'
     assert vocab.valid?
-    assert_equal 'http://purl.obolibrary.org/obo/GO_0090395, http://purl.obolibrary.org/obo/GO_0085035, http://purl.obolibrary.org/obo/GO_0090396', vocab.ols_root_term_uri
-    vocab.ols_root_term_uri = 'http://purl.obolibrary.org/obo/GO_0090395, wibble'
+    assert_equal 'http://purl.obolibrary.org/obo/GO_0090395, http://purl.obolibrary.org/obo/GO_0085035, http://purl.obolibrary.org/obo/GO_0090396', vocab.ols_root_term_uris
+    vocab.ols_root_term_uris = 'http://purl.obolibrary.org/obo/GO_0090395, wibble'
     refute vocab.valid?
 
-    vocab.ols_root_term_uri = 'http://purl.obolibrary.org/obo/GO_0090395, '
+    vocab.ols_root_term_uris = 'http://purl.obolibrary.org/obo/GO_0090395, '
     assert vocab.valid?
-    assert_equal 'http://purl.obolibrary.org/obo/GO_0090395', vocab.ols_root_term_uri
+    assert_equal 'http://purl.obolibrary.org/obo/GO_0090395', vocab.ols_root_term_uris
   end
 
   test 'validate unique key' do

--- a/test/vcr_cassettes/ols/fetch_obo_haustorium.yml
+++ b/test/vcr_cassettes/ols/fetch_obo_haustorium.yml
@@ -1,0 +1,224 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://www.ebi.ac.uk/ols4/api/ontologies/go/terms/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FGO_0085035
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux x86_64) ruby/3.1.4p223
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - www.ebi.ac.uk
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Vary:
+      - Access-Control-Request-Headers
+      - Access-Control-Request-Method
+      - Origin
+      Content-Type:
+      - application/json
+      Strict-Transport-Security:
+      - max-age=0
+      Date:
+      - Tue, 06 Feb 2024 10:29:41 GMT
+      Transfer-Encoding:
+      - chunked
+      Content-Disposition:
+      - inline;filename=f.txt
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "iri" : "http://purl.obolibrary.org/obo/GO_0085035",
+          "lang" : "en",
+          "description" : [ "A projection from a cell or tissue that penetrates the host's cell wall and invaginates the host cell membrane.", "See also: extrahaustorial matrix ; GO:0085036 and extrahaustorial membrane ; GO:0085037." ],
+          "synonyms" : [ ],
+          "annotation" : {
+            "created_by" : [ "jl" ],
+            "creation_date" : [ "2010-07-27T03:42:24Z" ],
+            "has_obo_namespace" : [ "cellular_component" ],
+            "id" : [ "GO:0085035" ]
+          },
+          "label" : "haustorium",
+          "ontology_name" : "go",
+          "ontology_prefix" : "GO",
+          "ontology_iri" : "http://purl.obolibrary.org/obo/go/extensions/go-plus.owl",
+          "is_obsolete" : false,
+          "term_replaced_by" : null,
+          "is_defining_ontology" : true,
+          "has_children" : true,
+          "is_root" : false,
+          "short_form" : "GO_0085035",
+          "obo_id" : "GO:0085035",
+          "in_subset" : null,
+          "obo_definition_citation" : [ {
+            "definition" : "A projection from a cell or tissue that penetrates the host's cell wall and invaginates the host cell membrane.",
+            "oboXrefs" : [ {
+              "database" : "GOC",
+              "id" : "pamgo_curators",
+              "description" : null,
+              "url" : null
+            } ]
+          } ],
+          "obo_xref" : null,
+          "obo_synonym" : null,
+          "is_preferred_root" : false,
+          "_links" : {
+            "self" : {
+              "href" : "https://www.ebi.ac.uk/ols4/api/ontologies/go/terms/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FGO_0085035?lang=en"
+            },
+            "parents" : {
+              "href" : "https://www.ebi.ac.uk/ols4/api/ontologies/go/terms/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FGO_0085035/parents"
+            },
+            "ancestors" : {
+              "href" : "https://www.ebi.ac.uk/ols4/api/ontologies/go/terms/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FGO_0085035/ancestors"
+            },
+            "hierarchicalParents" : {
+              "href" : "https://www.ebi.ac.uk/ols4/api/ontologies/go/terms/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FGO_0085035/hierarchicalParents"
+            },
+            "hierarchicalAncestors" : {
+              "href" : "https://www.ebi.ac.uk/ols4/api/ontologies/go/terms/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FGO_0085035/hierarchicalAncestors"
+            },
+            "jstree" : {
+              "href" : "https://www.ebi.ac.uk/ols4/api/ontologies/go/terms/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FGO_0085035/jstree"
+            },
+            "children" : {
+              "href" : "https://www.ebi.ac.uk/ols4/api/ontologies/go/terms/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FGO_0085035/children"
+            },
+            "descendants" : {
+              "href" : "https://www.ebi.ac.uk/ols4/api/ontologies/go/terms/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FGO_0085035/descendants"
+            },
+            "hierarchicalChildren" : {
+              "href" : "https://www.ebi.ac.uk/ols4/api/ontologies/go/terms/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FGO_0085035/hierarchicalChildren"
+            },
+            "hierarchicalDescendants" : {
+              "href" : "https://www.ebi.ac.uk/ols4/api/ontologies/go/terms/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FGO_0085035/hierarchicalDescendants"
+            },
+            "graph" : {
+              "href" : "https://www.ebi.ac.uk/ols4/api/ontologies/go/terms/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FGO_0085035/graph"
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Tue, 06 Feb 2024 10:29:41 GMT
+- request:
+    method: get
+    uri: https://www.ebi.ac.uk/ols4/api/ontologies/go/terms/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FGO_0085035/children
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux x86_64) ruby/3.1.4p223
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - www.ebi.ac.uk
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Vary:
+      - Access-Control-Request-Headers
+      - Access-Control-Request-Method
+      - Origin
+      Content-Type:
+      - application/json
+      Strict-Transport-Security:
+      - max-age=0
+      Date:
+      - Tue, 06 Feb 2024 10:29:41 GMT
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "_embedded" : {
+            "terms" : [ {
+              "iri" : "http://purl.obolibrary.org/obo/GO_0085041",
+              "lang" : "en",
+              "description" : [ "Highly branched symbiont haustoria within host root cortex cells, responsible for nutrient exchange.", "See also: periarbuscular membrane ; GO:0085042." ],
+              "synonyms" : [ ],
+              "annotation" : {
+                "created_by" : [ "jl" ],
+                "creation_date" : [ "2010-07-27T04:29:03Z" ],
+                "has_obo_namespace" : [ "cellular_component" ],
+                "id" : [ "GO:0085041" ]
+              },
+              "label" : "arbuscule",
+              "ontology_name" : "go",
+              "ontology_prefix" : "GO",
+              "ontology_iri" : "http://purl.obolibrary.org/obo/go/extensions/go-plus.owl",
+              "is_obsolete" : false,
+              "term_replaced_by" : null,
+              "is_defining_ontology" : true,
+              "has_children" : false,
+              "is_root" : false,
+              "short_form" : "GO_0085041",
+              "obo_id" : "GO:0085041",
+              "in_subset" : null,
+              "obo_definition_citation" : [ {
+                "definition" : "Highly branched symbiont haustoria within host root cortex cells, responsible for nutrient exchange.",
+                "oboXrefs" : [ {
+                  "database" : "GOC",
+                  "id" : "pamgo_curators",
+                  "description" : null,
+                  "url" : null
+                } ]
+              } ],
+              "obo_xref" : null,
+              "obo_synonym" : null,
+              "is_preferred_root" : false,
+              "_links" : {
+                "self" : {
+                  "href" : "https://www.ebi.ac.uk/ols4/api/ontologies/go/terms/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FGO_0085041?lang=en"
+                },
+                "parents" : {
+                  "href" : "https://www.ebi.ac.uk/ols4/api/ontologies/go/terms/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FGO_0085041/parents"
+                },
+                "ancestors" : {
+                  "href" : "https://www.ebi.ac.uk/ols4/api/ontologies/go/terms/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FGO_0085041/ancestors"
+                },
+                "hierarchicalParents" : {
+                  "href" : "https://www.ebi.ac.uk/ols4/api/ontologies/go/terms/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FGO_0085041/hierarchicalParents"
+                },
+                "hierarchicalAncestors" : {
+                  "href" : "https://www.ebi.ac.uk/ols4/api/ontologies/go/terms/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FGO_0085041/hierarchicalAncestors"
+                },
+                "jstree" : {
+                  "href" : "https://www.ebi.ac.uk/ols4/api/ontologies/go/terms/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FGO_0085041/jstree"
+                },
+                "graph" : {
+                  "href" : "https://www.ebi.ac.uk/ols4/api/ontologies/go/terms/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FGO_0085041/graph"
+                }
+              }
+            } ]
+          },
+          "_links" : {
+            "self" : {
+              "href" : "https://www.ebi.ac.uk/ols4/api/ontologies/go/terms/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FGO_0085035/children?page=0&size=20"
+            }
+          },
+          "page" : {
+            "size" : 20,
+            "totalElements" : 1,
+            "totalPages" : 1,
+            "number" : 0
+          }
+        }
+    http_version: 
+  recorded_at: Tue, 06 Feb 2024 10:29:41 GMT
+recorded_with: VCR 2.9.3


### PR DESCRIPTION
can now add a comma separated list of uris, and terms will be fetched from each

* fix for #1690 

also fixes a bug where terms for a new controlled vocab weren't being removed correctly when cleared - they we being marked for removal (which is the case when editing) rather than just being removed. Bug was introduced as part of #1691 