### PR TITLE
Issue 1832 fix seeding minimal starter templates

### DIFF
--- a/app/models/template_attribute.rb
+++ b/app/models/template_attribute.rb
@@ -15,7 +15,7 @@ class TemplateAttribute < ApplicationRecord
   before_save :default_pos
 
   def controlled_vocab?
-    sample_attribute_type.base_type == Seek::Samples::BaseType::CV
+    sample_attribute_type&.base_type == Seek::Samples::BaseType::CV
   end
 
   def allow_isa_tag_change?

--- a/db/seeds/017_minimal_starter_isa_templates.seeds.rb
+++ b/db/seeds/017_minimal_starter_isa_templates.seeds.rb
@@ -1,21 +1,38 @@
+# This code seeds the starter templates in the database.
+# To keep the link between parent and child template attributes, do not change the attribute titles !!!
+# Changing the titles will replace the existing attributes with new ones instead of updating them.
+
+# Custom upsert function for template attributes
+# This will create a new template attribute if it does not exist, or update the existing one.
+# This also assumes that a template_attribute is considered unique by its title and template_id.
+# All other fields can be updated.
+def upsert_template_attribute(title, template_id, **fields)
+  template_attribute = TemplateAttribute.find_or_create_by(title:, template_id:)
+  template_attribute.update(fields)
+  template_attribute
+end
+
 # Source - ISA minimal starter template
 source_template = Template.find_or_initialize_by(title: 'Source - ISA minimal starter template', level: 'study source',
                                                  group: 'ISA minimal starter')
 
 source_temp_attributes = []
-source_temp_attributes << TemplateAttribute.new(title: 'Source Name',
-                                                description: 'Sources are considered as the starting biological material used in a study.',
-                                                sample_attribute_type: SampleAttributeType.find_by(title: 'String'),
-                                                is_title: true,
-                                                required: true,
-                                                isa_tag: IsaTag.find_by(title: 'source'))
+source_temp_attributes << upsert_template_attribute('Source Name',
+                                                    source_template.id,
+                                                    description: 'Sources are considered as the starting biological material used in a study.',
+                                                    sample_attribute_type: SampleAttributeType.find_by(title: 'String'),
+                                                    is_title: true,
+                                                    required: true,
+                                                    isa_tag: IsaTag.find_by(title: 'source')
+)
 
-source_temp_attributes << TemplateAttribute.new(title: 'Source Characteristic 1',
-                                                description: 'A characteristic of the source.',
-                                                sample_attribute_type: SampleAttributeType.find_by(title: 'String'),
-                                                is_title: false,
-                                                required: true,
-                                                isa_tag: IsaTag.find_by(title: 'source_characteristic'))
+source_temp_attributes << upsert_template_attribute('Source Characteristic 1',
+                                                    source_template.id,
+                                                    description: 'A characteristic of the source.',
+                                                    sample_attribute_type: SampleAttributeType.find_by(title: 'String'),
+                                                    is_title: false,
+                                                    required: true,
+                                                    isa_tag: IsaTag.find_by(title: 'source_characteristic'))
 
 disable_authorization_checks do
   source_template.update(group_order: 1,
@@ -36,40 +53,45 @@ sample_template = Template.find_or_initialize_by(title: 'Sample - ISA minimal st
                                                  group: 'ISA minimal starter')
 
 sample_temp_attributes = []
-sample_temp_attributes << TemplateAttribute.new(title: 'Input',
-                                                description: 'Registered Samples in the platform used as input for this protocol.',
-                                                sample_attribute_type: SampleAttributeType.find_by(title: 'Registered Sample List'),
-                                                is_title: false,
-                                                required: true)
+sample_temp_attributes << upsert_template_attribute('Input',
+                                                    sample_template.id,
+                                                    description: 'Registered Samples in the platform used as input for this protocol.',
+                                                    sample_attribute_type: SampleAttributeType.find_by(title: 'Registered Sample List'),
+                                                    is_title: false,
+                                                    required: true)
 
-sample_temp_attributes << TemplateAttribute.new(title: 'Name of a protocol with samples as outputs',
-                                                description: 'Type of experimental step that generates samples as outputs from the study sources.',
-                                                sample_attribute_type: SampleAttributeType.find_by(title: 'String'),
-                                                is_title: false,
-                                                required: true,
-                                                isa_tag: IsaTag.find_by(title: 'protocol'))
+sample_temp_attributes << upsert_template_attribute('Name of a protocol with samples as outputs',
+                                                    sample_template.id,
+                                                    description: 'Type of experimental step that generates samples as outputs from the study sources.',
+                                                    sample_attribute_type: SampleAttributeType.find_by(title: 'String'),
+                                                    is_title: false,
+                                                    required: true,
+                                                    isa_tag: IsaTag.find_by(title: 'protocol'))
 
-sample_temp_attributes << TemplateAttribute.new(title: 'Name of protocol parameter 1',
-                                                description: 'A parameter for the protocol.',
-                                                sample_attribute_type: SampleAttributeType.find_by(title: 'String'),
-                                                is_title: false,
-                                                required: true,
-                                                isa_tag: IsaTag.find_by(title: 'parameter_value'))
+sample_temp_attributes << upsert_template_attribute('Name of protocol parameter 1',
+                                                    sample_template.id,
+                                                    description: 'A parameter for the protocol.',
+                                                    sample_attribute_type: SampleAttributeType.find_by(title: 'String'),
+                                                    is_title: false,
+                                                    required: true,
+                                                    isa_tag: IsaTag.find_by(title: 'parameter_value'))
 
-sample_temp_attributes << TemplateAttribute.new(title: 'Sample Name',
-                                                description: 'Samples are considered as biological material sampled from sources and used in the study.',
-                                                sample_attribute_type: SampleAttributeType.find_by(title: 'String'),
-                                                is_title: true,
-                                                required: true,
-                                                isa_tag: IsaTag.find_by(title: 'sample'))
+sample_temp_attributes << upsert_template_attribute('Sample Name',
+                                                    sample_template.id,
+                                                    description: 'Samples are considered as biological material sampled from sources and used in the study.',
+                                                    sample_attribute_type: SampleAttributeType.find_by(title: 'String'),
+                                                    is_title: true,
+                                                    required: true,
+                                                    isa_tag: IsaTag.find_by(title: 'sample'))
 
-sample_temp_attributes << TemplateAttribute.new(title: 'Sample Characteristic 1',
-                                                description: 'A characteristic of the sample.',
-                                                sample_attribute_type: SampleAttributeType.find_by(title: 'String'),
-                                                is_title: false,
-                                                required: true,
-                                                sample_controlled_vocab: nil,
-                                                isa_tag: IsaTag.find_by(title: 'sample_characteristic'))
+sample_temp_attributes << upsert_template_attribute('Sample Characteristic 1',
+                                                    sample_template.id,
+                                                    description: 'A characteristic of the sample.',
+                                                    sample_attribute_type: SampleAttributeType.find_by(title: 'String'),
+                                                    is_title: false,
+                                                    required: true,
+                                                    sample_controlled_vocab: nil,
+                                                    isa_tag: IsaTag.find_by(title: 'sample_characteristic'))
 
 disable_authorization_checks do
   sample_template.update(group_order: 2,
@@ -92,39 +114,44 @@ material_template = Template.find_or_initialize_by(title: 'Material output assay
                                                    level: 'assay - material', group: 'ISA minimal starter')
 
 material_temp_attributes = []
-material_temp_attributes << TemplateAttribute.new(title: 'Input',
-                                                  description: 'Registered Samples in the platform used as input for this protocol.',
-                                                  sample_attribute_type: SampleAttributeType.find_by(title: 'Registered Sample List'),
-                                                  is_title: false,
-                                                  required: true)
+material_temp_attributes << upsert_template_attribute('Input',
+                                                      material_template.id,
+                                                      description: 'Registered Samples in the platform used as input for this protocol.',
+                                                      sample_attribute_type: SampleAttributeType.find_by(title: 'Registered Sample List'),
+                                                      is_title: false,
+                                                      required: true)
 
-material_temp_attributes << TemplateAttribute.new(title: 'Name of a protocol with material output',
-                                                  description: 'Type of assay or experimental step performed that generates a material output.',
-                                                  sample_attribute_type: SampleAttributeType.find_by(title: 'String'),
-                                                  is_title: false,
-                                                  required: true,
-                                                  isa_tag: IsaTag.find_by(title: 'protocol'))
+material_temp_attributes << upsert_template_attribute('Name of a protocol with material output',
+                                                      material_template.id,
+                                                      description: 'Type of assay or experimental step performed that generates a material output.',
+                                                      sample_attribute_type: SampleAttributeType.find_by(title: 'String'),
+                                                      is_title: false,
+                                                      required: true,
+                                                      isa_tag: IsaTag.find_by(title: 'protocol'))
 
-material_temp_attributes << TemplateAttribute.new(title: 'Name of protocol parameter 1',
-                                                  description: 'A parameter for the protocol.',
-                                                  sample_attribute_type: SampleAttributeType.find_by(title: 'String'),
-                                                  is_title: false,
-                                                  required: true,
-                                                  isa_tag: IsaTag.find_by(title: 'parameter_value'))
+material_temp_attributes << upsert_template_attribute('Name of protocol parameter 1',
+                                                      material_template.id,
+                                                      description: 'A parameter for the protocol.',
+                                                      sample_attribute_type: SampleAttributeType.find_by(title: 'String'),
+                                                      is_title: false,
+                                                      required: true,
+                                                      isa_tag: IsaTag.find_by(title: 'parameter_value'))
 
-material_temp_attributes << TemplateAttribute.new(title: 'Output material Name',
-                                                  description: 'Name of the major material output resulting from the application of the protocol.',
-                                                  sample_attribute_type: SampleAttributeType.find_by(title: 'String'),
-                                                  is_title: true,
-                                                  required: true,
-                                                  isa_tag: IsaTag.find_by(title: 'other_material'))
+material_temp_attributes << upsert_template_attribute('Output material Name',
+                                                      material_template.id,
+                                                      description: 'Name of the major material output resulting from the application of the protocol.',
+                                                      sample_attribute_type: SampleAttributeType.find_by(title: 'String'),
+                                                      is_title: true,
+                                                      required: true,
+                                                      isa_tag: IsaTag.find_by(title: 'other_material'))
 
-material_temp_attributes << TemplateAttribute.new(title: 'Output material characteristic 1',
-                                                  description: 'Characteristic 1 of the output material.',
-                                                  sample_attribute_type: SampleAttributeType.find_by(title: 'String'),
-                                                  is_title: false,
-                                                  required: true,
-                                                  isa_tag: IsaTag.find_by(title: 'other_material_characteristic'))
+material_temp_attributes << upsert_template_attribute('Output material characteristic 1',
+                                                      material_template.id,
+                                                      description: 'Characteristic 1 of the output material.',
+                                                      sample_attribute_type: SampleAttributeType.find_by(title: 'String'),
+                                                      is_title: false,
+                                                      required: true,
+                                                      isa_tag: IsaTag.find_by(title: 'other_material_characteristic'))
 
 disable_authorization_checks do
   material_template.update(group_order: 3,
@@ -148,39 +175,44 @@ data_file_template = Template.find_or_initialize_by(title: 'Data file output ass
                                                     level: 'assay - data file', group: 'ISA minimal starter')
 
 data_file_temp_attributes = []
-data_file_temp_attributes << TemplateAttribute.new(title: 'Input',
-                                                   description: 'Registered Samples in the platform used as input for this protocol.',
-                                                   sample_attribute_type: SampleAttributeType.find_by(title: 'Registered Sample List'),
-                                                   is_title: false,
-                                                   required: true)
+data_file_temp_attributes << upsert_template_attribute('Input',
+                                                       data_file_template.id,
+                                                       description: 'Registered Samples in the platform used as input for this protocol.',
+                                                       sample_attribute_type: SampleAttributeType.find_by(title: 'Registered Sample List'),
+                                                       is_title: false,
+                                                       required: true)
 
-data_file_temp_attributes << TemplateAttribute.new(title: 'Name of a protocol with data file output',
-                                                   description: 'Type of assay or experimental step performed that generates a data file output.',
-                                                   sample_attribute_type: SampleAttributeType.find_by(title: 'String'),
-                                                   is_title: false,
-                                                   required: true,
-                                                   isa_tag: IsaTag.find_by(title: 'protocol'))
+data_file_temp_attributes << upsert_template_attribute('Name of a protocol with data file output',
+                                                       data_file_template.id,
+                                                       description: 'Type of assay or experimental step performed that generates a data file output.',
+                                                       sample_attribute_type: SampleAttributeType.find_by(title: 'String'),
+                                                       is_title: false,
+                                                       required: true,
+                                                       isa_tag: IsaTag.find_by(title: 'protocol'))
 
-data_file_temp_attributes << TemplateAttribute.new(title: 'Name of protocol parameter 1',
-                                                   description: 'A parameter for the protocol.',
-                                                   sample_attribute_type: SampleAttributeType.find_by(title: 'String'),
-                                                   is_title: false,
-                                                   required: true,
-                                                   isa_tag: IsaTag.find_by(title: 'data_file_comment'))
+data_file_temp_attributes << upsert_template_attribute('Name of protocol parameter 1',
+                                                       data_file_template.id,
+                                                       description: 'A parameter for the protocol.',
+                                                       sample_attribute_type: SampleAttributeType.find_by(title: 'String'),
+                                                       is_title: false,
+                                                       required: true,
+                                                       isa_tag: IsaTag.find_by(title: 'data_file_comment'))
 
-data_file_temp_attributes << TemplateAttribute.new(title: 'Data file Name',
-                                                   description: 'Name of the major data file output resulting from the application of the protocol.',
-                                                   sample_attribute_type: SampleAttributeType.find_by(title: 'String'),
-                                                   is_title: true,
-                                                   required: true,
-                                                   isa_tag: IsaTag.find_by(title: 'data_file'))
+data_file_temp_attributes << upsert_template_attribute('Data file Name',
+                                                       data_file_template.id,
+                                                       description: 'Name of the major data file output resulting from the application of the protocol.',
+                                                       sample_attribute_type: SampleAttributeType.find_by(title: 'String'),
+                                                       is_title: true,
+                                                       required: true,
+                                                       isa_tag: IsaTag.find_by(title: 'data_file'))
 
-data_file_temp_attributes << TemplateAttribute.new(title: 'Data file characteristic 1',
-                                                   description: 'Characteristic 1 of the data file output.',
-                                                   sample_attribute_type: SampleAttributeType.find_by(title: 'String'),
-                                                   is_title: false,
-                                                   required: true,
-                                                   isa_tag: IsaTag.find_by(title: 'data_file_comment'))
+data_file_temp_attributes << upsert_template_attribute('Data file characteristic 1',
+                                                       data_file_template.id,
+                                                       description: 'Characteristic 1 of the data file output.',
+                                                       sample_attribute_type: SampleAttributeType.find_by(title: 'String'),
+                                                       is_title: false,
+                                                       required: true,
+                                                       isa_tag: IsaTag.find_by(title: 'data_file_comment'))
 
 disable_authorization_checks do
   data_file_template.update(group_order: 4,


### PR DESCRIPTION
Fixes issue #1832.

Re-seeding `017_minimal_starter_isa_templates` will not replace the template attributes unless actual changes are made to the attributes.