### PR TITLE
MIAPPE title mis-match fix

### DIFF
--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -202,7 +202,7 @@ class StudiesController < ApplicationController
     # e.g: Study.new(title: 'title', investigation: investigations(:metabolomics_investigation), policy: FactoryBot.create(:private_policy))
     # study.policy = Policy.create(name: 'default policy', access_type: 1)
     # render plain: params[:studies].inspect
-    metadata_types = ExtendedMetadataType.where(title: 'MIAPPE metadata', supported_type: 'Study').last
+    metadata_types = ExtendedMetadataType.where(title: ExtendedMetadataType::MIAPPE_TITLE, supported_type: 'Study').last
     studies_length = params[:studies][:title].length
     studies_uploaded = false
     data_file_uploaded = false

--- a/app/helpers/studies_helper.rb
+++ b/app/helpers/studies_helper.rb
@@ -24,6 +24,6 @@ module StudiesHelper
   end
 
   def show_batch_miappe_button?
-    ExtendedMetadataType.where(supported_type: 'Study', title: 'MIAPPE metadata v1.1').any?
+    ExtendedMetadataType.where(supported_type: 'Study', title: ExtendedMetadataType::MIAPPE_TITLE).any?
   end
 end

--- a/app/models/extended_metadata.rb
+++ b/app/models/extended_metadata.rb
@@ -22,4 +22,5 @@ class ExtendedMetadata < ApplicationRecord
   def attribute_class
     ExtendedMetadataAttribute
   end
+
 end

--- a/app/models/extended_metadata_type.rb
+++ b/app/models/extended_metadata_type.rb
@@ -13,6 +13,9 @@ class ExtendedMetadataType < ApplicationRecord
   scope :enabled, ->{ where(enabled: true) }
   scope :disabled, ->{ where(enabled: false) }
 
+  # built in type
+  MIAPPE_TITLE = 'MIAPPE metadata v1.1'
+
   def attribute_by_title(title)
     extended_metadata_attributes.where(title: title).first
   end

--- a/app/models/extended_metadata_type.rb
+++ b/app/models/extended_metadata_type.rb
@@ -14,7 +14,7 @@ class ExtendedMetadataType < ApplicationRecord
   scope :disabled, ->{ where(enabled: false) }
 
   # built in type
-  MIAPPE_TITLE = 'MIAPPE metadata v1.1'
+  MIAPPE_TITLE = 'MIAPPE metadata v1.1'.freeze
 
   def attribute_by_title(title)
     extended_metadata_attributes.where(title: title).first

--- a/app/models/study_batch_upload.rb
+++ b/app/models/study_batch_upload.rb
@@ -29,7 +29,7 @@ class StudyBatchUpload < ApplicationRecord
   def self.extract_studies_from_file(studies_file)
     studies = []
     parsed_sheet = Seek::Templates::StudiesReader.new(studies_file)
-    metadata_type = ExtendedMetadataType.where(title: 'MIAPPE metadata', supported_type: 'Study').last
+    metadata_type = ExtendedMetadataType.where(title: 'MIAPPE metadata v1.1', supported_type: 'Study').last
     columns = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
     study_start_row_index = 4
     parsed_sheet.each_record(3, columns) do |index, data|

--- a/app/models/study_batch_upload.rb
+++ b/app/models/study_batch_upload.rb
@@ -29,7 +29,7 @@ class StudyBatchUpload < ApplicationRecord
   def self.extract_studies_from_file(studies_file)
     studies = []
     parsed_sheet = Seek::Templates::StudiesReader.new(studies_file)
-    metadata_type = ExtendedMetadataType.where(title: 'MIAPPE metadata v1.1', supported_type: 'Study').last
+    metadata_type = ExtendedMetadataType.where(title: ExtendedMetadataType::MIAPPE_TITLE, supported_type: 'Study').last
     columns = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
     study_start_row_index = 4
     parsed_sheet.each_record(3, columns) do |index, data|

--- a/test/factories/extended_metadata_types.rb
+++ b/test/factories/extended_metadata_types.rb
@@ -142,7 +142,7 @@ FactoryBot.define do
   end
 
   factory(:study_extended_metadata_type_for_MIAPPE, class: ExtendedMetadataType) do
-    title { 'MIAPPE metadata v1.1' }
+    title { ExtendedMetadataType::MIAPPE_TITLE }
     supported_type { 'Study' }
     after(:build) do |a|
       a.extended_metadata_attributes << FactoryBot.create(:name_extended_metadata_attribute, title:'id')

--- a/test/factories/extended_metadata_types.rb
+++ b/test/factories/extended_metadata_types.rb
@@ -142,7 +142,7 @@ FactoryBot.define do
   end
 
   factory(:study_extended_metadata_type_for_MIAPPE, class: ExtendedMetadataType) do
-    title { 'MIAPPE metadata' }
+    title { 'MIAPPE metadata v1.1' }
     supported_type { 'Study' }
     after(:build) do |a|
       a.extended_metadata_attributes << FactoryBot.create(:name_extended_metadata_attribute, title:'id')

--- a/test/unit/studies/studies_extractor_test.rb
+++ b/test/unit/studies/studies_extractor_test.rb
@@ -39,7 +39,8 @@ class StudiesExtractorTest < ActiveSupport::TestCase
 
   test 'extract study correctly' do
     user_uuid = 'user_uuid'
-    FactoryBot.create(:study_extended_metadata_type_for_MIAPPE)
+    extended_metadata_type = FactoryBot.create(:study_extended_metadata_type_for_MIAPPE)
+    assert_equal 'MIAPPE metadata v1.1', extended_metadata_type.title, 'must match the seed data title'
     studies_file = ContentBlob.new
     studies_file.tmp_io_object = File.open("#{Rails.root}/tmp/#{user_uuid}_studies_upload/#{@studies.first.name}")
     studies_file.original_filename = @studies.first.name.to_s


### PR DESCRIPTION
Fix mismatch between seeded MIAPPE extended metadata title and that which is used when populating from an uploaded template, which was also missed to due mismatch in the test factories

* fix for #1811 