### PR TITLE
Optimise an upgrade task

### DIFF
--- a/lib/tasks/seek_upgrades.rake
+++ b/lib/tasks/seek_upgrades.rake
@@ -125,8 +125,6 @@ namespace :seek do
           affected_samples << sample
         end
       end
-      #won't have been queued, as the policy has no associated assets yet when saved
-      #AuthLookupUpdateQueue.enqueue(affected_samples) if affected_samples.any?
     end
     puts "..... finished creating independent policies of #{affected_samples.count} extracted samples"
   ensure
@@ -134,7 +132,6 @@ namespace :seek do
     Policy.set_callback :commit, :after, :queue_rdf_generation_job
     Permission.set_callback :commit, :after, :queue_update_auth_table
     Permission.set_callback :commit, :after, :queue_rdf_generation_job
-
   end
 
   task(decouple_extracted_samples_projects: [:environment]) do

--- a/lib/tasks/seek_upgrades.rake
+++ b/lib/tasks/seek_upgrades.rake
@@ -107,7 +107,14 @@ namespace :seek do
   task(decouple_extracted_samples_policies: [:environment]) do
     puts '..... creating independent policies for extracted samples (this can take a while if there are many samples) ...'
     affected_samples = []
+
+    Policy.skip_callback :commit, :after, :queue_update_auth_table
+    Policy.skip_callback :commit, :after, :queue_rdf_generation_job
+    Permission.skip_callback :commit, :after, :queue_update_auth_table
+    Permission.skip_callback :commit, :after, :queue_rdf_generation_job
+
     disable_authorization_checks do
+
       Sample.includes(:originating_data_file).find_each do |sample|
         # check if the sample was extracted from a datafile and their policies are linked
         if sample.extracted? && sample.policy_id == sample.originating_data_file&.policy_id
@@ -119,9 +126,15 @@ namespace :seek do
         end
       end
       #won't have been queued, as the policy has no associated assets yet when saved
-      AuthLookupUpdateQueue.enqueue(affected_samples) if affected_samples.any?
+      #AuthLookupUpdateQueue.enqueue(affected_samples) if affected_samples.any?
     end
     puts "..... finished creating independent policies of #{affected_samples.count} extracted samples"
+  ensure
+    Policy.set_callback :commit, :after, :queue_update_auth_table
+    Policy.set_callback :commit, :after, :queue_rdf_generation_job
+    Permission.set_callback :commit, :after, :queue_update_auth_table
+    Permission.set_callback :commit, :after, :queue_rdf_generation_job
+
   end
 
   task(decouple_extracted_samples_projects: [:environment]) do


### PR DESCRIPTION
the task `decouple_extracted_samples_policies` was taking a long time when tested against the fairdomhub database. Now about 15x quicker by skipping call backs.

Callbacks aren't necessary since the policies and other content hasn't changed, just copied. Also has the benefit of avoiding running a large number of unnecessary jobs