### PR TITLE
Convert sample floating point attributes from string to float

### DIFF
--- a/lib/seek/samples/attribute_handlers/float_attribute_handler.rb
+++ b/lib/seek/samples/attribute_handlers/float_attribute_handler.rb
@@ -5,6 +5,12 @@ module Seek
         def test_value(value)
           Float(value)
         end
+
+        def convert(value)
+          float_value = Float(value, exception: false) if value.is_a?(String)
+          float_value.nil? ? value : float_value
+        end
+
       end
     end
   end

--- a/public/api/definitions/_schemas.yml
+++ b/public/api/definitions/_schemas.yml
@@ -833,6 +833,8 @@ sampleAttributeMap:
       - type: string
       - type: array
       - type: 'null'
+      - type: number
+      - type: boolean
 extendedMetadataAttributeMap:
   type: object
   additionalProperties: true

--- a/test/factories/sample_types.rb
+++ b/test/factories/sample_types.rb
@@ -124,6 +124,9 @@ FactoryBot.define do
       type.sample_attributes << FactoryBot.build(:sample_attribute, title: 'apple', sample_attribute_type: FactoryBot.create(:controlled_vocab_attribute_type), required: false, sample_controlled_vocab: FactoryBot.create(:apples_sample_controlled_vocab), sample_type: type)
       type.sample_attributes << FactoryBot.build(:sample_attribute, title: 'apples', sample_attribute_type: FactoryBot.create(:cv_list_attribute_type), required: false, sample_controlled_vocab: FactoryBot.create(:apples_sample_controlled_vocab), sample_type: type)
       type.sample_attributes << FactoryBot.build(:sample_multi_sample_attribute, title: 'patients', linked_sample_type: FactoryBot.create(:patient_sample_type), required: false, sample_type: type)
+      type.sample_attributes << FactoryBot.build(:sample_attribute, title: 'weight', sample_attribute_type: FactoryBot.create(:float_sample_attribute_type), required: false, sample_type: type)
+      type.sample_attributes << FactoryBot.build(:sample_attribute, title: 'age', sample_attribute_type: FactoryBot.create(:integer_sample_attribute_type), required: false, sample_type: type)
+      type.sample_attributes << FactoryBot.build(:sample_attribute, title: 'bool', sample_attribute_type: FactoryBot.create(:boolean_sample_attribute_type), required: false, sample_type: type)
     end
     after(:create) do |type|
       type.annotate_with(['tag1', 'tag2'], 'sample_type_tag', type.contributor)

--- a/test/factories/samples.rb
+++ b/test/factories/samples.rb
@@ -53,6 +53,9 @@ FactoryBot.define do
       sample.set_attribute_value(:apple,['Bramley'])
       sample.set_attribute_value(:apples, ['Granny Smith','Golden Delicious'])
       sample.set_attribute_value(:patients, [FactoryBot.create(:patient_sample).id.to_s, FactoryBot.create(:patient_sample).id.to_s])
+      sample.set_attribute_value(:weight, '3.7')
+      sample.set_attribute_value(:age, '42')
+      sample.set_attribute_value(:bool, true)
     end
   end
 

--- a/test/fixtures/json/requests/patch_max_sample.json.erb
+++ b/test/fixtures/json/requests/patch_max_sample.json.erb
@@ -9,7 +9,10 @@
         "postcode": "M13 8PL",
         "CAPITAL key": "changed",
         "apple": "Granny Smith",
-        "apples": ["Golden Delicious", "Bramley"]
+        "apples": ["Golden Delicious", "Bramley"],
+        "weight": 3.7,
+        "age": 42,
+        "bool": true
       },
       "tags": []
     },

--- a/test/fixtures/json/requests/post_max_sample.json.erb
+++ b/test/fixtures/json/requests/post_max_sample.json.erb
@@ -8,7 +8,10 @@
         "postcode": "M13 9PL",
         "CAPITAL key": "key must remain capitalised",
         "apple": "Bramley",
-        "apples": ["Golden Delicious", "Granny Smith"]
+        "apples": ["Golden Delicious", "Granny Smith"],
+        "weight": 3.7,
+        "age": 42,
+        "bool": true
       },
       "tags": ["tag1", "tag2"]
     },

--- a/test/fixtures/json/responses/get_max_sample.json.erb
+++ b/test/fixtures/json/responses/get_max_sample.json.erb
@@ -28,7 +28,10 @@
             "title": "Fred Bloggs",
             "id": <%= res.get_attribute_value(:patients)[1]['id'] %>
           }
-        ]
+        ],
+        "weight": 3.7,
+        "age": 42,
+        "bool": true
       },
       "policy": {
         "access": "no_access",

--- a/test/fixtures/json/responses/get_max_sample_type.json.erb
+++ b/test/fixtures/json/responses/get_max_sample_type.json.erb
@@ -131,6 +131,42 @@
           "is_title": false,
           "sample_controlled_vocab_id": null,
           "linked_sample_type_id": "<%= res.sample_attributes[6].linked_sample_type_id %>"
+        },
+        {
+          "id": "<%= res.sample_attributes[7].id %>",
+          "title": "weight",
+          "description": null,
+          "pid": null,
+          "sample_attribute_type": {
+            "id": "<%= res.sample_attributes[7].sample_attribute_type_id %>",
+            "title": "<%= res.sample_attributes[7].sample_attribute_type.title %>",
+            "base_type": "Float",
+            "regexp": ".*"
+          }
+        },
+        {
+          "id": "<%= res.sample_attributes[8].id %>",
+          "title": "age",
+          "description": null,
+          "pid": null,
+          "sample_attribute_type": {
+            "id": "<%= res.sample_attributes[8].sample_attribute_type_id %>",
+            "title": "<%= res.sample_attributes[8].sample_attribute_type.title %>",
+            "base_type": "Integer",
+            "regexp": ".*"
+          }
+        },
+        {
+          "id": "<%= res.sample_attributes[9].id %>",
+          "title": "bool",
+          "description": null,
+          "pid": null,
+          "sample_attribute_type": {
+            "id": "<%= res.sample_attributes[9].sample_attribute_type_id %>",
+            "title": "<%= res.sample_attributes[9].sample_attribute_type.title %>",
+            "base_type": "Boolean",
+            "regexp": ".*"
+          }
         }
       ],
       "tags": [

--- a/test/functional/samples_controller_test.rb
+++ b/test/functional/samples_controller_test.rb
@@ -71,7 +71,7 @@ class SamplesControllerTest < ActionController::TestCase
     assert_equal 'Fred Smith', sample.title
     assert_equal 'Fred Smith', sample.get_attribute_value('full name')
     assert_equal 22, sample.get_attribute_value(:age)
-    assert_equal '22.1', sample.get_attribute_value(:weight)
+    assert_equal 22.1, sample.get_attribute_value(:weight)
     assert_equal 'M13 9PL', sample.get_attribute_value(:postcode)
     assert_equal person, sample.contributor
     assert_equal [creator], sample.creators
@@ -95,7 +95,7 @@ class SamplesControllerTest < ActionController::TestCase
     assert_equal 'Fred Smith', sample.title
     assert_equal 'Fred Smith', sample.get_attribute_value('full name')
     assert_equal 22, sample.get_attribute_value(:age)
-    assert_equal '22.1', sample.get_attribute_value(:weight)
+    assert_equal 22.1, sample.get_attribute_value(:weight)
     assert_equal 'M13 9PL', sample.get_attribute_value(:postcode)
     assert_equal person, sample.contributor
     assert_equal [creator], sample.creators
@@ -1051,7 +1051,7 @@ class SamplesControllerTest < ActionController::TestCase
     assert_equal 'Fred Smith', sample1.title
     assert_equal 'Fred Smith', sample1.get_attribute_value('full name')
     assert_equal 22, sample1.get_attribute_value(:age)
-    assert_equal '22.1', sample1.get_attribute_value(:weight)
+    assert_equal 22.1, sample1.get_attribute_value(:weight)
     assert_equal 'M13 9PL', sample1.get_attribute_value(:postcode)
     assert_equal [assay], sample1.assays
 
@@ -1059,7 +1059,7 @@ class SamplesControllerTest < ActionController::TestCase
     assert_equal 'David Tailor', sample2.title
     assert_equal 'David Tailor', sample2.get_attribute_value('full name')
     assert_equal 33, sample2.get_attribute_value(:age)
-    assert_equal '33.1', sample2.get_attribute_value(:weight)
+    assert_equal 33.1, sample2.get_attribute_value(:weight)
     assert_equal 'M12 8PL', sample2.get_attribute_value(:postcode)
   end
 
@@ -1112,7 +1112,7 @@ class SamplesControllerTest < ActionController::TestCase
     assert_equal 'Alfred Marcus', first_updated_sample.get_attribute_value('full name')
     assert_equal 22, first_updated_sample.get_attribute_value(:age)
     assert_nil first_updated_sample.get_attribute_value(:postcode)
-    assert_equal '22.1', first_updated_sample.get_attribute_value(:weight)
+    assert_equal 22.1, first_updated_sample.get_attribute_value(:weight)
 
     last_updated_sample = samples[1]
     assert_equal type_id2, last_updated_sample.sample_type.id
@@ -1120,7 +1120,7 @@ class SamplesControllerTest < ActionController::TestCase
     assert_equal 'David Tailor', last_updated_sample.get_attribute_value('full name')
     assert_equal 33, last_updated_sample.get_attribute_value(:age)
     assert_nil last_updated_sample.get_attribute_value(:postcode)
-    assert_equal '33.1', last_updated_sample.get_attribute_value(:weight)
+    assert_equal 33.1, last_updated_sample.get_attribute_value(:weight)
   end
 
   test 'batch_delete' do

--- a/test/unit/samples/float_attribute_handler_test.rb
+++ b/test/unit/samples/float_attribute_handler_test.rb
@@ -8,7 +8,6 @@ class FloatAttributeHandlerTest < ActiveSupport::TestCase
     assert_equal 2.7, handler.convert("2.7")
     assert_equal 2.0, handler.convert("2")
     assert_equal 2.0, handler.convert(2)
-    assert_equal 2.0, handler.convert(2.0)
     assert_equal 3.5, handler.convert(3.5)
 
     assert_nil handler.convert(nil)

--- a/test/unit/samples/float_attribute_handler_test.rb
+++ b/test/unit/samples/float_attribute_handler_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class FloatAttributeHandlerTest < ActiveSupport::TestCase
+
+  test 'convert' do
+    handler = Seek::Samples::AttributeHandlers::FloatAttributeHandler.new({})
+
+    assert_equal 2.7, handler.convert("2.7")
+    assert_equal 2.0, handler.convert("2")
+    assert_equal 2.0, handler.convert(2)
+    assert_equal 2.0, handler.convert(2.0)
+    assert_equal 3.5, handler.convert(3.5)
+
+    assert_nil handler.convert(nil)
+  end
+
+end


### PR DESCRIPTION
in line with boolean and integer conversions.
Expanded max_sample and max_sample_type to include boolean, float and integer and expand api test coverage, requiring an update of the api schema to support these types for the sample attribute map

* fix for #1791 