### PR TITLE
Allow custom OIDC auth provider + other omniauth fixes/changes

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -96,6 +96,9 @@ class AdminController < ApplicationController
 
     Seek::Config.omniauth_oidc_enabled = string_to_boolean params[:omniauth_oidc_enabled]
     Seek::Config.omniauth_oidc_name = params[:omniauth_oidc_name]
+    Seek::Config.omniauth_oidc_image&.destroy! if params[:clear_omniauth_oidc_image] == '1'
+    Seek::Config.omniauth_oidc_image = params[:omniauth_oidc_image]
+
     params[:omniauth_oidc_issuer] = params[:omniauth_oidc_issuer].chomp('/') + '/' if params[:omniauth_oidc_issuer].present?
     Seek::Config.omniauth_oidc_issuer = params[:omniauth_oidc_issuer]
     Seek::Config.omniauth_oidc_client_id = params[:omniauth_oidc_client_id]
@@ -249,7 +252,7 @@ class AdminController < ApplicationController
 
     Seek::Config.header_image_enabled = string_to_boolean params[:header_image_enabled]
     Seek::Config.header_image_title = params[:header_image_title]
-    header_image_file
+    set_header_image_file
 
     Seek::Config.copyright_addendum_enabled = string_to_boolean params[:copyright_addendum_enabled]
     Seek::Config.copyright_addendum_content = params[:copyright_addendum_content]
@@ -556,7 +559,7 @@ class AdminController < ApplicationController
     end
   end
 
-  def header_image_file
+  def set_header_image_file
     if params[:header_image_file]
       file_io = params[:header_image_file]
       avatar = Avatar.new(original_filename: file_io.original_filename, image_file: file_io, skip_owner_validation: true)
@@ -621,23 +624,6 @@ class AdminController < ApplicationController
   end
 
   private
-
-  def created_at_data_for_model(model)
-    x = {}
-    start = '1 Nov 2008'
-
-    x[Date.parse(start).jd] = 0
-    x[Date.today.jd] = 0
-
-    model.order(:created_at).each do |i|
-      date = i.created_at.to_date
-      day = date.jd
-      x[day] ||= 0
-      x[day] += 1
-    end
-    sorted_keys = x.keys.sort
-    (sorted_keys.first..sorted_keys.last).map { |i| x[i].nil? ? 0 : x[i] }
-  end
 
   def check_valid_email(email_address, field)
     if email_address.blank? || email_address =~ /^([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})$/

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -94,6 +94,13 @@ class AdminController < ApplicationController
     Seek::Config.omniauth_github_client_id = params[:omniauth_github_client_id]
     Seek::Config.omniauth_github_secret = params[:omniauth_github_secret]
 
+    Seek::Config.omniauth_oidc_enabled = string_to_boolean params[:omniauth_oidc_enabled]
+    Seek::Config.omniauth_oidc_name = params[:omniauth_oidc_name]
+    params[:omniauth_oidc_issuer] = params[:omniauth_oidc_issuer].chomp('/') + '/' if params[:omniauth_oidc_issuer].present?
+    Seek::Config.omniauth_oidc_issuer = params[:omniauth_oidc_issuer]
+    Seek::Config.omniauth_oidc_client_id = params[:omniauth_oidc_client_id]
+    Seek::Config.omniauth_oidc_secret = params[:omniauth_oidc_secret]
+
     Seek::Config.solr_enabled = string_to_boolean params[:solr_enabled]
     Seek::Config.filtering_enabled = string_to_boolean params[:filtering_enabled]
     Seek::Config.jws_enabled = string_to_boolean params[:jws_enabled]

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -89,6 +89,7 @@ class AdminController < ApplicationController
     Seek::Config.omniauth_elixir_aai_enabled = string_to_boolean params[:omniauth_elixir_aai_enabled]
     Seek::Config.omniauth_elixir_aai_client_id = params[:omniauth_elixir_aai_client_id]
     Seek::Config.omniauth_elixir_aai_secret = params[:omniauth_elixir_aai_secret]
+    Seek::Config.omniauth_elixir_aai_legacy_mode = string_to_boolean params[:omniauth_elixir_aai_legacy_mode]
 
     Seek::Config.omniauth_github_enabled = string_to_boolean params[:omniauth_github_enabled]
     Seek::Config.omniauth_github_client_id = params[:omniauth_github_client_id]

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -56,6 +56,8 @@ class SessionsController < ApplicationController
     error = "#{t("login.#{params[:strategy]}")} authentication failure"
     error += " (#{failure_message})" if failure_message
     flash[:error] = error
+    # Ideally we would return to the original "return_to", prior to the error, but it gets lost somewhere along the way.
+    params[:return_to] = root_path
     respond_to do |format|
       format.html { render :new }
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -30,6 +30,8 @@ class SessionsController < ApplicationController
                            Seek::Config.omniauth_ldap_enabled
                          when 'elixir_aai'
                            Seek::Config.omniauth_elixir_aai_enabled
+                         when 'oidc'
+                           Seek::Config.omniauth_oidc_enabled
                          else
                            true
                          end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -45,7 +45,17 @@ class SessionsController < ApplicationController
   end
 
   def omniauth_failure
-    flash[:error] = "#{t("login.#{params[:strategy]}")} authentication failure (Invalid username/password?)"
+    failure_message = case params[:message]
+                      when 'invalid_credentials'
+                        'Invalid username/password'
+                      when 'missing_credentials'
+                        'Missing credentials'
+                      else
+                        nil
+                      end
+    error = "#{t("login.#{params[:strategy]}")} authentication failure"
+    error += " (#{failure_message})" if failure_message
+    flash[:error] = error
     respond_to do |format|
       format.html { render :new }
     end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -47,4 +47,8 @@ module SessionsHelper
   def show_github_login?
     Seek::Config.omniauth_github_enabled
   end
+
+  def show_oidc_login?
+    Seek::Config.omniauth_oidc_enabled
+  end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -51,4 +51,11 @@ module SessionsHelper
   def show_oidc_login?
     Seek::Config.omniauth_oidc_enabled
   end
+
+  def omniauth_method_name(key)
+    name = nil
+    name = Seek::Config.omniauth_oidc_name if key == :oidc
+    name = t("login.#{key}") if name.blank?
+    name
+  end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -58,4 +58,14 @@ module SessionsHelper
     name = t("login.#{key}") if name.blank?
     name
   end
+
+  def oidc_login_button(original_path)
+    text = "Sign in with #{Seek::Config.omniauth_oidc_name}"
+    link = omniauth_authorize_path(:oidc, state: "return_to:#{original_path}")
+    if Seek::Config.omniauth_oidc_image_id && (avatar = Avatar.find_by_id(Seek::Config.omniauth_oidc_image_id))
+      link_to(image_tag(avatar.public_asset_url, alt: text), link, method: :post)
+    else
+      button_link_to(text, 'lock', link, method: :post)
+    end
+  end
 end

--- a/app/views/admin/_omniauth.html.erb
+++ b/app/views/admin/_omniauth.html.erb
@@ -37,48 +37,93 @@
   <%= admin_checkbox_setting(:omniauth_elixir_aai_enabled, 1, Seek::Config.omniauth_elixir_aai_enabled,
                              "#{t('login.elixir_aai')} authentication", "Enables use of #{t('login.elixir_aai')} for authentication.",
                              onchange: toggle_appear_javascript('omniauth_elixir_aai_settings')) %>
-  <div id="omniauth_elixir_aai_settings" class="additional_settings" style="<%= show_or_hide_block(Seek::Config.omniauth_elixir_aai_enabled) -%>;">
-    <%= admin_text_setting(:omniauth_elixir_aai_client_id, Seek::Config.omniauth_elixir_aai_client_id,
-                           "#{t('login.elixir_aai')} Client ID", "The client ID provided by #{t('login.elixir_aai')} for your installation.") %>
-    <%= admin_password_setting(:omniauth_elixir_aai_secret, Seek::Config.omniauth_elixir_aai_secret,
-                               "#{t('login.elixir_aai')} Secret", "The secret key provided by #{t('login.elixir_aai')} for your installation.") %>
+  <div id="omniauth_elixir_aai_settings" class="additional_settings row" style="<%= show_or_hide_block(Seek::Config.omniauth_elixir_aai_enabled) -%>;">
+    <div class="row">
+      <div class="col-sm-7">
+        <%= admin_text_setting(:omniauth_elixir_aai_client_id, Seek::Config.omniauth_elixir_aai_client_id,
+                               "#{t('login.elixir_aai')} Client ID", "The client ID provided by #{t('login.elixir_aai')} for your installation.") %>
+        <%= admin_password_setting(:omniauth_elixir_aai_secret, Seek::Config.omniauth_elixir_aai_secret,
+                                   "#{t('login.elixir_aai')} Secret", "The secret key provided by #{t('login.elixir_aai')} for your installation.") %>
+      </div>
+      <div class="col-sm-5">
+        <%= panel('Client Info') do %>
+          <p class="help-block">
+            Provide this info to <%= t('login.elixir_aai') %> when registering your SEEK instance as a relying party.
+          </p>
+          <label>Redirect URI</label><br/>
+          <pre><%= omniauth_callback_url('elixir_aai') %></pre>
+          <br/>
+          <label>Grant type</label><br/>
+          <pre>authorization_code</pre>
+        <% end %>
+      </div>
+    </div>
   </div>
 
   <%= admin_checkbox_setting(:omniauth_github_enabled, 1, Seek::Config.omniauth_github_enabled,
                              "GitHub authentication", "Enables use of GitHub for authentication.",
                              onchange: toggle_appear_javascript('omniauth_github_settings')) %>
   <div id="omniauth_github_settings" class="additional_settings" style="<%= show_or_hide_block(Seek::Config.omniauth_github_enabled) -%>;">
-    <%= admin_text_setting(:omniauth_github_client_id, Seek::Config.omniauth_github_client_id,
-                           'GitHub Client ID', 'The client ID provided by GitHub for your installation.') %>
-    <%= admin_password_setting(:omniauth_github_secret, Seek::Config.omniauth_github_secret,
-                               'GitHub Secret', 'The secret key provided by GitHub for your installation.') %>
+    <div class="row">
+      <div class="col-sm-7">
+        <%= admin_text_setting(:omniauth_github_client_id, Seek::Config.omniauth_github_client_id,
+                               'GitHub Client ID', 'The client ID provided by GitHub for your installation.') %>
+        <%= admin_password_setting(:omniauth_github_secret, Seek::Config.omniauth_github_secret,
+                                   'GitHub Secret', 'The secret key provided by GitHub for your installation.') %>
+      </div>
+      <div class="col-sm-5">
+        <%= panel('Client Info') do %>
+          <p class="help-block">
+            Provide this info to GitHub when registering your SEEK instance as an OAuth App.
+          </p>
+          <label>Authorization callback URL</label><br/>
+          <pre><%= omniauth_callback_url('github') %></pre>
+        <% end %>
+      </div>
+    </div>
   </div>
 
   <%= admin_checkbox_setting(:omniauth_oidc_enabled, 1, Seek::Config.omniauth_oidc_enabled,
                              "#{t('login.oidc')} authentication", "Enables use of a #{t('login.oidc')} provider for authentication.",
                              onchange: toggle_appear_javascript('omniauth_oidc_settings')) %>
   <div id="omniauth_oidc_settings" class="additional_settings" style="<%= show_or_hide_block(Seek::Config.omniauth_oidc_enabled) -%>;">
-    <%= admin_text_setting(:omniauth_oidc_name, Seek::Config.omniauth_oidc_name,
-                           "#{t('login.oidc')} Name", "The name of this authentication method that will be displayed to users.") %>
-    <%= admin_file_setting(:omniauth_oidc_image,
-                           "#{t('login.oidc')} Login Image", "An image to use as the login button for #{t('login.oidc')}.") %>
-    <% if Seek::Config.omniauth_oidc_image_id && (oidc_image = Avatar.find_by_id(Seek::Config.omniauth_oidc_image_id)) %>
-      <div>
-        Current image:<br/>
-        <%= image_tag(oidc_image.public_asset_url) %>
-        <div class="checkbox">
-          <label>
-            <%= check_box_tag(:clear_omniauth_oidc_image, '1', false) %>
-            Remove image?
-          </label>
-        </div>
+    <div class="row">
+      <div class="col-sm-7">
+        <%= admin_text_setting(:omniauth_oidc_name, Seek::Config.omniauth_oidc_name,
+                               "#{t('login.oidc')} Name", "The name of this authentication method that will be displayed to users.") %>
+        <%= admin_file_setting(:omniauth_oidc_image,
+                               "#{t('login.oidc')} Login Image", "An image to use as the login button for #{t('login.oidc')}.") %>
+        <% if Seek::Config.omniauth_oidc_image_id && (oidc_image = Avatar.find_by_id(Seek::Config.omniauth_oidc_image_id)) %>
+          <div>
+            Current image:<br/>
+            <%= image_tag(oidc_image.public_asset_url) %>
+            <div class="checkbox">
+              <label>
+                <%= check_box_tag(:clear_omniauth_oidc_image, '1', false) %>
+                Remove image?
+              </label>
+            </div>
+          </div>
+        <% end %>
+        <%= admin_text_setting(:omniauth_oidc_issuer, Seek::Config.omniauth_oidc_issuer,
+                               "#{t('login.oidc')} URL", "The base URL of the #{t('login.oidc')} provider. It is expected that the discovery endpoint <code>/.well-known/openid-configuration</code> exists under this URL.") %>
+        <%= admin_text_setting(:omniauth_oidc_client_id, Seek::Config.omniauth_oidc_client_id,
+                               "#{t('login.oidc')} Client ID", "The client ID to use to authenticate with the #{t('login.oidc')} provider.") %>
+        <%= admin_password_setting(:omniauth_oidc_secret, Seek::Config.omniauth_oidc_secret,
+                                   "#{t('login.oidc')} Secret", "The secret to use to authenticate with the #{t('login.oidc')} provider.") %>
       </div>
-    <% end %>
-    <%= admin_text_setting(:omniauth_oidc_issuer, Seek::Config.omniauth_oidc_issuer,
-                           "#{t('login.oidc')} URL", "The base URL of the #{t('login.oidc')} provider. It is expected that the discovery endpoint <code>/.well-known/openid-configuration</code> exists under this URL.") %>
-    <%= admin_text_setting(:omniauth_oidc_client_id, Seek::Config.omniauth_oidc_client_id,
-                           "#{t('login.oidc')} Client ID", "The client ID to use to authenticate with the #{t('login.oidc')} provider.") %>
-    <%= admin_password_setting(:omniauth_oidc_secret, Seek::Config.omniauth_oidc_secret,
-                               "#{t('login.oidc')} Secret", "The secret to use to authenticate with the #{t('login.oidc')} provider.") %>
+      <div class="col-sm-5">
+        <%= panel('Client Info') do %>
+          <p class="help-block">
+            Provide this info to the <%= t('login.oidc') %> provider when registering your SEEK instance as a relying party.
+          </p>
+          <label>Redirect URI</label><br/>
+          <pre><%= omniauth_callback_url('oidc') %></pre>
+          <br/>
+          <label>Grant type</label><br/>
+          <pre>authorization_code</pre>
+        <% end %>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/views/admin/_omniauth.html.erb
+++ b/app/views/admin/_omniauth.html.erb
@@ -44,6 +44,8 @@
                                "#{t('login.elixir_aai')} Client ID", "The client ID provided by #{t('login.elixir_aai')} for your installation.") %>
         <%= admin_password_setting(:omniauth_elixir_aai_secret, Seek::Config.omniauth_elixir_aai_secret,
                                    "#{t('login.elixir_aai')} Secret", "The secret key provided by #{t('login.elixir_aai')} for your installation.") %>
+        <%= admin_checkbox_setting(:omniauth_elixir_aai_legacy_mode, 1, Seek::Config.omniauth_elixir_aai_legacy_mode,
+                                   "Use legacy configuration", "Use this if your client was registered prior to the transition from #{t('login.elixir_aai_legacy')} to #{t('login.elixir_aai')}.") %>
       </div>
       <div class="col-sm-5">
         <%= panel('Client Info') do %>

--- a/app/views/admin/_omniauth.html.erb
+++ b/app/views/admin/_omniauth.html.erb
@@ -60,6 +60,20 @@
   <div id="omniauth_oidc_settings" class="additional_settings" style="<%= show_or_hide_block(Seek::Config.omniauth_oidc_enabled) -%>;">
     <%= admin_text_setting(:omniauth_oidc_name, Seek::Config.omniauth_oidc_name,
                            "#{t('login.oidc')} Name", "The name of this authentication method that will be displayed to users.") %>
+    <%= admin_file_setting(:omniauth_oidc_image,
+                           "#{t('login.oidc')} Login Image", "An image to use as the login button for #{t('login.oidc')}.") %>
+    <% if Seek::Config.omniauth_oidc_image_id && (oidc_image = Avatar.find_by_id(Seek::Config.omniauth_oidc_image_id)) %>
+      <div>
+        Current image:<br/>
+        <%= image_tag(oidc_image.public_asset_url) %>
+        <div class="checkbox">
+          <label>
+            <%= check_box_tag(:clear_omniauth_oidc_image, '1', false) %>
+            Remove image?
+          </label>
+        </div>
+      </div>
+    <% end %>
     <%= admin_text_setting(:omniauth_oidc_issuer, Seek::Config.omniauth_oidc_issuer,
                            "#{t('login.oidc')} URL", "The base URL of the #{t('login.oidc')} provider. It is expected that the discovery endpoint <code>/.well-known/openid-configuration</code> exists under this URL.") %>
     <%= admin_text_setting(:omniauth_oidc_client_id, Seek::Config.omniauth_oidc_client_id,

--- a/app/views/admin/_omniauth.html.erb
+++ b/app/views/admin/_omniauth.html.erb
@@ -53,4 +53,18 @@
     <%= admin_password_setting(:omniauth_github_secret, Seek::Config.omniauth_github_secret,
                                'GitHub Secret', 'The secret key provided by GitHub for your installation.') %>
   </div>
+
+  <%= admin_checkbox_setting(:omniauth_oidc_enabled, 1, Seek::Config.omniauth_oidc_enabled,
+                             "#{t('login.oidc')} authentication", "Enables use of a #{t('login.oidc')} provider for authentication.",
+                             onchange: toggle_appear_javascript('omniauth_oidc_settings')) %>
+  <div id="omniauth_oidc_settings" class="additional_settings" style="<%= show_or_hide_block(Seek::Config.omniauth_oidc_enabled) -%>;">
+    <%= admin_text_setting(:omniauth_oidc_name, Seek::Config.omniauth_oidc_name,
+                           "#{t('login.oidc')} Name", "The name of this authentication method that will be displayed to users.") %>
+    <%= admin_text_setting(:omniauth_oidc_issuer, Seek::Config.omniauth_oidc_issuer,
+                           "#{t('login.oidc')} URL", "The base URL of the #{t('login.oidc')} provider. It is expected that the discovery endpoint <code>/.well-known/openid-configuration</code> exists under this URL.") %>
+    <%= admin_text_setting(:omniauth_oidc_client_id, Seek::Config.omniauth_oidc_client_id,
+                           "#{t('login.oidc')} Client ID", "The client ID to use to authenticate with the #{t('login.oidc')} provider.") %>
+    <%= admin_password_setting(:omniauth_oidc_secret, Seek::Config.omniauth_oidc_secret,
+                               "#{t('login.oidc')} Secret", "The secret to use to authenticate with the #{t('login.oidc')} provider.") %>
+  </div>
 </div>

--- a/app/views/admin/features_enabled.html.erb
+++ b/app/views/admin/features_enabled.html.erb
@@ -1,6 +1,6 @@
 <h1>Enable or disable features</h1>
 
-<%= form_tag :action=>"update_features_enabled" do -%>
+<%= form_tag({ action: 'update_features_enabled' }, multipart: true) do -%>
   <h2>SEEK services</h2>
   <%= admin_checkbox_setting(:solr_enabled, 1, Seek::Config.solr_enabled,
                              "Search enabled", "Whether the search is enabled. If switched on you need to ensure SOLR is running and its index is up to date. You need to restart both the server, and the Background service, after changing this setting.") %>

--- a/app/views/gadgets/_sign_in.html.erb
+++ b/app/views/gadgets/_sign_in.html.erb
@@ -31,6 +31,11 @@
                 <a href="#github_login" aria-controls="github_login" role="tab" data-toggle="tab"><%= t('login.github') %></a>
               <% end %>
             <% end %>
+            <% if show_oidc_login? %>
+              <%= content_tag(:li, role: 'presentation', class: strategy == 'oidc' ? 'active' : nil) do %>
+                <a href="#oidc_login" aria-controls="oidc_login" role="tab" data-toggle="tab"><%= Seek::Config.omniauth_oidc_name %></a>
+              <% end %>
+            <% end %>
           </ul>
         <% end #omniauth enabled and providers available %>
 
@@ -80,6 +85,13 @@
               <%= content_tag(:div, id: 'github_login', role: 'tabpanel', class: strategy == 'github' ? 'tab-pane active' : 'tab-pane') do %>
                 <div class='text-center'>
                   <%= button_link_to 'Sign in with GitHub', 'github_large', omniauth_authorize_path(:github, state: "return_to:#{original_path}"), method: :post %>
+                </div>
+              <% end %>
+            <% end %>
+            <% if show_oidc_login? %>
+              <%= content_tag(:div, id: 'oidc_login', role: 'tabpanel', class: strategy == 'oidc' ? 'tab-pane active' : 'tab-pane') do %>
+                <div class='text-center'>
+                  <%= button_link_to Seek::Config.omniauth_oidc_name, 'lock', omniauth_authorize_path(:oidc, state: "return_to:#{original_path}"), method: :post %>
                 </div>
               <% end %>
             <% end %>

--- a/app/views/gadgets/_sign_in.html.erb
+++ b/app/views/gadgets/_sign_in.html.erb
@@ -91,7 +91,7 @@
             <% if show_oidc_login? %>
               <%= content_tag(:div, id: 'oidc_login', role: 'tabpanel', class: strategy == 'oidc' ? 'tab-pane active' : 'tab-pane') do %>
                 <div class='text-center'>
-                  <%= button_link_to Seek::Config.omniauth_oidc_name, 'lock', omniauth_authorize_path(:oidc, state: "return_to:#{original_path}"), method: :post %>
+                  <%= oidc_login_button(original_path) %>
                 </div>
               <% end %>
             <% end %>

--- a/app/views/gadgets/_sign_in.html.erb
+++ b/app/views/gadgets/_sign_in.html.erb
@@ -18,22 +18,22 @@
             <% end %>
             <% if show_elixir_aai_login? %>
               <%= content_tag(:li, role: 'presentation', class: strategy == 'elixir_aai' ? 'active' : nil) do %>
-                <a href="#elixir_aai_login" aria-controls="elixir_aai_login" role="tab" data-toggle="tab"><%= t('login.elixir_aai') %></a>
+                <a href="#elixir_aai_login" aria-controls="elixir_aai_login" role="tab" data-toggle="tab"><%= omniauth_method_name(:elixir_aai) %></a>
               <% end %>
             <% end %>
             <% if show_ldap_login? %>
               <%= content_tag(:li, role: 'presentation', class: strategy == 'ldap' ? 'active' : nil) do %>
-                <a href="#ldap_login" aria-controls="ldap_login" role="tab" data-toggle="tab"><%= t('login.ldap') %></a>
+                <a href="#ldap_login" aria-controls="ldap_login" role="tab" data-toggle="tab"><%= omniauth_method_name(:ldap) %></a>
               <% end %>
             <% end %>
             <% if show_github_login? %>
               <%= content_tag(:li, role: 'presentation', class: strategy == 'github' ? 'active' : nil) do %>
-                <a href="#github_login" aria-controls="github_login" role="tab" data-toggle="tab"><%= t('login.github') %></a>
+                <a href="#github_login" aria-controls="github_login" role="tab" data-toggle="tab"><%= omniauth_method_name(:github) %></a>
               <% end %>
             <% end %>
             <% if show_oidc_login? %>
               <%= content_tag(:li, role: 'presentation', class: strategy == 'oidc' ? 'active' : nil) do %>
-                <a href="#oidc_login" aria-controls="oidc_login" role="tab" data-toggle="tab"><%= Seek::Config.omniauth_oidc_name %></a>
+                <a href="#oidc_login" aria-controls="oidc_login" role="tab" data-toggle="tab"><%= omniauth_method_name(:oidc) %></a>
               <% end %>
             <% end %>
           </ul>

--- a/app/views/identities/index.html.erb
+++ b/app/views/identities/index.html.erb
@@ -10,6 +10,9 @@
     <% if Seek::Config.omniauth_github_enabled %>
       <li><%= link_to(t("login.github"), omniauth_authorize_path(:github), method: :post) -%></li>
     <% end %>
+    <% if Seek::Config.omniauth_oidc_enabled %>
+      <li><%= link_to(Seek::Config.omniauth_oidc_name, omniauth_authorize_path(:oidc), method: :post) -%></li>
+    <% end %>
   <% end %>
 </div>
 

--- a/app/views/identities/index.html.erb
+++ b/app/views/identities/index.html.erb
@@ -2,16 +2,16 @@
 <div class="pull-right">
   <%= dropdown_button('Add identity', 'add') do %>
     <% if Seek::Config.omniauth_elixir_aai_enabled %>
-      <li><%= link_to(t("login.elixir_aai"), omniauth_authorize_path(:elixir_aai), method: :post) -%></li>
+      <li><%= link_to(omniauth_method_name(:elixir_aai), omniauth_authorize_path(:elixir_aai), method: :post) -%></li>
     <% end %>
     <% if Seek::Config.omniauth_ldap_enabled %>
-      <li><%= link_to(t("login.ldap"), '#', 'data-toggle' => 'modal', 'data-target' => "#ldap-form") -%></li>
+      <li><%= link_to(omniauth_method_name(:ldap), '#', 'data-toggle' => 'modal', 'data-target' => "#ldap-form") -%></li>
     <% end %>
     <% if Seek::Config.omniauth_github_enabled %>
-      <li><%= link_to(t("login.github"), omniauth_authorize_path(:github), method: :post) -%></li>
+      <li><%= link_to(omniauth_method_name(:github), omniauth_authorize_path(:github), method: :post) -%></li>
     <% end %>
     <% if Seek::Config.omniauth_oidc_enabled %>
-      <li><%= link_to(Seek::Config.omniauth_oidc_name, omniauth_authorize_path(:oidc), method: :post) -%></li>
+      <li><%= link_to(omniauth_method_name(:oidc), omniauth_authorize_path(:oidc), method: :post) -%></li>
     <% end %>
   <% end %>
 </div>
@@ -48,7 +48,7 @@
       <tbody>
       <% @identities.each do |identity| %>
         <tr>
-          <td><%= t("login.#{identity.provider}") %></td>
+          <td><%= omniauth_method_name(identity.provider.to_sym) %></td>
           <td><%= content_tag(:pre, identity.uid) %></td>
           <td><%= identity.created_at %></td>
           <td>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -90,6 +90,9 @@
       <% end %>
       </li>
     <% end %>
+    <% if show_oidc_login? %>
+      <li><%= link_to "Log in using #{Seek::Config.omniauth_oidc_name}", omniauth_authorize_path(:oidc, state: "return_to:/") %></li>
+    <% end %>
   </ul>
 <% end %>
 

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -75,23 +75,23 @@
     <% if show_elixir_aai_login? %>
       <li>
         <%= link_to(omniauth_authorize_path(:elixir_aai, state: "return_to:/"), method: :post) do %>
-          Log in using <%= t('login.elixir_aai') -%><br/>
+          Log in using <%= omniauth_method_name(:elixir_aai) -%><br/>
           <%= image('elixir_aai_login') %>
         <% end %>
       </li>
     <% end %>
     <% if show_ldap_login? %>
-      <li><%= link_to "Log in using #{t('login.ldap')}", login_path(anchor: 'ldap_login') %></li>
+      <li><%= link_to "Log in using #{omniauth_method_name(:ldap)}", login_path(anchor: 'ldap_login') %></li>
     <% end %>
     <% if show_github_login? %>
       <li>
         <%= link_to(omniauth_authorize_path(:github, state: "return_to:/"), method: :post) do%>
-          Log in using <%= t('login.github') -%> <%= image('github') %>
+          Log in using <%= omniauth_method_name(:github) -%> <%= image('github') %>
       <% end %>
       </li>
     <% end %>
     <% if show_oidc_login? %>
-      <li><%= link_to "Log in using #{Seek::Config.omniauth_oidc_name}", omniauth_authorize_path(:oidc, state: "return_to:/") %></li>
+      <li><%= link_to "Log in using #{omniauth_method_name(:oidc)}", omniauth_authorize_path(:oidc, state: "return_to:/") %></li>
     <% end %>
   </ul>
 <% end %>

--- a/config/initializers/seek_configuration.rb
+++ b/config/initializers/seek_configuration.rb
@@ -237,6 +237,8 @@ def load_seek_config_defaults!
     password: '',
     bind_dn: ''
   }
+  Seek::Config.default :omniauth_oidc_enabled, false
+  Seek::Config.default :omniauth_oidc_name, 'OpenID Connect Provider'
 
   Seek::Config.default :openbis_enabled,false
   Seek::Config.default :openbis_download_limit, 2.gigabytes

--- a/config/initializers/seek_omniauth.rb
+++ b/config/initializers/seek_omniauth.rb
@@ -7,7 +7,7 @@ if Seek::Config.omniauth_enabled
     begin
       providers = Seek::Config.omniauth_providers
     rescue Settings::DecryptionError
-      providers = {}
+      providers = []
     end
 
     providers.each do |key, options|

--- a/config/initializers/seek_testing.rb
+++ b/config/initializers/seek_testing.rb
@@ -131,6 +131,12 @@ def load_seek_testing_defaults!
       Settings.defaults[:omniauth_github_client_id] = 'abc'
       Settings.defaults[:omniauth_github_secret] = '456'
 
+      Settings.defaults[:omniauth_oidc_enabled] = true
+      Settings.defaults[:omniauth_oidc_name] = 'SEEK Testing OIDC'
+      Settings.defaults[:omniauth_oidc_issuer] = 'https://example.com/oidc/'
+      Settings.defaults[:omniauth_oidc_client_id] = 'def'
+      Settings.defaults[:omniauth_oidc_secret] = '789'
+
       Settings.defaults[:ga4gh_trs_api_enabled] = true
 
       Settings.defaults[:life_monitor_url] = 'https://localhost:8443'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,7 @@ en:
 
   login:
     elixir_aai: 'LS Login'
+    elixir_aai_legacy: 'ELIXIR AAI'
     ldap: 'LDAP'
     github: 'GitHub'
     oidc: 'OpenID Connect'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,7 @@ en:
     elixir_aai: 'LS Login'
     ldap: 'LDAP'
     github: 'GitHub'
+    oidc: 'OpenID Connect'
 
   single_page: "Single Page"
   default_view: "Default View"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -822,7 +822,7 @@ SEEK::Application.routes.draw do
   # Omniauth
   post '/auth/:provider' => 'sessions#create', as: :omniauth_authorize # For security, ONLY POST should be enabled on this route.
   match '/auth/:provider/callback' => 'sessions#create', as: :omniauth_callback, via: [:get, :post] # Callback routes need both GET and POST enabled.
-  match '/identities/auth/:provider/callback' => 'sessions#create', via: [:get, :post] # Needed for legacy support..
+  match '/identities/auth/:provider/callback' => 'sessions#create', as: :legacy_omniauth_callback, via: [:get, :post] # Needed for legacy support..
   get '/auth/failure' => 'sessions#omniauth_failure', as: :omniauth_failure
 
   get '/activate(/:activation_code)' => 'users#activate', as: :activate

--- a/lib/seek/config.rb
+++ b/lib/seek/config.rb
@@ -378,24 +378,26 @@ module Seek
     def omniauth_oidc_config
       # Cannot use url helpers here because routes are not loaded at this point :( -Finn
       callback_path = 'identities/auth/oidc/callback'
-
-      omniauth_oidc_settings.merge(
-        {
-          callback_path: "#{Rails.application.config.relative_url_root}/#{callback_path}",
-          name: :oidc,
-          response_type: 'code',
-          discovery: true,
-          client_options: omniauth_oidc_settings.merge(
-            redirect_uri: site_base_url.join(callback_path).to_s)
-        })
+      {
+        callback_path: "#{Rails.application.config.relative_url_root}/#{callback_path}",
+        issuer: omniauth_oidc_issuer,
+        name: :oidc,
+        response_type: 'code',
+        discovery: true,
+        client_options: {
+          identifier: omniauth_oidc_client_id,
+          secret: omniauth_oidc_secret,
+          redirect_uri: site_base_url.join(callback_path).to_s
+        }
+      }
     end
 
     def omniauth_providers
-      providers = {}
-      providers[:ldap] = omniauth_ldap_config.merge(name: :ldap, form: SessionsController.action(:new)) if omniauth_ldap_enabled
-      providers[:openid_connect] = omniauth_elixir_aai_config if omniauth_elixir_aai_enabled
-      providers[:github] = omniauth_github_config if omniauth_github_enabled
-      providers[:oidc] = omniauth_oidc_config if omniauth_oidc_enabled
+      providers = []
+      providers << [:ldap, omniauth_ldap_config.merge(name: :ldap, form: SessionsController.action(:new))] if omniauth_ldap_enabled
+      providers << [:github, omniauth_github_config] if omniauth_github_enabled
+      providers << [:openid_connect, omniauth_elixir_aai_config] if omniauth_elixir_aai_enabled
+      providers << [:openid_connect, omniauth_oidc_config] if omniauth_oidc_enabled
       providers
     end
   end

--- a/lib/seek/config.rb
+++ b/lib/seek/config.rb
@@ -333,33 +333,47 @@ module Seek
     end
 
     def omniauth_elixir_aai_config
-      # Cannot use url helpers here because routes are not loaded at this point :( -Finn
-      callback_path = 'identities/auth/elixir_aai/callback'
-
-      {
-          callback_path: "#{Rails.application.config.relative_url_root}/#{callback_path}",
+      if omniauth_elixir_aai_legacy_mode
+        {
+            callback_path: omniauth_callback_path('elixir_aai'),
+            name: :elixir_aai,
+            scope: [:openid, :email],
+            response_type: 'code',
+            issuer: 'https://login.elixir-czech.org/oidc/',
+            # I had an issue using discovery in the past, maybe it works now?
+            discovery: false,
+            send_nonce: true,
+            client_signing_alg: :RS256,
+            # The following is obtained from: https://login.elixir-czech.org/oidc/jwk
+            client_jwk_signing_key: '{"keys":[{"kty":"RSA","e":"AQAB","kid":"rsa1","alg":"RS256","n":"uVHPfUHVEzpgOnDNi3e2pVsbK1hsINsTy_1mMT7sxDyP-1eQSjzYsGSUJ3GHq9LhiVndpwV8y7Enjdj0purywtwk_D8z9IIN36RJAh1yhFfbyhLPEZlCDdzxas5Dku9k0GrxQuV6i30Mid8OgRQ2q3pmsks414Afy6xugC6u3inyjLzLPrhR0oRPTGdNMXJbGw4sVTjnh5AzTgX-GrQWBHSjI7rMTcvqbbl7M8OOhE3MQ_gfVLXwmwSIoKHODC0RO-XnVhqd7Qf0teS1JiILKYLl5FS_7Uy2ClVrAYd2T6X9DIr_JlpRkwSD899pq6PR9nhKguipJE0qUXxamdY9nw"}]}',
+            client_options: {
+                identifier: omniauth_elixir_aai_client_id,
+                secret: omniauth_elixir_aai_secret,
+                redirect_uri: omniauth_redirect_uri('elixir_aai'),
+                scheme: 'https',
+                host: 'login.elixir-czech.org',
+                port: 443,
+                authorization_endpoint: '/oidc/authorize',
+                token_endpoint: '/oidc/token',
+                userinfo_endpoint: '/oidc/userinfo',
+                jwks_uri: '/oidc/jwk',
+            }
+        }
+      else
+        {
+          callback_path: omniauth_callback_path('elixir_aai'),
           name: :elixir_aai,
           scope: [:openid, :email],
           response_type: 'code',
-          issuer: 'https://login.elixir-czech.org/oidc/',
-          discovery: false,
-          send_nonce: true,
-          client_signing_alg: :RS256,
-          # The following is obtained from: https://login.elixir-czech.org/oidc/jwk
-          client_jwk_signing_key: '{"keys":[{"kty":"RSA","e":"AQAB","kid":"rsa1","alg":"RS256","n":"uVHPfUHVEzpgOnDNi3e2pVsbK1hsINsTy_1mMT7sxDyP-1eQSjzYsGSUJ3GHq9LhiVndpwV8y7Enjdj0purywtwk_D8z9IIN36RJAh1yhFfbyhLPEZlCDdzxas5Dku9k0GrxQuV6i30Mid8OgRQ2q3pmsks414Afy6xugC6u3inyjLzLPrhR0oRPTGdNMXJbGw4sVTjnh5AzTgX-GrQWBHSjI7rMTcvqbbl7M8OOhE3MQ_gfVLXwmwSIoKHODC0RO-XnVhqd7Qf0teS1JiILKYLl5FS_7Uy2ClVrAYd2T6X9DIr_JlpRkwSD899pq6PR9nhKguipJE0qUXxamdY9nw"}]}',
+          issuer: 'https://proxy.aai.lifescience-ri.eu/',
+          discovery: true,
           client_options: {
-              identifier: omniauth_elixir_aai_client_id,
-              secret: omniauth_elixir_aai_secret,
-              redirect_uri: site_base_url.join(callback_path).to_s,
-              scheme: 'https',
-              host: 'login.elixir-czech.org',
-              port: 443,
-              authorization_endpoint: '/oidc/authorize',
-              token_endpoint: '/oidc/token',
-              userinfo_endpoint: '/oidc/userinfo',
-              jwks_uri: '/oidc/jwk',
+            identifier: omniauth_elixir_aai_client_id,
+            secret: omniauth_elixir_aai_secret,
+            redirect_uri: omniauth_redirect_uri('elixir_aai'),
           }
-      }
+        }
+      end
     end
 
     def omniauth_ldap_settings(field)
@@ -376,10 +390,8 @@ module Seek
     end
 
     def omniauth_oidc_config
-      # Cannot use url helpers here because routes are not loaded at this point :( -Finn
-      callback_path = 'identities/auth/oidc/callback'
       {
-        callback_path: "#{Rails.application.config.relative_url_root}/#{callback_path}",
+        callback_path: omniauth_callback_path('oidc'),
         issuer: omniauth_oidc_issuer,
         name: :oidc,
         response_type: 'code',
@@ -387,7 +399,7 @@ module Seek
         client_options: {
           identifier: omniauth_oidc_client_id,
           secret: omniauth_oidc_secret,
-          redirect_uri: site_base_url.join(callback_path).to_s
+          redirect_uri: omniauth_redirect_uri('oidc')
         }
       }
     end
@@ -413,6 +425,17 @@ module Seek
       providers << [:openid_connect, omniauth_elixir_aai_config] if omniauth_elixir_aai_enabled
       providers << [:openid_connect, omniauth_oidc_config] if omniauth_oidc_enabled
       providers
+    end
+
+    private
+
+    def omniauth_callback_path(provider)
+      # Cannot use url helpers here because routes are not loaded at this point :( -Finn
+      "#{Rails.application.config.relative_url_root}/identities/auth/#{provider}/callback"
+    end
+
+    def omniauth_redirect_uri(provider)
+      site_base_url.join("identities/auth/#{provider}/callback").to_s
     end
   end
 

--- a/lib/seek/config.rb
+++ b/lib/seek/config.rb
@@ -335,7 +335,7 @@ module Seek
     def omniauth_elixir_aai_config
       if omniauth_elixir_aai_legacy_mode
         {
-            callback_path: omniauth_callback_path('elixir_aai'),
+            callback_path: legacy_omniauth_callback_path('elixir_aai'),
             name: :elixir_aai,
             scope: [:openid, :email],
             response_type: 'code',
@@ -349,7 +349,7 @@ module Seek
             client_options: {
                 identifier: omniauth_elixir_aai_client_id,
                 secret: omniauth_elixir_aai_secret,
-                redirect_uri: omniauth_redirect_uri('elixir_aai'),
+                redirect_uri: legacy_omniauth_redirect_uri('elixir_aai'),
                 scheme: 'https',
                 host: 'login.elixir-czech.org',
                 port: 443,
@@ -429,12 +429,20 @@ module Seek
 
     private
 
+    # Cannot use url helpers here because routes are not loaded at this point :( -Finn
     def omniauth_callback_path(provider)
-      # Cannot use url helpers here because routes are not loaded at this point :( -Finn
+      "#{Rails.application.config.relative_url_root}/auth/#{provider}/callback"
+    end
+
+    def legacy_omniauth_callback_path(provider)
       "#{Rails.application.config.relative_url_root}/identities/auth/#{provider}/callback"
     end
 
     def omniauth_redirect_uri(provider)
+      site_base_url.join("auth/#{provider}/callback").to_s
+    end
+
+    def legacy_omniauth_redirect_uri(provider)
       site_base_url.join("identities/auth/#{provider}/callback").to_s
     end
   end

--- a/lib/seek/config.rb
+++ b/lib/seek/config.rb
@@ -392,6 +392,20 @@ module Seek
       }
     end
 
+    def omniauth_oidc_image
+      Avatar.find_by_id(omniauth_oidc_image_id) if omniauth_oidc_image_id
+    end
+
+    def omniauth_oidc_image= file
+      return if file.blank?
+      current = omniauth_oidc_image
+      omniauth_oidc_image.destroy! if current
+      avatar = Avatar.new(original_filename: file.original_filename, image_file: file, skip_owner_validation: true)
+      avatar.save!
+      self.omniauth_oidc_image_id = avatar.id
+      avatar
+    end
+
     def omniauth_providers
       providers = []
       providers << [:ldap, omniauth_ldap_config.merge(name: :ldap, form: SessionsController.action(:new))] if omniauth_ldap_enabled

--- a/lib/seek/config.rb
+++ b/lib/seek/config.rb
@@ -375,11 +375,27 @@ module Seek
       [omniauth_github_client_id, omniauth_github_secret, { scope: 'user:email' }]
     end
 
+    def omniauth_oidc_config
+      # Cannot use url helpers here because routes are not loaded at this point :( -Finn
+      callback_path = 'identities/auth/oidc/callback'
+
+      omniauth_oidc_settings.merge(
+        {
+          callback_path: "#{Rails.application.config.relative_url_root}/#{callback_path}",
+          name: :oidc,
+          response_type: 'code',
+          discovery: true,
+          client_options: omniauth_oidc_settings.merge(
+            redirect_uri: site_base_url.join(callback_path).to_s)
+        })
+    end
+
     def omniauth_providers
       providers = {}
       providers[:ldap] = omniauth_ldap_config.merge(name: :ldap, form: SessionsController.action(:new)) if omniauth_ldap_enabled
       providers[:openid_connect] = omniauth_elixir_aai_config if omniauth_elixir_aai_enabled
       providers[:github] = omniauth_github_config if omniauth_github_enabled
+      providers[:oidc] = omniauth_oidc_config if omniauth_oidc_enabled
       providers
     end
   end

--- a/lib/seek/config_setting_attributes.yml
+++ b/lib/seek/config_setting_attributes.yml
@@ -232,6 +232,10 @@ omniauth_github_enabled:
 omniauth_github_client_id:
 omniauth_github_secret:
   encrypt: true
+omniauth_oidc_enabled:
+omniauth_oidc_name:
+omniauth_oidc_settings:
+  encrypt: true
 ga4gh_trs_api_enabled:
 search_results_limit:
   convert: :to_i

--- a/lib/seek/config_setting_attributes.yml
+++ b/lib/seek/config_setting_attributes.yml
@@ -225,6 +225,7 @@ omniauth_elixir_aai_enabled:
 omniauth_elixir_aai_client_id:
 omniauth_elixir_aai_secret:
   encrypt: true
+omniauth_elixir_aai_legacy_mode:
 omniauth_ldap_enabled:
 omniauth_ldap_config:
   encrypt: true

--- a/lib/seek/config_setting_attributes.yml
+++ b/lib/seek/config_setting_attributes.yml
@@ -234,7 +234,9 @@ omniauth_github_secret:
   encrypt: true
 omniauth_oidc_enabled:
 omniauth_oidc_name:
-omniauth_oidc_settings:
+omniauth_oidc_issuer:
+omniauth_oidc_client_id:
+omniauth_oidc_secret:
   encrypt: true
 ga4gh_trs_api_enabled:
 search_results_limit:

--- a/lib/seek/config_setting_attributes.yml
+++ b/lib/seek/config_setting_attributes.yml
@@ -234,6 +234,7 @@ omniauth_github_secret:
   encrypt: true
 omniauth_oidc_enabled:
 omniauth_oidc_name:
+omniauth_oidc_image_id:
 omniauth_oidc_issuer:
 omniauth_oidc_client_id:
 omniauth_oidc_secret:

--- a/lib/tasks/seek_upgrades.rake
+++ b/lib/tasks/seek_upgrades.rake
@@ -19,6 +19,7 @@ namespace :seek do
     db:seed:017_minimal_starter_isa_templates
     recognise_isa_json_compliant_items
     implement_assay_streams_for_isa_assays
+    set_ls_login_legacy_mode
   ]
 
   # these are the tasks that are executes for each upgrade as standard, and rarely change
@@ -223,6 +224,15 @@ namespace :seek do
     end
 
     puts "...Created #{assay_streams_created} new assay streams"
+  end
+
+  task(set_ls_login_legacy_mode: [:environment]) do
+    only_once('ls_login_legacy') do
+      if Seek::Config.omniauth_elixir_aai_enabled
+        puts "Enabling LS Login legacy mode"
+        Seek::Config.omniauth_elixir_aai_legacy_mode = true
+      end
+    end
   end
 
   private

--- a/test/integration/omniauth_test.rb
+++ b/test/integration/omniauth_test.rb
@@ -367,7 +367,23 @@ class OmniauthTest < ActionDispatch::IntegrationTest
         assert_redirected_to(omniauth_failure_path(strategy: 'ldap', message: 'invalid_credentials'))
         follow_redirect!
 
-        assert_equal "LDAP authentication failure (Invalid username/password?)", flash[:error]
+        assert_equal "LDAP authentication failure (Invalid username/password)", flash[:error]
+        assert_select '#ldap_login.active'
+        assert_select '#password_login.active', count: 0
+      end
+    end
+  end
+
+  test 'LDAP auth failure should redirect to login page and show generic error if message not recognized' do
+    OmniAuth.config.mock_auth[:ldap] = 'blagjsdkgjsdfgi'
+
+    assert_no_difference('User.count') do
+      assert_no_difference('Identity.count') do
+        post omniauth_callback_path(:ldap)
+        assert_redirected_to(omniauth_failure_path(strategy: 'ldap', message: 'blagjsdkgjsdfgi'))
+        follow_redirect!
+
+        assert_equal "LDAP authentication failure", flash[:error]
         assert_select '#ldap_login.active'
         assert_select '#password_login.active', count: 0
       end
@@ -384,7 +400,7 @@ class OmniauthTest < ActionDispatch::IntegrationTest
         assert_redirected_to(omniauth_failure_path(strategy: 'elixir_aai', message: 'invalid_credentials'))
         follow_redirect!
 
-        assert_equal "LS Login authentication failure (Invalid username/password?)", flash[:error]
+        assert_equal "LS Login authentication failure (Invalid username/password)", flash[:error]
         assert_select '#elixir_aai_login.active'
         assert_select '#ldap_login.active', count: 0
         assert_select '#password_login.active', count: 0

--- a/test/integration/omniauth_test.rb
+++ b/test/integration/omniauth_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class OmniauthTest < ActionDispatch::IntegrationTest
   include AuthenticatedTestHelper
+  include HtmlHelper
 
   fixtures :users, :people
 
@@ -404,6 +405,8 @@ class OmniauthTest < ActionDispatch::IntegrationTest
         assert_select '#elixir_aai_login.active'
         assert_select '#ldap_login.active', count: 0
         assert_select '#password_login.active', count: 0
+        # Should override return_to, to avoid it redirecting back to the login form with garbled error message.
+        assert_select '#elixir_aai_login a[href=?]', omniauth_authorize_path(:elixir_aai, state: 'return_to:/')
       end
     end
   end

--- a/test/integration/omniauth_test.rb
+++ b/test/integration/omniauth_test.rb
@@ -376,7 +376,7 @@ class OmniauthTest < ActionDispatch::IntegrationTest
   end
 
   test 'LDAP auth failure should redirect to login page and show generic error if message not recognized' do
-    OmniAuth.config.mock_auth[:ldap] = 'blagjsdkgjsdfgi'
+    OmniAuth.config.mock_auth[:ldap] = :blagjsdkgjsdfgi
 
     assert_no_difference('User.count') do
       assert_no_difference('Identity.count') do

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -607,8 +607,8 @@ class ConfigTest < ActiveSupport::TestCase
             config = Seek::Config.omniauth_elixir_aai_config
             assert_equal 'abc', config[:client_options][:identifier]
             assert_equal '123', config[:client_options][:secret]
-            assert_equal '/identities/auth/elixir_aai/callback', config[:callback_path]
-            assert_equal 'https://secure.website:3001/identities/auth/elixir_aai/callback', config[:client_options][:redirect_uri]
+            assert_equal '/auth/elixir_aai/callback', config[:callback_path]
+            assert_equal 'https://secure.website:3001/auth/elixir_aai/callback', config[:client_options][:redirect_uri]
           end
         end
       end
@@ -616,15 +616,18 @@ class ConfigTest < ActiveSupport::TestCase
     with_config_value(:site_base_host, 'http://localhost') do
       with_relative_root('/seeks/seek1') do
         config = Seek::Config.omniauth_elixir_aai_config
-        assert_equal '/seeks/seek1/identities/auth/elixir_aai/callback', config[:callback_path]
-        assert_equal 'http://localhost/seeks/seek1/identities/auth/elixir_aai/callback', config[:client_options][:redirect_uri]
         refute Seek::Config.omniauth_elixir_aai_legacy_mode
-        assert_equal 'https://proxy.aai.lifescience-ri.eu/', Seek::Config.omniauth_elixir_aai_config[:issuer]
+        assert_equal '/seeks/seek1/auth/elixir_aai/callback', config[:callback_path]
+        assert_equal 'http://localhost/seeks/seek1/auth/elixir_aai/callback', config[:client_options][:redirect_uri]
+        assert_equal 'https://proxy.aai.lifescience-ri.eu/',config[:issuer]
+        with_config_value(:omniauth_elixir_aai_legacy_mode, true) do
+          assert Seek::Config.omniauth_elixir_aai_legacy_mode
+          config = Seek::Config.omniauth_elixir_aai_config
+          assert_equal '/seeks/seek1/identities/auth/elixir_aai/callback', config[:callback_path]
+          assert_equal 'http://localhost/seeks/seek1/identities/auth/elixir_aai/callback', config[:client_options][:redirect_uri]
+          assert_equal 'https://login.elixir-czech.org/oidc/', config[:issuer]
+        end
       end
-    end
-    with_config_value(:omniauth_elixir_aai_legacy_mode, true) do
-      assert Seek::Config.omniauth_elixir_aai_legacy_mode
-      assert_equal 'https://login.elixir-czech.org/oidc/', Seek::Config.omniauth_elixir_aai_config[:issuer]
     end
   end
 end

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -618,7 +618,13 @@ class ConfigTest < ActiveSupport::TestCase
         config = Seek::Config.omniauth_elixir_aai_config
         assert_equal '/seeks/seek1/identities/auth/elixir_aai/callback', config[:callback_path]
         assert_equal 'http://localhost/seeks/seek1/identities/auth/elixir_aai/callback', config[:client_options][:redirect_uri]
+        refute Seek::Config.omniauth_elixir_aai_legacy_mode
+        assert_equal 'https://proxy.aai.lifescience-ri.eu/', Seek::Config.omniauth_elixir_aai_config[:issuer]
       end
+    end
+    with_config_value(:omniauth_elixir_aai_legacy_mode, true) do
+      assert Seek::Config.omniauth_elixir_aai_legacy_mode
+      assert_equal 'https://login.elixir-czech.org/oidc/', Seek::Config.omniauth_elixir_aai_config[:issuer]
     end
   end
 end


### PR DESCRIPTION
- Adds admin options for a custom OpenID Connect provider, with custom name & login image
- Adds new config for LS Login authentication (with option to use legacy config)
- Improves auth failure handling
- Displays some useful info (e.g. redirect URI) to provide to authentication providers when registering SEEK instance as a client/relying party



![image](https://github.com/seek4science/seek/assets/503373/928a8304-3b3f-423b-a30e-3477335804d4)

![image](https://github.com/seek4science/seek/assets/503373/3dd0b4e3-d96d-4ace-a84d-fe83aa6f3739)

Fixes #984
Fixes #1415