### PR TITLE
Issue 1756 fix sample attribute order in sp

### DIFF
--- a/app/assets/javascripts/sample_types.js
+++ b/app/assets/javascripts/sample_types.js
@@ -12,7 +12,7 @@ var SampleTypes = {
             helper: SampleTypes.fixHelper,
             handle: '.attribute-handle'
         }).on('sortupdate', function() {
-            SampleTypes.recalculatePositions();
+            SampleTypes.recalculatePositions(selector);
         });
     },
 

--- a/app/assets/javascripts/single_page/dynamic_table.js.erb
+++ b/app/assets/javascripts/single_page/dynamic_table.js.erb
@@ -94,7 +94,6 @@ const handleSelect = (e) => {
       columns.unshift(...defaultCols);
 
       const columnDefs = [{
-          orderable: false,
           targets: options.readonly ? [0] : [0, 1]
         },
         {

--- a/app/assets/javascripts/single_page/dynamic_table.js.erb
+++ b/app/assets/javascripts/single_page/dynamic_table.js.erb
@@ -105,6 +105,7 @@ const handleSelect = (e) => {
       ];
       const editor = this.editor;
       this.table = this.table.DataTable({
+        colReorder: true,
         columnDefs,
         columns,
         scrollX: "100%",

--- a/app/views/isa_assays/_assay_samples.html.erb
+++ b/app/views/isa_assays/_assay_samples.html.erb
@@ -24,7 +24,7 @@
             $j('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
                 $j.fn.dataTable.tables( {visible: true, api: true} ).columns.adjust();
             });
-            const dt = <%= sanitize(dt_data(sample_type).to_json) %>
+            const dt = <%= sanitize(dt_data(sample_type).to_json) %>;
             window.sampleDynamicTable = new $j.dynamicTable('#assay-samples-table');
             const elem = $j("#btn_save_assay_sample")
             const options = {


### PR DESCRIPTION
Fixes #1756 :

- Fixes the reordering of sample attributes in an ISA JSON compliant Sample Type
- Ability to temporarily reorder the columns in the dynamic table by drag-and-drop
- Always displays the sample metadata in the dynamic table in the same order as the sample attributes in the sample type.