### PR TITLE
Fix batch upload dynamic table

### DIFF
--- a/app/assets/javascripts/single_page/index.js.erb
+++ b/app/assets/javascripts/single_page/index.js.erb
@@ -316,6 +316,7 @@ async function handleUploadSubmit(formData){
       $j('#upload-excel').html(response);
     },
     error: function(err){
+        alert(`Failed to upload file!\nStatus: ${err.status}\nError: ${err.statusText}`);
       location.reload(); // Page needs reloading for the notice message to appear
     }
   });

--- a/app/views/single_pages/sample_upload_content.html.erb
+++ b/app/views/single_pages/sample_upload_content.html.erb
@@ -148,7 +148,7 @@
 
     const {id: objId, ...attrMap} = samplesObj;
 
-    attrMap["status"] = action;
+      attrMap["sampleUploadAction"] = action;
 
     if (action === "update"){
       return {

--- a/app/views/single_pages/sample_upload_content.html.erb
+++ b/app/views/single_pages/sample_upload_content.html.erb
@@ -83,10 +83,15 @@
     try{
       const postCall = await uploadAjaxCall("<%= batch_create_samples_path %>", "POST", { data: JSON.stringify(newSamples) });
       const putCall = await uploadAjaxCall("<%= batch_update_samples_path %>", "PUT", { data: JSON.stringify(updatedSamples) });
+        let errors = {newSamples: postCall.errors, updatedSamples: putCall.errors};
+        if (errors.newSamples.length > 0 || errors.updatedSamples.length > 0) {
+            throw new Error(JSON.stringify(errors));
+        }
       $j('#sample-upload-spinner').hide();
       closeModalForm();
       location.reload();
     } catch (error){
+        alert(`Error: ${error}`);
       $j('#sample-upload-spinner').hide();
     }
   }
@@ -132,7 +137,7 @@
         const inputIds = multiInputfields.map(is => is.title.split(" ").pop()).join(',');
         samplesObj[key] = inputIds;
       } else if (cvListFields.length > 0){
-        cvTerms = cvListFields.map(cvt => cvt.title)
+          let cvTerms = cvListFields.map(cvt => cvt.title)
         samplesObj[key] = cvTerms;
       } else if (seekSample.length > 0) {
         samplesObj[key] = seekSample[0].title


### PR DESCRIPTION
Fixes #1762:

- JS `Alert` displaying error messages when HTTP requests fail
- Change the field from `status` to `sampleUploadAction` so it doesn't make the requests fail when the Sample Type contains an attribute called status.