### PR TITLE
flag content blobs to be deleted after asset deleted

### DIFF
--- a/app/models/data_file.rb
+++ b/app/models/data_file.rb
@@ -15,7 +15,7 @@ class DataFile < ApplicationRecord
   # allow same titles, but only if these belong to different users
   # validates_uniqueness_of :title, :scope => [ :contributor_id, :contributor_type ], :message => "error - you already have a Data file with such title."
 
-  has_one :content_blob, ->(r) { where('content_blobs.asset_version =?', r.version) }, as: :asset, foreign_key: :asset_id
+  has_one :content_blob, ->(r) { where('content_blobs.asset_version =? AND deleted =?', r.version, false) }, as: :asset, foreign_key: :asset_id
   has_one :external_asset, as: :seek_entity, dependent: :destroy
 
   belongs_to :file_template

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -10,7 +10,7 @@ class Document < ApplicationRecord
   acts_as_doi_parent
 
   #don't add a dependent=>:destroy, as the content_blob needs to remain to detect future duplicates
-  has_one :content_blob, -> (r) { where('content_blobs.asset_version = ?', r.version) }, :as => :asset, :foreign_key => :asset_id
+  has_one :content_blob, -> (r) { where('content_blobs.asset_version =? AND deleted =?', r.version, false) }, :as => :asset, :foreign_key => :asset_id
 
   has_and_belongs_to_many :workflows, -> { distinct }
 

--- a/app/models/file_template.rb
+++ b/app/models/file_template.rb
@@ -16,7 +16,7 @@ class FileTemplate < ApplicationRecord
   has_controlled_vocab_annotations :data_types, :data_formats
 
   #don't add a dependent=>:destroy, as the content_blob needs to remain to detect future duplicates
-  has_one :content_blob, -> (r) { where('content_blobs.asset_version = ?', r.version) }, :as => :asset, :foreign_key => :asset_id
+  has_one :content_blob, -> (r) { where('content_blobs.asset_version =? AND deleted =?', r.version, false) }, :as => :asset, :foreign_key => :asset_id
 
   has_many :data_files, inverse_of: :file_template
   has_many :placeholders, inverse_of: :file_template

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -30,7 +30,7 @@ class Model < ApplicationRecord
   has_many :model_images, inverse_of: :model
   belongs_to :model_image, inverse_of: :model
 
-  has_many :content_blobs, -> (r) { where('content_blobs.asset_version =?', r.version) }, :as => :asset, :foreign_key => :asset_id
+  has_many :content_blobs, -> (r) { where('content_blobs.asset_version =? AND deleted =?', r.version, false) }, :as => :asset, :foreign_key => :asset_id
 
   belongs_to :organism
   belongs_to :human_disease

--- a/app/models/presentation.rb
+++ b/app/models/presentation.rb
@@ -8,7 +8,7 @@ class Presentation < ApplicationRecord
   #even though in Seek::ActsAsAsset::Search it is already set to false!
   acts_as_asset
 
-  has_one :content_blob, -> (r) { where('content_blobs.asset_version =?', r.version) }, :as => :asset, :foreign_key => :asset_id
+  has_one :content_blob, -> (r) { where('content_blobs.asset_version =? AND deleted =?', r.version, false) }, :as => :asset, :foreign_key => :asset_id
 
   validates :projects, presence: true, projects: { self: true }
 

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -45,7 +45,7 @@ class Publication < ApplicationRecord
   has_many :publication_authors, dependent: :destroy, autosave: true
   has_many :people, through: :publication_authors
 
-  has_one :content_blob, ->(r) { where('content_blobs.asset_version =?', r.version) }, as: :asset, foreign_key: :asset_id
+  has_one :content_blob, ->(r) { where('content_blobs.asset_version =? AND deleted=?', r.version, false) }, as: :asset, foreign_key: :asset_id
 
   explicit_versioning(:version_column => "version", sync_ignore_columns: ['license','other_creators']) do
     acts_as_versioned_resource

--- a/app/models/sop.rb
+++ b/app/models/sop.rb
@@ -11,10 +11,9 @@ class Sop < ApplicationRecord
   validates :projects, presence: true, projects: { self: true }
 
   #don't add a dependent=>:destroy, as the content_blob needs to remain to detect future duplicates
-  has_one :content_blob, -> (r) { where('content_blobs.asset_version =?', r.version) }, :as => :asset, :foreign_key => :asset_id
+  has_one :content_blob, -> (r) { where('content_blobs.asset_version =? AND deleted=?', r.version, false) }, :as => :asset, :foreign_key => :asset_id
 
   has_and_belongs_to_many :workflows
-
 
   has_filter assay_type: Seek::Filtering::Filter.new(
       value_field: 'assays.assay_type_uri',

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -19,7 +19,7 @@ class Workflow < ApplicationRecord
   validates :projects, presence: true, projects: { self: true }
 
   #don't add a dependent=>:destroy, as the content_blob needs to remain to detect future duplicates
-  has_one :content_blob, -> (r) { where('content_blobs.asset_version =?', r.version) }, :as => :asset, :foreign_key => :asset_id
+  has_one :content_blob, -> (r) { where('content_blobs.asset_version =? AND deleted =?', r.version, false) }, :as => :asset, :foreign_key => :asset_id
 
   has_and_belongs_to_many :sops
   has_and_belongs_to_many :presentations

--- a/db/migrate/20240311113858_add_deleted_flag_to_content_blob.rb
+++ b/db/migrate/20240311113858_add_deleted_flag_to_content_blob.rb
@@ -1,0 +1,5 @@
+class AddDeletedFlagToContentBlob < ActiveRecord::Migration[6.1]
+  def change
+    add_column :content_blobs, :deleted, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_02_12_145449) do
+ActiveRecord::Schema.define(version: 2024_03_11_113858) do
 
   create_table "activity_logs", id: :integer, force: :cascade do |t|
     t.string "action"
@@ -348,6 +348,7 @@ ActiveRecord::Schema.define(version: 2024_02_12_145449) do
     t.bigint "file_size"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean "deleted", default: false
     t.index ["asset_id", "asset_type"], name: "index_content_blobs_on_asset_id_and_asset_type"
   end
 

--- a/lib/seek/acts_as_asset.rb
+++ b/lib/seek/acts_as_asset.rb
@@ -47,7 +47,6 @@ module Seek
         validates :description, length: { maximum: 65_535 }, if: -> { respond_to?(:description) }
         validates :license, license:true, allow_blank: true, if: -> { respond_to?(:license) }
 
-
         include Seek::Stats::ActivityCounts
 
         include Seek::ActsAsAsset::ISA::Associations
@@ -61,6 +60,7 @@ module Seek
         include Seek::ActsAsAsset::InstanceMethods
         include Seek::Search::BackgroundReindexing
         include Seek::Subscribable
+        include Seek::ActsAsAsset::ContentBlobs::ClassMethods
         extend SingletonMethods
       end
 

--- a/lib/seek/acts_as_asset/content_blobs.rb
+++ b/lib/seek/acts_as_asset/content_blobs.rb
@@ -2,7 +2,15 @@ module Seek
   module ActsAsAsset
     # Acts as Asset behaviour that relates to content
     module ContentBlobs
+      module ClassMethods
+        extend ActiveSupport::Concern
+        included do
+          after_destroy :mark_deleted_content_blobs
+        end
+      end
+
       module InstanceMethods
+
         def contains_downloadable_items?
           all_content_blobs.compact.any?(&:is_downloadable?)
         end
@@ -44,6 +52,13 @@ module Seek
               end
             end
             self.save!
+          end
+        end
+
+        # flags that content blob has been deleted, after the associated asset has been destroyed
+        def mark_deleted_content_blobs
+          all_content_blobs.each do |cb|
+            cb.update_column(:deleted, true)
           end
         end
       end


### PR DESCRIPTION
set a flag to say the content blob has been deleted, and prevent from showing linked to the asset. This is for cases where the asset_id may be reused, mainly affecting mysql5 but this prevents future surprises.

Current the content blobs aren't deleted, but could be deleted by the regular maintenance job after a set period (perhaps 24hr to make sure there is a chance to back them up). This needs further discussion.

fix for #1784 