### PR TITLE
Fix to make sure controlled vocab controller permissions correlate to the model

### DIFF
--- a/app/controllers/sample_controlled_vocabs_controller.rb
+++ b/app/controllers/sample_controlled_vocabs_controller.rb
@@ -6,7 +6,7 @@ class SampleControlledVocabsController < ApplicationController
 
   before_action :samples_enabled?, except: :typeahead
   before_action :login_required, except: %i[show index]
-  before_action :is_user_admin_auth, only: %i[destroy update]
+  before_action :is_user_admin_auth, only: %i[destroy]
   before_action :find_and_authorize_requested_item, except: %i[index new create]
   before_action :find_assets, only: :index
   before_action :auth_to_create, only: %i[new create]

--- a/app/controllers/sample_controlled_vocabs_controller.rb
+++ b/app/controllers/sample_controlled_vocabs_controller.rb
@@ -6,7 +6,6 @@ class SampleControlledVocabsController < ApplicationController
 
   before_action :samples_enabled?, except: :typeahead
   before_action :login_required, except: %i[show index]
-  before_action :is_user_admin_auth, only: %i[destroy]
   before_action :find_and_authorize_requested_item, except: %i[index new create]
   before_action :find_assets, only: :index
   before_action :auth_to_create, only: %i[new create]

--- a/test/functional/sample_controlled_vocabs_controller_test.rb
+++ b/test/functional/sample_controlled_vocabs_controller_test.rb
@@ -181,6 +181,7 @@ class SampleControlledVocabsControllerTest < ActionController::TestCase
     get :edit, params: { id: cv.id }
     assert_response :success
 
+    # a system vocab cannot be edited or deleted
     cv2 = FactoryBot.create(:topics_controlled_vocab)
     refute cv2.can_edit?
 
@@ -190,6 +191,8 @@ class SampleControlledVocabsControllerTest < ActionController::TestCase
 
   test 'can_edit permission required to update' do
     login_as(FactoryBot.create(:person))
+
+    # a system vocab cannot be edited or deleted
     cv_bad = FactoryBot.create(:topics_controlled_vocab)
     refute cv_bad.can_edit?
 
@@ -235,15 +238,32 @@ class SampleControlledVocabsControllerTest < ActionController::TestCase
     assert_response :redirect
   end
 
-  test 'need to be project member to destroy' do
-    login_as(FactoryBot.create(:user))
-    cv = FactoryBot.create(:apples_sample_controlled_vocab)
-    assert_no_difference('SampleControlledVocab.count') do
-      assert_no_difference('SampleControlledVocabTerm.count') do
-        delete :destroy, params: { id: cv }
+  test 'can_delete permission required to destroy' do
+    login_as(FactoryBot.create(:person))
+
+    # a system vocab cannot be edited or deleted
+    cv_bad = FactoryBot.create(:topics_controlled_vocab)
+    refute cv_bad.can_delete?
+
+    cv_good = FactoryBot.create(:apples_sample_controlled_vocab)
+    assert cv_good.can_delete?
+
+    assert_difference('SampleControlledVocab.count', -1) do
+      assert_difference('SampleControlledVocabTerm.count', -4) do
+        delete :destroy, params: { id: cv_good }
       end
     end
-    assert_response :redirect
+    assert_redirected_to sample_controlled_vocabs_path
+    refute flash[:error]
+
+    assert_no_difference('SampleControlledVocab.count') do
+      assert_no_difference('SampleControlledVocabTerm.count') do
+        delete :destroy, params: { id: cv_bad }
+      end
+    end
+    assert_redirected_to sample_controlled_vocab_path(cv_bad)
+    assert flash[:error]
+
   end
 
   test 'cannot access when disabled' do

--- a/test/functional/sample_controlled_vocabs_controller_test.rb
+++ b/test/functional/sample_controlled_vocabs_controller_test.rb
@@ -173,6 +173,42 @@ class SampleControlledVocabsControllerTest < ActionController::TestCase
     assert_response :redirect
   end
 
+  test 'can_edit permission required to edit' do
+    login_as(FactoryBot.create(:person))
+    cv = FactoryBot.create(:apples_sample_controlled_vocab)
+    assert cv.can_edit?
+
+    get :edit, params: { id: cv.id }
+    assert_response :success
+
+    cv2 = FactoryBot.create(:topics_controlled_vocab)
+    refute cv2.can_edit?
+
+    get :edit, params: { id: cv2.id }
+    assert_response :redirect
+  end
+
+  test 'can_edit permission required to update' do
+    login_as(FactoryBot.create(:person))
+    cv_bad = FactoryBot.create(:topics_controlled_vocab)
+    refute cv_bad.can_edit?
+
+    cv_good = FactoryBot.create(:apples_sample_controlled_vocab)
+    assert cv_good.can_edit?
+
+    put :update, params: { id: cv_good, sample_controlled_vocab: { title: 'updated title' } }
+    assert_redirected_to sample_controlled_vocab_path(cv_good)
+    refute flash[:error]
+    assert_equal 'updated title',assigns(:sample_controlled_vocab).title
+    assert_equal 'updated title',cv_good.reload.title
+
+    put :update, params: { id: cv_bad, sample_controlled_vocab: { title: 'updated title' } }
+    assert_redirected_to sample_controlled_vocab_path(cv_bad)
+    assert flash[:error]
+    refute_equal 'updated title',cv_bad.reload.title
+
+  end
+
   test 'index' do
     cv = FactoryBot.create(:apples_sample_controlled_vocab)
     get :index

--- a/test/integration/api/sample_controlled_vocab_api_test.rb
+++ b/test/integration/api/sample_controlled_vocab_api_test.rb
@@ -17,4 +17,12 @@ class SampleControlledVocabApiTest < ActionDispatch::IntegrationTest
     @sample_controlled_vocab.sample_controlled_vocab_terms << @sample_controlled_vocab_term
     @sample_controlled_vocab.save!
   end
+
+  def private_resource
+    # setting the key to a known key will make it a system vocab which isn't editable or deletable
+    @sample_controlled_vocab.update_column(:key, SampleControlledVocab::SystemVocabs.database_key_for_property(:topics))
+    refute @sample_controlled_vocab.can_edit?
+    refute @sample_controlled_vocab.can_delete?
+    @sample_controlled_vocab
+  end
 end


### PR DESCRIPTION
make sure the update and edit actions check against can_edit? and also that destroy checks can_delete?

* Fix for #1693 