### PR TITLE
Enable explore for presentations

### DIFF
--- a/app/controllers/presentations_controller.rb
+++ b/app/controllers/presentations_controller.rb
@@ -8,7 +8,7 @@ class PresentationsController < ApplicationController
   before_action :presentations_enabled?
   before_action :find_assets, :only => [ :index ]
   before_action :find_and_authorize_requested_item, :except => [ :index, :new, :create, :preview,:update_annotations_ajax]
-  before_action :find_display_asset, :only=>[:show, :download]
+  before_action :find_display_asset, :only=>[:show, :explore, :download]
 
   include Seek::Publishing::PublishingCommon
 

--- a/app/models/presentation.rb
+++ b/app/models/presentation.rb
@@ -35,4 +35,8 @@ class Presentation < ApplicationRecord
   def is_in_isa_publishable?
     true
   end
+
+  def supports_spreadsheet_explore?
+    true
+  end
 end

--- a/app/views/assets/_view_content.html.erb
+++ b/app/views/assets/_view_content.html.erb
@@ -18,7 +18,7 @@
       <% url = polymorphic_path([asset, content_blob], action: 'view_content', code: params[:code]) %>
       <% options = { title: 'View contents of this file' } %>
     <% end %>
-  <% elsif !asset.is_a?(Model) && content_blob.is_supported_spreadsheet_format? %>
+  <% elsif asset.supports_spreadsheet_explore? && content_blob.is_supported_spreadsheet_format? %>
     <% if content_blob.is_extractable_spreadsheet? %>
       <% url = polymorphic_path([asset], action: 'explore', code: params[:code], version: asset_version) %>
       <% options = { title: 'Explore the contents of this file' } %>

--- a/app/views/presentations/explore.html.erb
+++ b/app/views/presentations/explore.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "spreadsheets/explore", locals: { resource: @display_presentation } -%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -502,7 +502,7 @@ SEEK::Application.routes.draw do
     resources :people, :programmes, :projects, :investigations, :assays, :samples, :studies, :publications, :events, :collections, :workflows, :file_templates, :placeholders, only: [:index]
   end
 
-  resources :presentations, concerns: [:has_content_blobs, :publishable, :has_versions, :asset] do
+  resources :presentations, concerns: [:has_content_blobs, :publishable, :has_versions, :asset, :explorable_spreadsheet] do
     resources :people, :programmes, :projects, :publications, :events, :collections, :workflows, :investigations, :studies, :assays, only: [:index]
   end
 

--- a/test/factories/presentations.rb
+++ b/test/factories/presentations.rb
@@ -104,4 +104,8 @@ FactoryBot.define do
       end
     end
   end
+
+  factory(:small_test_spreadsheet_presentation, parent: :presentation) do
+    association :content_blob, factory: :small_test_spreadsheet_content_blob
+  end
 end

--- a/test/functional/documents_controller_test.rb
+++ b/test/functional/documents_controller_test.rb
@@ -302,7 +302,7 @@ class DocumentsControllerTest < ActionController::TestCase
     get :show, params: { id: doc }
     assert_response :success
     assert_select '#buttons' do
-      assert_select 'a[href=?]', explore_document_path(doc, version: doc.version), count: 1
+      assert_select 'a[href=?]', explore_document_path(doc, version: doc.version), text:'Explore', count: 1
       assert_select 'a.disabled', text: 'Explore', count: 0
     end
   end

--- a/test/functional/presentations_controller_test.rb
+++ b/test/functional/presentations_controller_test.rb
@@ -656,4 +656,21 @@ class PresentationsControllerTest < ActionController::TestCase
       assert flash[:error].include?('disabled')
     end
   end
+
+  test 'show explore button' do
+    presentation = FactoryBot.create(:small_test_spreadsheet_presentation)
+    login_as(presentation.contributor.user)
+    get :show, params: { id: presentation }
+    assert_response :success
+    assert_select '#buttons' do
+      assert_select 'a[href=?]', explore_presentation_path(presentation, version: presentation.version), text:'Explore', count: 1
+      assert_select 'a.disabled', text: 'Explore', count: 0
+    end
+  end
+
+  test 'explore latest version' do
+    presentation = FactoryBot.create :small_test_spreadsheet_presentation, policy: FactoryBot.create(:public_policy)
+    get :explore, params: { id: presentation }
+    assert_response :success
+  end
 end

--- a/test/unit/asset_test.rb
+++ b/test/unit/asset_test.rb
@@ -121,7 +121,7 @@ class AssetTest < ActiveSupport::TestCase
     assert FactoryBot.create(:sop).supports_spreadsheet_explore?
     assert FactoryBot.create(:file_template).supports_spreadsheet_explore?
     refute FactoryBot.create(:model).supports_spreadsheet_explore?
-    refute FactoryBot.create(:presentation).supports_spreadsheet_explore?
+    assert FactoryBot.create(:presentation).supports_spreadsheet_explore?
     refute FactoryBot.create(:placeholder).supports_spreadsheet_explore?
     refute FactoryBot.create(:workflow).supports_spreadsheet_explore?
     refute FactoryBot.create(:publication).supports_spreadsheet_explore?


### PR DESCRIPTION
* fix for #1858 

required a few other small changes to fully support explore for Presentations, which is what we claimed in the 1.14 release.

The root cause of the error was also fixed, which was to use `supports_spreadsheet_explore?` in the _view_content.erb.html partial rather than just skipping models.