### PR TITLE
UX improvements for remote Git files

### DIFF
--- a/app/controllers/git_controller.rb
+++ b/app/controllers/git_controller.rb
@@ -8,6 +8,7 @@ class GitController < ApplicationController
   before_action :fetch_git_version
   before_action :get_tree, only: [:tree]
   before_action :get_blob, only: [:blob, :download, :raw]
+  before_action :check_fetched, only: [:download, :raw]
 
   user_content_actions :raw
 
@@ -254,6 +255,12 @@ class GitController < ApplicationController
                          activity_loggable: @parent_resource,
                          user_agent: request.env['HTTP_USER_AGENT'],
                          data: data)
+    end
+  end
+
+  def check_fetched
+    if @blob.remote? && !@blob.fetched?
+      render_git_error('This file is held externally.', status: 404)
     end
   end
 

--- a/app/views/git/_blob.html.erb
+++ b/app/views/git/_blob.html.erb
@@ -8,8 +8,13 @@
 
 <div>
   <div class="pull-right">
-    <%= button_link_to('Download', 'download', polymorphic_path([@parent_resource, :git_download], version: @git_version.version, path: @blob.path)) %>
-    <%= button_link_to('Raw', 'markup', polymorphic_path([@parent_resource, :git_raw], version: @git_version.version, path: @blob.path)) %>
+    <% if @blob.fetched? %>
+      <%= button_link_to('Download', 'download', polymorphic_path([@parent_resource, :git_download], version: @git_version.version, path: @blob.path)) %>
+      <%= button_link_to('Raw', 'markup', polymorphic_path([@parent_resource, :git_raw], version: @git_version.version, path: @blob.path)) %>
+    <% end %>
+    <% if @blob.remote? %>
+      <%= button_link_to('External Link', 'external_link', @blob.url, target: :_blank) %>
+    <% end %>
     <% if @git_version.can_edit? %>
       <% if @git_version.mutable? %>
         <%= button_link_to('Move/rename', 'move', '#', { 'data-toggle' => 'modal', 'data-target' => '#git-move-modal' }) %>
@@ -25,7 +30,9 @@
   </div>
 
   <strong>Path: </strong> <%= @blob.path -%><br/>
-  <strong>Size: </strong> <%= number_to_human_size @blob.size -%><br/>
+  <% if @blob.fetched? %>
+    <strong>Size: </strong> <%= number_to_human_size @blob.size -%><br/>
+  <% end %>
   <div class="hidden">
     <strong>SHA: </strong> <code><%= @blob.oid %></code><br/>
   </div>

--- a/lib/seek/renderers/text_renderer.rb
+++ b/lib/seek/renderers/text_renderer.rb
@@ -6,7 +6,13 @@ module Seek
       end
 
       def render_content
-        "<pre>#{h(blob.read)}</pre>"
+        content = blob.read
+        if content.empty?
+          '<span class="subtle">No content to display</span>'
+        else
+          "<pre>#{h(content)}</pre>"
+        end
+
       end
 
       def render_standalone

--- a/test/functional/git_controller_test.rb
+++ b/test/functional/git_controller_test.rb
@@ -210,6 +210,17 @@ class GitControllerTest < ActionController::TestCase
     assert_select 'img.git-image-preview[src=?]', workflow_git_raw_path(@workflow, version: @git_version.version, path: 'test.svg')
   end
 
+  test 'get remote blob' do
+    @git_version.add_remote_file('something', 'https://example.com/something', fetch: false)
+    @git_version.save!
+    get :blob, params: { workflow_id: @workflow.id, version: @git_version.version, path: 'something' }
+
+    assert_response :success
+    assert_select 'a.btn[href=?]', workflow_git_remove_file_path(@workflow, version: @git_version.version, path: 'something')
+    assert_select 'a.btn[href=?]', 'https://example.com/something'
+    assert_select 'img.git-image-preview[src=?]', workflow_git_raw_path(@workflow, version: @git_version.version, path: 'something'), count: 0
+  end
+
   test 'get raw binary file' do
     get :raw, params: { workflow_id: @workflow.id, version: @git_version.version, path: 'diagram.png' }
 
@@ -222,6 +233,24 @@ class GitControllerTest < ActionController::TestCase
 
     assert_response :success
     assert @response.header['Content-Disposition'].include?('attachment')
+  end
+
+  test 'attempting to download remote blob throws error' do
+    @git_version.add_remote_file('something', 'https://example.com/something', fetch: false)
+    @git_version.save!
+    get :download, params: { workflow_id: @workflow.id, version: @git_version.version, path: 'something' }
+
+    assert_redirected_to workflow_path(@workflow, tab: 'files')
+    assert flash[:error].include?('held externally')
+  end
+
+  test 'attempting to get raw remote blob throws error' do
+    @git_version.add_remote_file('something', 'https://example.com/something', fetch: false)
+    @git_version.save!
+    get :raw, params: { workflow_id: @workflow.id, version: @git_version.version, path: 'something' }
+
+    assert_redirected_to workflow_path(@workflow, tab: 'files')
+    assert flash[:error].include?('held externally')
   end
 
   test 'getting non-existent blob throws error' do

--- a/test/unit/renderers_test.rb
+++ b/test/unit/renderers_test.rb
@@ -363,6 +363,12 @@ class RenderersTest < ActiveSupport::TestCase
     blob = FactoryBot.create(:image_content_blob, asset: @asset)
     renderer = Seek::Renderers::TextRenderer.new(blob)
     refute renderer.can_render?
+
+    @git.add_remote_file('empty', 'https://example.com/file', fetch: false)
+    git_blob = @git.get_blob('empty')
+    renderer = Seek::Renderers::TextRenderer.new(git_blob)
+    assert renderer.can_render?
+    assert_equal '<span class="subtle">No content to display</span>', renderer.render
   end
 
   test 'image renderer' do


### PR DESCRIPTION
- Only shows "Raw" and "Download" buttons if content has been fetched. Previously they would just return a blank file.
- Shows "External Link" button to visit the URL of the remote file.
- Shows some greyed-out "missing" text when trying to display a blank blob.