### PR TITLE
Fix controlled vocabs in template attributes

### DIFF
--- a/app/helpers/templates_helper.rb
+++ b/app/helpers/templates_helper.rb
@@ -67,7 +67,7 @@ module TemplatesHelper
       type += ' - ' + link_to(template_attribute.linked_sample_type&.title, template_attribute.linked_sample_type)
     end
 
-    if template_attribute.sample_attribute_type.controlled_vocab?
+    if template_attribute.sample_attribute_type.controlled_vocab? && template_attribute.sample_controlled_vocab
       type += ' - ' + link_to(template_attribute.sample_controlled_vocab.title,
                               template_attribute.sample_controlled_vocab)
     end

--- a/app/models/template_attribute.rb
+++ b/app/models/template_attribute.rb
@@ -27,7 +27,7 @@ class TemplateAttribute < ApplicationRecord
   end
 
   def input_attribute?
-    isa_tag_id && title&.downcase&.include?('input') && sample_attribute_type.seek_sample_multi?
+    isa_tag.nil? && title&.downcase&.include?('input') && sample_attribute_type.seek_sample_multi?
   end
 
   private

--- a/app/models/template_attribute.rb
+++ b/app/models/template_attribute.rb
@@ -27,7 +27,7 @@ class TemplateAttribute < ApplicationRecord
   end
 
   def input_attribute?
-    isa_tag.nil? && title&.downcase&.include?('input') && sample_attribute_type.seek_sample_multi?
+    isa_tag_id && title&.downcase&.include?('input') && sample_attribute_type.seek_sample_multi?
   end
 
   private

--- a/app/models/template_attribute.rb
+++ b/app/models/template_attribute.rb
@@ -1,4 +1,5 @@
 class TemplateAttribute < ApplicationRecord
+  include Seek::JSONMetadata::Attribute
   belongs_to :sample_controlled_vocab
   belongs_to :sample_attribute_type
   belongs_to :template, inverse_of: :template_attributes

--- a/app/views/isa_assays/_assay_design.html.erb
+++ b/app/views/isa_assays/_assay_design.html.erb
@@ -36,7 +36,7 @@
 <% else %>
 	<p>
 		<em>
-			This <%="#{t(:assay)}"%> has not been created in Single Page.
+			This <%= "#{t(:assay)}" %> has not been created in <%= "#{t(:single_page)}" %> %>.
 			Please, create the <%="#{t(:assay)}"%> by using the <strong>Design <%="#{t(:assay)}"%></strong> button at the <%="#{t(:study)}"%> level.
 		</em>
 	</p>

--- a/app/views/isa_studies/_study_design.html.erb
+++ b/app/views/isa_studies/_study_design.html.erb
@@ -42,7 +42,7 @@
 <% else %>
 	<p>
 		<em>
-			This <%="#{t(:study)}"%>	has not been created in Single Page.
+			This <%= "#{t(:study)}" %>  has not been created in <%= "#{t(:single_page)}" %> .
 			Please, create the <%="#{t(:study)}"%> by using the <strong>Design <%="#{t(:study)}"%></strong> button at the <%="#{t(:investigation)}"%> level.
 		</em>
 	</p>

--- a/lib/seek/json_metadata/attribute.rb
+++ b/lib/seek/json_metadata/attribute.rb
@@ -78,9 +78,9 @@ module Seek
         if sample_attribute_type && linked_sample_type && !seek_sample? && !seek_sample_multi?
           errors.add(:sample_attribute_type, 'Attribute type must be SeekSample if linked sample type set')
         end
-        if seek_sample? && linked_sample_type.nil? && is_isa_compliant_input?
+        if seek_sample? && linked_sample_type.nil? && !is_isa_compliant_input?
           errors.add(:seek_sample, 'Linked Sample Type must be set if attribute type is Registered Sample')
-        elsif seek_sample_multi? && linked_sample_type.nil? && is_isa_compliant_input?
+        elsif seek_sample_multi? && linked_sample_type.nil? && !is_isa_compliant_input?
           errors.add(:seek_sample_multi, 'Linked Sample Type must be set if attribute type is Registered Sample List')
         end
       end
@@ -96,9 +96,9 @@ module Seek
 
       def is_isa_compliant_input?
         if is_a?(SampleAttribute)
-          !(input_attribute? && sample_type.is_isa_json_compliant?)
+          input_attribute? && sample_type.is_isa_json_compliant?
         else
-          !input_attribute?
+          input_attribute?
         end
       end
     end

--- a/lib/seek/json_metadata/attribute.rb
+++ b/lib/seek/json_metadata/attribute.rb
@@ -78,9 +78,9 @@ module Seek
         if sample_attribute_type && linked_sample_type && !seek_sample? && !seek_sample_multi?
           errors.add(:sample_attribute_type, 'Attribute type must be SeekSample if linked sample type set')
         end
-        if seek_sample? && linked_sample_type.nil? && !is_isa_compliant_input?
+        if seek_sample? && linked_sample_type.nil? && !is_isa_compliant_template_input?
           errors.add(:seek_sample, 'Linked Sample Type must be set if attribute type is Registered Sample')
-        elsif seek_sample_multi? && linked_sample_type.nil? && !is_isa_compliant_input?
+        elsif seek_sample_multi? && linked_sample_type.nil? && !is_isa_compliant_template_input?
           errors.add(:seek_sample_multi, 'Linked Sample Type must be set if attribute type is Registered Sample List')
         end
       end
@@ -94,12 +94,10 @@ module Seek
         base_type_handler.validate_value?(value)
       end
 
-      def is_isa_compliant_input?
-        if is_a?(SampleAttribute)
-          input_attribute? && sample_type.is_isa_json_compliant?
-        else
-          input_attribute?
-        end
+      def is_isa_compliant_template_input?
+        return input_attribute? if is_a?(TemplateAttribute)
+
+        false
       end
     end
   end

--- a/lib/seek/json_metadata/attribute.rb
+++ b/lib/seek/json_metadata/attribute.rb
@@ -78,9 +78,9 @@ module Seek
         if sample_attribute_type && linked_sample_type && !seek_sample? && !seek_sample_multi?
           errors.add(:sample_attribute_type, 'Attribute type must be SeekSample if linked sample type set')
         end
-        if seek_sample? && linked_sample_type.nil?
+        if seek_sample? && linked_sample_type.nil? && is_isa_compliant_input?
           errors.add(:seek_sample, 'Linked Sample Type must be set if attribute type is Registered Sample')
-        elsif seek_sample_multi? && linked_sample_type.nil?
+        elsif seek_sample_multi? && linked_sample_type.nil? && is_isa_compliant_input?
           errors.add(:seek_sample_multi, 'Linked Sample Type must be set if attribute type is Registered Sample List')
         end
       end
@@ -94,6 +94,13 @@ module Seek
         base_type_handler.validate_value?(value)
       end
 
+      def is_isa_compliant_input?
+        if is_a?(SampleAttribute)
+          !(input_attribute? && sample_type.is_isa_json_compliant?)
+        else
+          !input_attribute?
+        end
+      end
     end
   end
 end

--- a/test/factories/template_attributes.rb
+++ b/test/factories/template_attributes.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
   factory(:template_attribute) do
     sequence(:title) { |n| "Template attribute #{n}" }
     association :template, factory: :template
-    isa_tag_id { FactoryBot.create(:default_isa_tag).id }
+    isa_tag_id { nil }
   end
 
   factory(:apples_controlled_vocab_template_attribute, parent: :template_attribute) do

--- a/test/functional/templates_controller_test.rb
+++ b/test/functional/templates_controller_test.rb
@@ -16,6 +16,8 @@ class TemplatesControllerTest < ActionController::TestCase
     @template = FactoryBot.create(:min_template, project_ids: @project_ids, contributor: @person)
     @string_type = FactoryBot.create(:string_sample_attribute_type)
     @int_type = FactoryBot.create(:integer_sample_attribute_type)
+    @registered_sample_attribute_type = FactoryBot.create(:sample_sample_attribute_type)
+    @registered_sample_multi_attribute_type = FactoryBot.create(:sample_multi_sample_attribute_type)
     @controlled_vocab_type = FactoryBot.create(:controlled_vocab_attribute_type)
     @default_isa_tag = FactoryBot.create(:default_isa_tag)
   end
@@ -304,6 +306,149 @@ class TemplatesControllerTest < ActionController::TestCase
     cnt_last_attribute = inherited_template.template_attributes.count - 1
 
     assert_select "select#template_template_attributes_attributes_#{cnt_last_attribute}_isa_tag_title[disabled='disabled']", text: 'source_characteristic', count: 0
+
+  end
+
+  test 'should not allow to create template with registered sample template attributes with no linked sample type' do
+    source_isa_tag = FactoryBot.create(:source_isa_tag)
+    source_characteristic_isa_tag = FactoryBot.create(:source_characteristic_isa_tag)
+    source_attribute = {
+      pos: '1',
+      title: 'Source Name',
+      required: '1',
+      short_name: 'attribute1 short name',
+      ontology_version: '0.1.1',
+      description: 'attribute1 description',
+      isa_tag_id: source_isa_tag.id,
+      sample_attribute_type_id: @string_type.id,
+      is_title: '1',
+      _destroy: '0'
+    }
+
+    bad_registered_sample_attribute = {
+      pos: '2',
+      title: 'Correct registered sample attribute',
+      required: '1',
+      short_name: 'attribute2 short name',
+      ontology_version: '0.1.2',
+      description: 'attribute2 description',
+      isa_tag_id: source_characteristic_isa_tag,
+      sample_attribute_type_id: @registered_sample_attribute_type.id,
+      linked_sample_type_id: nil,
+      _destroy: '0'
+    }
+
+    bad_template_params = { title: 'Bad template',
+                            project_ids: @project_ids,
+                            level: 'study source',
+                            organism: 'any',
+                            version: '1.0.0',
+                            parent_id: nil,
+                            description: 'Template containing registered samples attributes with no linked sample type',
+                            template_attributes_attributes: {
+                              '0' => source_attribute,
+                              '1' => bad_registered_sample_attribute
+                            } }
+
+    assert_no_difference('Template.count') do
+      post :create, params: { template: bad_template_params }
+      assert_response :unprocessable_entity
+      assert_template :new
+      assert_select 'div#error_explanation'
+    end
+
+    sample_type = FactoryBot.create(:simple_sample_type, project_ids: @project_ids, contributor: @person)
+
+    correct_registered_sample_attribute = {
+      pos: '2',
+      title: 'Correct registered sample attribute',
+      required: '1',
+      short_name: 'attribute2 short name',
+      ontology_version: '0.1.2',
+      description: 'attribute2 description',
+      isa_tag_id: source_characteristic_isa_tag,
+      sample_attribute_type_id: @registered_sample_attribute_type.id,
+      linked_sample_type_id: sample_type.id,
+      _destroy: '0'
+    }
+
+    correct_source_template_params = { title: 'Correct source template',
+                                       project_ids: @project_ids,
+                                       level: 'study source',
+                                       organism: 'any',
+                                       version: '1.0.0',
+                                       parent_id: nil,
+                                       description: 'Template containing attributes with no isa tags',
+                                       template_attributes_attributes: {
+                                         '0' => source_attribute,
+                                         '1' => correct_registered_sample_attribute
+                                       } }
+
+    assert_difference('Template.count', 1) do
+      post :create, params: { template: correct_source_template_params }
+      assert_response :redirect
+      assert_redirected_to template_path(assigns(:template))
+    end
+
+    sample_isa_tag = FactoryBot.create(:sample_isa_tag)
+    sample_characteristic_isa_tag = FactoryBot.create(:sample_characteristic_isa_tag)
+
+    input_sample_attribute = {
+      pos: '1',
+      title: 'Input (Source sample)',
+      required: '1',
+      short_name: 'attribute1 short name',
+      ontology_version: '0.1.2',
+      description: 'attribute1 description',
+      sample_attribute_type_id: @registered_sample_multi_attribute_type.id,
+      linked_sample_type_id: nil,
+      _destroy: '0'
+    }
+
+    collected_sample_attribute = {
+      pos: '2',
+      title: 'Sample Name',
+      required: '1',
+      short_name: 'attribute2 short name',
+      ontology_version: '0.1.1',
+      description: 'attribute2 description',
+      isa_tag_id: sample_isa_tag.id,
+      sample_attribute_type_id: @string_type.id,
+      is_title: '1',
+      _destroy: '0'
+    }
+
+    sample_characteristic_attribute = {
+      pos: '3',
+      title: 'Correct registered sample attribute',
+      required: '1',
+      short_name: 'attribute3 short name',
+      ontology_version: '0.1.2',
+      description: 'attribute3 description',
+      isa_tag_id: sample_characteristic_isa_tag.id,
+      sample_attribute_type_id: @registered_sample_attribute_type.id,
+      linked_sample_type_id: sample_type.id,
+      _destroy: '0'
+    }
+
+    correct_sample_collection_template_params = { title: 'Correct Sample collection template',
+                                                  project_ids: @project_ids,
+                                                  level: 'study sample',
+                                                  organism: 'any',
+                                                  version: '1.0.0',
+                                                  parent_id: nil,
+                                                  description: 'Sample collection template made correctly',
+                                                  template_attributes_attributes: {
+                                                    '0' => input_sample_attribute,
+                                                    '1' => collected_sample_attribute,
+                                                    '2' => sample_characteristic_attribute
+                                                  } }
+
+    assert_difference('Template.count', 1) do
+      post :create, params: { template: correct_sample_collection_template_params }
+      assert_response :redirect
+      assert_redirected_to template_path(assigns(:template))
+    end
 
   end
 

--- a/test/functional/templates_controller_test.rb
+++ b/test/functional/templates_controller_test.rb
@@ -354,7 +354,7 @@ class TemplatesControllerTest < ActionController::TestCase
       post :create, params: { template: bad_template_params }
       assert_response :unprocessable_entity
       assert_template :new
-      assert_select 'div#error_explanation'
+      assert_select 'div#error_explanation', text: /Linked Sample Type must be set if attribute type is Registered Sample/
     end
 
     sample_type = FactoryBot.create(:simple_sample_type, project_ids: @project_ids, contributor: @person)
@@ -450,6 +450,86 @@ class TemplatesControllerTest < ActionController::TestCase
       assert_redirected_to template_path(assigns(:template))
     end
 
+  end
+
+  test 'should not allow to create template with controlled vocabulary template attributes with no sample controlled vocabulary' do
+    source_isa_tag = FactoryBot.create(:source_isa_tag)
+    source_characteristic_isa_tag = FactoryBot.create(:source_characteristic_isa_tag)
+    source_attribute = {
+      pos: '1',
+      title: 'Source Name',
+      required: '1',
+      short_name: 'attribute1 short name',
+      ontology_version: '0.1.1',
+      description: 'attribute1 description',
+      isa_tag_id: source_isa_tag.id,
+      sample_attribute_type_id: @string_type.id,
+      is_title: '1',
+      _destroy: '0'
+    }
+
+    bad_controlled_vocab_attribute = {
+      pos: '2',
+      title: 'Correct registered sample attribute',
+      required: '1',
+      short_name: 'attribute2 short name',
+      ontology_version: '0.1.2',
+      description: 'attribute2 description',
+      isa_tag_id: source_characteristic_isa_tag,
+      sample_attribute_type_id: @controlled_vocab_type.id,
+      _destroy: '0'
+    }
+
+    bad_template_params = { title: 'Bad template',
+                            project_ids: @project_ids,
+                            level: 'study source',
+                            organism: 'any',
+                            version: '1.0.0',
+                            parent_id: nil,
+                            description: 'Template containing controlled vocabulary attributes with no sample controlled vocabulary',
+                            template_attributes_attributes: {
+                              '0' => source_attribute,
+                              '1' => bad_controlled_vocab_attribute
+                            } }
+
+    assert_no_difference('Template.count') do
+      post :create, params: { template: bad_template_params }
+      assert_response :unprocessable_entity
+      assert_template :new
+      assert_select 'div#error_explanation', text: /Controlled vocabulary must be set if attribute type is CV/
+    end
+
+    controlled_vocab = FactoryBot.create(:apples_sample_controlled_vocab)
+    correct_controlled_vocab_attribute = {
+      pos: '2',
+      title: 'Correct registered sample attribute',
+      required: '1',
+      short_name: 'attribute2 short name',
+      ontology_version: '0.1.2',
+      description: 'attribute2 description',
+      isa_tag_id: source_characteristic_isa_tag,
+      sample_attribute_type_id: @controlled_vocab_type.id,
+      sample_controlled_vocab_id: controlled_vocab.id,
+      _destroy: '0'
+    }
+
+    correct_source_template_params = { title: 'Correct source template',
+                                       project_ids: @project_ids,
+                                       level: 'study source',
+                                       organism: 'any',
+                                       version: '1.0.0',
+                                       parent_id: nil,
+                                       description: 'Template containing controlled vocabulary attributes with no linked sample type',
+                                       template_attributes_attributes: {
+                                         '0' => source_attribute,
+                                         '1' => correct_controlled_vocab_attribute
+                                       } }
+
+    assert_difference('Template.count', 1) do
+      post :create, params: { template: correct_source_template_params }
+      assert_response :redirect
+      assert_redirected_to template_path(assigns(:template))
+    end
   end
 
   def create_template_from_parent_template(parent_template, person= @person, linked_sample_type= nil)

--- a/test/unit/template_attribute_test.rb
+++ b/test/unit/template_attribute_test.rb
@@ -1,12 +1,18 @@
 require 'test_helper'
+
 class TemplateAttributeTest < ActiveSupport::TestCase
 
   test 'allow isa tag change' do
     # When template doesn't have child templates => editable
     # When template has child templates => disabled
-    parent_attribute = FactoryBot.create(:template_attribute)
-    child_attribute = FactoryBot.create(:template_attribute, parent_attribute: parent_attribute)
-    parentless_attribute = FactoryBot.create(:template_attribute)
+    string_type = FactoryBot.create(:string_sample_attribute_type)
+
+    parent_attribute = FactoryBot.create(:template_attribute,
+                                         sample_attribute_type: string_type)
+    child_attribute = FactoryBot.create(:template_attribute,
+                                        parent_attribute: parent_attribute,
+                                        sample_attribute_type: string_type)
+    parentless_attribute = FactoryBot.create(:template_attribute, sample_attribute_type: string_type)
     assert parentless_attribute.allow_isa_tag_change?
     refute child_attribute.allow_isa_tag_change?
   end

--- a/test/unit/template_attribute_test.rb
+++ b/test/unit/template_attribute_test.rb
@@ -2,18 +2,35 @@ require 'test_helper'
 
 class TemplateAttributeTest < ActiveSupport::TestCase
 
+  def setup
+    @string_type = FactoryBot.create(:string_sample_attribute_type)
+    @registered_sample_multi_attribute_type = FactoryBot.create(:sample_multi_sample_attribute_type)
+    @registered_sample_attribute_type = FactoryBot.create(:sample_sample_attribute_type)
+  end
+
   test 'allow isa tag change' do
     # When template doesn't have child templates => editable
     # When template has child templates => disabled
-    string_type = FactoryBot.create(:string_sample_attribute_type)
 
     parent_attribute = FactoryBot.create(:template_attribute,
-                                         sample_attribute_type: string_type)
+                                         sample_attribute_type: @string_type)
     child_attribute = FactoryBot.create(:template_attribute,
                                         parent_attribute: parent_attribute,
-                                        sample_attribute_type: string_type)
-    parentless_attribute = FactoryBot.create(:template_attribute, sample_attribute_type: string_type)
+                                        sample_attribute_type: @string_type)
+    parentless_attribute = FactoryBot.create(:template_attribute, sample_attribute_type: @string_type)
     assert parentless_attribute.allow_isa_tag_change?
     refute child_attribute.allow_isa_tag_change?
+  end
+
+  test 'is input attribute?' do
+    # When isa tag is nil, title includes 'input' and sample attribute type is seek sample multi => true
+    # Otherwise => false
+
+    attribute = FactoryBot.create(:template_attribute,
+                                  sample_attribute_type: @registered_sample_multi_attribute_type,
+                                  title: 'Input attribute')
+    assert attribute.input_attribute?
+    attribute.isa_tag = FactoryBot.create(:source_characteristic_isa_tag)
+    refute attribute.input_attribute?
   end
 end


### PR DESCRIPTION
- Prevents user to create a template attribute of type controlled vocabulary (List) without specifying a controlled vocabulary.
- Uses same validation as Sample Attributes to ensure similar behavior

Fixes issue #1755.