### PR TITLE
Magnifier icon next to file name will now take you to Explore for spreadsheets

### DIFF
--- a/app/views/assets/_view_content.html.erb
+++ b/app/views/assets/_view_content.html.erb
@@ -2,9 +2,10 @@
 <% options = {} %>
 <% url = nil %>
 <% asset = content_blob.asset %>
+<% asset_version = content_blob.asset_version %>
 
 <% if Seek::Util.inline_viewable_content_types.include?(asset.class) %>
-  <% if content_blob.is_content_viewable? %>
+  <% if content_blob.is_content_viewable? && !content_blob.is_supported_spreadsheet_format? %>
     <%# Use fancy lightbox thing for displaying images in page %>
     <% if content_blob.is_image? %>
       <% zoom_width = content_blob.width.to_i.clamp(Seek::ActsAsFleximageExtension::STANDARD_SIZE,
@@ -16,6 +17,13 @@
     <% else %>
       <% url = polymorphic_path([asset, content_blob], action: 'view_content', code: params[:code]) %>
       <% options = { title: 'View contents of this file' } %>
+    <% end %>
+  <% elsif !asset.is_a?(Model) && content_blob.is_supported_spreadsheet_format? %>
+    <% if content_blob.is_extractable_spreadsheet? %>
+      <% url = polymorphic_path([asset], action: 'explore', code: params[:code], version: asset_version) %>
+      <% options = { title: 'Explore the contents of this file' } %>
+    <% else %>
+      <% options = { disabled_reason: "This spreadsheet is too big to be explored (larger than #{Seek::Config.max_extractable_spreadsheet_size} MB), or the file does not exist." } %>
     <% end %>
   <% elsif !asset.is_a?(Model) && asset.is_downloadable_asset? %>
     <% if content_blob.file_exists? %>

--- a/test/functional/data_files_controller_test.rb
+++ b/test/functional/data_files_controller_test.rb
@@ -608,7 +608,7 @@ class DataFilesControllerTest < ActionController::TestCase
     end
   end
 
-  test 'show explore button' do
+  test 'show explore button and magnify icon' do
     df = FactoryBot.create(:small_test_spreadsheet_datafile)
     login_as(df.contributor.user)
     get :show, params: { id: df }
@@ -617,9 +617,12 @@ class DataFilesControllerTest < ActionController::TestCase
       assert_select 'a[href=?]', explore_data_file_path(df, version: df.version), count: 1
       assert_select 'a.disabled', text: 'Explore', count: 0
     end
+    assert_select 'div.fileinfo span.filename' do
+      assert_select 'a[href=?][title=?]', explore_data_file_path(df, version: df.version), 'Explore the contents of this file', count: 1
+    end
   end
 
-  test 'show explore button for csv file' do
+  test 'show explore button  and magnify icon for csv file' do
     df = FactoryBot.create(:csv_spreadsheet_datafile)
     login_as(df.contributor.user)
     get :show, params: { id: df }
@@ -627,6 +630,9 @@ class DataFilesControllerTest < ActionController::TestCase
     assert_select '#buttons' do
       assert_select 'a[href=?]', explore_data_file_path(df, version: df.version), count: 1
       assert_select 'a.disabled', text: 'Explore', count: 0
+    end
+    assert_select 'div.fileinfo span.filename' do
+      assert_select 'a[href=?][title=?]', explore_data_file_path(df, version: df.version), 'Explore the contents of this file', count: 1
     end
   end
 
@@ -642,9 +648,12 @@ class DataFilesControllerTest < ActionController::TestCase
       assert_select 'a[href=?]', explore_data_file_path(df, version: df.version), count: 0
       assert_select 'a', text: 'Explore', count: 0
     end
+    assert_select 'div.fileinfo span.filename' do
+      assert_select 'a[href=?][title=?]', explore_data_file_path(df, version: df.version), 'Explore the contents of this file', count: 0
+    end
   end
 
-  test 'show disabled explore button if spreadsheet too big' do
+  test 'show disabled explore button and magnify icon if spreadsheet too big' do
     df = FactoryBot.create(:small_test_spreadsheet_datafile)
     login_as(df.contributor.user)
     with_config_value(:max_extractable_spreadsheet_size, 0) do
@@ -654,6 +663,10 @@ class DataFilesControllerTest < ActionController::TestCase
     assert_select '#buttons' do
       assert_select 'a[href=?]', explore_data_file_path(df, version: df.version), count: 0
       assert_select 'a.disabled', text: 'Explore', count: 1
+    end
+    assert_select 'div.fileinfo span.filename' do
+      assert_select 'a[href=?][title=?]', explore_data_file_path(df, version: df.version), 'Explore the contents of this file', count: 0
+      assert_select 'span > a.disabled > img', count: 1
     end
   end
 


### PR DESCRIPTION
Instead of being disabled, which was a bit odd and inconsistent, the icon will now be shown with a link to /expore .
It's not shown for Models, as the explore feature is linked to the asset rather than the individual content blob. This is a possible future improvement. It would be nice if Explore was integrated with the renderers, but this was out of scope for this task.

* fix for #1711 