### PR TITLE
update docker compose to use mysql 8.0 #1743

### DIFF
--- a/docker-compose-relative-root.yml
+++ b/docker-compose-relative-root.yml
@@ -1,9 +1,9 @@
 version: '3'
 services:
   db: # Database implementation, in this case MySQL
-    image: mysql:5.7
+    image: mysql:8.0
     container_name: seek-mysql
-    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --log-error-verbosity=1
     restart: always
     stop_grace_period: 1m30s
     env_file:

--- a/docker-compose-virtuoso.yml
+++ b/docker-compose-virtuoso.yml
@@ -1,9 +1,9 @@
 version: '3'
 services:
   db: # Database implementation, in this case MySQL
-    image: mysql:5.7
+    image: mysql:8.0
     container_name: seek-mysql
-    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --log-error-verbosity=1
     restart: always
     env_file:
       - docker/db.env

--- a/docker-compose-with-email.yml
+++ b/docker-compose-with-email.yml
@@ -1,9 +1,9 @@
 version: '3'
 services:
   db: # Database implementation, in this case MySQL
-    image: mysql:5.7
+    image: mysql:8.0
     container_name: seek-mysql
-    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --log-error-verbosity=1
     restart: always
     stop_grace_period: 1m30s
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 version: '3'
 services:
   db: # Database implementation, in this case MySQL
-    image: mysql:5.7
+    image: mysql:8.0
     container_name: seek-mysql
-    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --log-error-verbosity=1
     restart: always
     stop_grace_period: 1m30s
     env_file:


### PR DESCRIPTION
tested updating an existing database, and also starting with a fresh install

the `--log-error-verbosity=1` is to switch of warning logs, and only show errors. There was a deprecation warning about `mysql_native_password` plugin which we may need to address in a later version.
It still shows startup and upgrade logs.

* fix for #1743 