### PR TITLE
LinkingSamplesUpdateJob only saves and triggers new jobs if the metadata changes

### DIFF
--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -145,8 +145,12 @@ class Sample < ApplicationRecord
           sample['title'] = title if sample['id'] == id
         end
         metadata.values[p - 1] = item_linked_samples
-        s.json_metadata = metadata.to_json
-        s.save
+
+        # only update if changed, to prevent triggered jobs that could potentially create an infinate loop
+        if s.json_metadata != metadata.to_json
+          s.json_metadata = metadata.to_json
+          s.save
+        end
       end
     end
   end


### PR DESCRIPTION
* Fix for #1818 