### PR TITLE
Batch permission on my items 

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -273,22 +273,6 @@ module ApplicationHelper
     contributor_name_link.html_safe
   end
 
-  # this helper is to be extended to include many more types of objects that can belong to the
-  # user - for example, SOPs and others
-  def mine?(thing)
-    return false if thing.nil?
-    return false unless logged_in?
-
-    c_id = current_user.id.to_i
-
-    case thing.class.name
-    when 'Person'
-      return (current_user.person.id == thing.id)
-    else
-      return false
-    end
-  end
-
   def link_to_draggable(link_name, url, link_options = {})
     link_to(link_name, url, link_options)
   end

--- a/app/views/avatars/index.html.erb
+++ b/app/views/avatars/index.html.erb
@@ -1,4 +1,4 @@
-<% editable = mine?(@avatar_owner_instance) || @avatar_owner_instance.can_edit?(current_user) -%>
+<% editable = @avatar_owner_instance.can_edit?(current_user) -%>
 
 <%
     item = @avatar_owner_instance.class.name.downcase

--- a/app/views/institutions/_buttons.html.erb
+++ b/app/views/institutions/_buttons.html.erb
@@ -1,5 +1,5 @@
 <%= item_actions_dropdown do %>
-    <% if mine?(item) || item.can_edit? -%>
+    <% if item.can_edit? -%>
           <li><%= icon_link_to("Edit #{t('institution')} Details", 'edit', edit_institution_path(item)) -%></li>
           <% if admin_logged_in? -%>
               <li><%= delete_icon(item,current_user) %></li>

--- a/app/views/people/_batch_permission_changes_buttons.html.erb
+++ b/app/views/people/_batch_permission_changes_buttons.html.erb
@@ -1,0 +1,4 @@
+<% tooltip_text_sharing = "You can change the sharing policy and permissions for your items in batch. A preview of selected items will be given before you choose new permissions for them." %>
+<% tooltip_text_publishing = "Publish your owned items in one click. A preview will be given before publishing" %>
+<%= button_link_to "Batch permission changes", "publish", batch_sharing_permission_preview_person_path(@person), 'data-tooltip': tooltip(tooltip_text_sharing) -%>
+<%= button_link_to "Publish your items", "publish", batch_publishing_preview_person_path(@person), 'data-tooltip': tooltip(tooltip_text_publishing) -%>

--- a/app/views/people/_batch_permission_changes_buttons.html.erb
+++ b/app/views/people/_batch_permission_changes_buttons.html.erb
@@ -1,4 +1,2 @@
-<% tooltip_text_sharing = "You can change the sharing policy and permissions for your items in batch. A preview of selected items will be given before you choose new permissions for them." %>
-<% tooltip_text_publishing = "Publish your owned items in one click. A preview will be given before publishing" %>
-<%= button_link_to "Batch permission changes", "publish", batch_sharing_permission_preview_person_path(@person), 'data-tooltip': tooltip(tooltip_text_sharing) -%>
-<%= button_link_to "Publish your items", "publish", batch_publishing_preview_person_path(@person), 'data-tooltip': tooltip(tooltip_text_publishing) -%>
+<%= button_link_to "Batch permission changes", "publish", batch_sharing_permission_preview_person_path(@person), 'data-tooltip': tooltip(t('tooltips.batch_permission_changes_button')) -%>
+<%= button_link_to "Publish your items", "publish", batch_publishing_preview_person_path(@person), 'data-tooltip': tooltip(t('tooltips.publish_your_items_button')) -%>

--- a/app/views/people/_buttons.html.erb
+++ b/app/views/people/_buttons.html.erb
@@ -1,4 +1,4 @@
-<% if mine?(@person) -%>
+<% if @person.me? -%>
   <%= render partial:'batch_permission_changes_buttons' %>
   <% if @person.is_in_any_gatekept_projects? %>
     <%= button_link_to "Assets awaiting approval", "waiting", waiting_approval_assets_person_path(@person),
@@ -11,11 +11,11 @@
 <% end %>
 
 <%= item_actions_dropdown do %>
-  <% if (mine?(@person) || @person.can_edit?(current_user)) -%>
+  <% if @person.me? || @person.can_edit?(current_user) -%>
       <li>
         <%= image_tag_for_key('edit', edit_person_path(@person), "Edit Person Profile", nil, 'Edit Profile') -%>
       </li>
-      <% if mine?(@person) -%>
+      <% if @person.me? -%>
           <li>
             <%= image_tag_for_key "lock", url_for({controller: :users, action: :edit, id: @person.user}), "Manage Account", nil, "Manage Account" -%>
           </li>

--- a/app/views/people/_buttons.html.erb
+++ b/app/views/people/_buttons.html.erb
@@ -1,8 +1,5 @@
 <% if mine?(@person) -%>
-    <% tooltip_text_sharing = "You can change the sharing policy and permissions for your items in batch. A preview of selected items will be given before you choose new permissions for them." %>
-    <% tooltip_text_publishing = "Publish your owned items in one click. A preview will be given before publishing" %>
-    <%= button_link_to "Batch permission changes", "publish", batch_sharing_permission_preview_person_path(@person), 'data-tooltip': tooltip(tooltip_text_sharing) -%>
-    <%= button_link_to "Publish your items", "publish", batch_publishing_preview_person_path(@person), 'data-tooltip': tooltip(tooltip_text_publishing) -%>
+  <%= render partial:'batch_permission_changes_buttons' %>
   <% if @person.is_in_any_gatekept_projects? %>
     <%= button_link_to "Assets awaiting approval", "waiting", waiting_approval_assets_person_path(@person),
                        'data-tooltip': tooltip("The assets you have requested to publish, but are awaiting the #{t('asset_gatekeeper').downcase} approval") -%>

--- a/app/views/people/items.html.erb
+++ b/app/views/people/items.html.erb
@@ -1,4 +1,8 @@
+
 <div id="my-items">
+  <div class='pull-right' id='buttons'>
+    <%= render partial:'batch_permission_changes_buttons' %>
+  </div>
   <%= render partial: "general/items_related_to", object: @person,
              locals: { limit: 50, title: "Items related to #{link_to(h(@person.name),@person)}".html_safe } %>
 </div>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -70,7 +70,7 @@
         </div>
       <% end %>
     </div>
-    <%= render :partial => "people/project_subscriptions", :locals => { :person => @person } if (mine?(@person) || current_user.try(:person).try(:is_admin?)) %>
+    <%= render :partial => "people/project_subscriptions", :locals => { :person => @person } if @person.me? || current_user.try(:person).try(:is_admin?) %>
 
   <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -336,3 +336,7 @@ you can choose to have a %{project} linked to a site managed %{programme} instea
       all: Allow all cookies
       embedding: Allow necessary cookies and embedded content
       necessary: Allow only necessary cookies
+
+  tooltips:
+    batch_permission_changes_button: "You can change the sharing policy and permissions for your items as a batch. A preview of selected items will be given before you choose new permissions for them."
+    publish_your_items_button: "Publish your owned items as a batch. A preview will be given before publishing"

--- a/test/functional/people_controller_test.rb
+++ b/test/functional/people_controller_test.rb
@@ -1039,6 +1039,12 @@ class PeopleControllerTest < ActionController::TestCase
       assert_select 'div.list_item_title  a[href=?]', data_file_path(other_data_file), text: /#{other_data_file.title}/, count: 0
       assert_select 'div.list_item_title  a[href=?]', project_path(other_project), text: /#{other_project.title}/, count: 0
     end
+
+    assert_select 'div#buttons' do
+      assert_select 'a[href=?]', batch_sharing_permission_preview_person_path(me),text: /Batch permission changes/
+      assert_select 'a[href=?]', batch_publishing_preview_person_path(me),text: /Publish your items/
+    end
+
   end
 
   test 'my items permissions' do


### PR DESCRIPTION
Show the batch permission and publish buttons on the My Items page

* fix for #1837 

also a little refactoring, removing the `mine?` helper method