### PR TITLE
handle nested extended metadata when getting values for search 

### DIFF
--- a/app/models/concerns/has_extended_metadata.rb
+++ b/app/models/concerns/has_extended_metadata.rb
@@ -3,8 +3,10 @@ module HasExtendedMetadata
 
   included do
     def extended_metadata_attribute_values_for_search
-      extended_metadata ? extended_metadata.data.values.reject(&:blank?).uniq : []
+      return [] unless extended_metadata
+      extended_metadata.data.extract_all_values.uniq.compact
     end
+
   end
 
   class_methods do

--- a/lib/seek/json_metadata/data.rb
+++ b/lib/seek/json_metadata/data.rb
@@ -34,6 +34,17 @@ module Seek
         end
       end
 
+      # extracts all values from the data as a list, including from within nested structures
+      def extract_all_values(data = self)
+        data.values.collect do |value|
+          if value.is_a?(Data)
+            extract_all_values(value)
+          else
+            value
+          end
+        end.flatten
+      end
+
       private
 
       def validate_hash(hash)

--- a/lib/seek/json_metadata/data.rb
+++ b/lib/seek/json_metadata/data.rb
@@ -37,7 +37,7 @@ module Seek
       # extracts all values from the data as a list, including from within nested structures
       def extract_all_values(data = self)
         data.values.collect do |value|
-          if value.is_a?(Data)
+          if value.is_a?(Seek::JSONMetadata::Data)
             extract_all_values(value)
           else
             value

--- a/test/unit/investigation_test.rb
+++ b/test/unit/investigation_test.rb
@@ -221,6 +221,10 @@ class InvestigationTest < ActiveSupport::TestCase
                    )
     )
     assert_equal ['James','25'].sort, item.extended_metadata_attribute_values_for_search.map(&:to_s).sort
+
+    #nested
+    item = FactoryBot.create(:investigation, extended_metadata: FactoryBot.create(:role_multiple_extended_metadata))
+    assert_equal ['alice@email.com','0012345','liddell','alice','wonder','land'].sort, item.extended_metadata_attribute_values_for_search.map(&:to_s).sort
   end
   
   test 'related sop ids' do


### PR DESCRIPTION
* fix for #1808 

now recurses over the values and steps into any Data objects to get their values and so on resulting in a list