### PR TITLE
Improvements to auth updates

### DIFF
--- a/app/jobs/auth_lookup_maintenance_job.rb
+++ b/app/jobs/auth_lookup_maintenance_job.rb
@@ -1,0 +1,33 @@
+class AuthLookupMaintenanceJob < ApplicationJob
+  RUN_PERIOD = 8.hours.freeze
+
+  queue_as QueueNames::AUTH_LOOKUP
+  queue_with_priority  3
+
+  def perform
+    check_authlookup_consistency
+  end
+
+  # checks lookup_table_consistent? on each type for each user, and if not triggers a job to repopulate for that user
+  def check_authlookup_consistency
+    found_types = [].to_set
+    items_for_queue = [].to_set
+    User.where.not(person_id: nil).to_a.push(nil).each do |user|
+
+      # will only deal with 1 type per user per run
+      found = Seek::Util.authorized_types.find do |type|
+        !type.lookup_table_consistent?(user)
+      end
+
+      next unless found.present?
+
+      found_types << found
+      missing = found.items_missing_from_authlookup(user)
+      items_for_queue.merge(missing)
+    end
+
+    found_types.each(&:remove_invalid_auth_lookup_entries)
+    AuthLookupUpdateQueue.enqueue(items_for_queue.to_a) unless items_for_queue.empty?
+  end
+
+end

--- a/app/jobs/auth_lookup_maintenance_job.rb
+++ b/app/jobs/auth_lookup_maintenance_job.rb
@@ -14,6 +14,9 @@ class AuthLookupMaintenanceJob < ApplicationJob
     items_for_queue = [].to_set
     User.where.not(person_id: nil).to_a.push(nil).each do |user|
 
+      # skip if this user is queued up
+      next if AuthLookupUpdateQueue.where(item:user).any?
+
       # will only deal with 1 type per user per run
       found = Seek::Util.authorized_types.find do |type|
         !type.lookup_table_consistent?(user)

--- a/app/jobs/auth_lookup_maintenance_job.rb
+++ b/app/jobs/auth_lookup_maintenance_job.rb
@@ -19,6 +19,9 @@ class AuthLookupMaintenanceJob < ApplicationJob
 
       # will only deal with 1 type per user per run
       found = Seek::Util.authorized_types.find do |type|
+        # skip if there are any queued items of this type
+        next if AuthLookupUpdateQueue.where(item_type:type.name).any?
+
         !type.lookup_table_consistent?(user)
       end
 

--- a/app/jobs/auth_lookup_maintenance_job.rb
+++ b/app/jobs/auth_lookup_maintenance_job.rb
@@ -20,8 +20,9 @@ class AuthLookupMaintenanceJob < ApplicationJob
 
       User.where.not(person_id: nil).to_a.push(nil).each do |user|
 
-        # skip if this user is queued up
-        next if AuthLookupUpdateQueue.where(item: user).any?
+        # skip if this user or person is queued up
+        next if user && AuthLookupUpdateQueue.where(item: user).or(AuthLookupUpdateQueue.where(item: user.person)).any?
+
         next if type.lookup_table_consistent?(user)
 
         items_for_queue.merge(type.items_missing_from_authlookup(user))

--- a/app/jobs/regular_maintenance_job.rb
+++ b/app/jobs/regular_maintenance_job.rb
@@ -20,7 +20,6 @@ class RegularMaintenanceJob < ApplicationJob
     clean_git_repositories
     resend_activation_emails
     remove_unregistered_users
-    check_authlookup_consistency
   end
 
   private
@@ -73,26 +72,4 @@ class RegularMaintenanceJob < ApplicationJob
     end
   end
 
-  # checks lookup_table_consistent? on each type for each user, and if not triggers a job to repopulate for that user
-  # if not already queued
-  def check_authlookup_consistency
-    found_types = [].to_set
-    items_for_queue = [].to_set
-    User.where.not(person_id: nil).to_a.push(nil).each do |user|
-
-      # will only deal with 1 type per user per run
-      found = Seek::Util.authorized_types.find do |type|
-        !type.lookup_table_consistent?(user)
-      end
-
-      next unless found.present?
-
-      found_types << found
-      missing = found.items_missing_from_authlookup(user)
-      items_for_queue.merge(missing)
-    end
-
-    found_types.each(&:remove_invalid_auth_lookup_entries)
-    AuthLookupUpdateQueue.enqueue(items_for_queue.to_a) unless items_for_queue.empty?
-  end
 end

--- a/app/jobs/user_auth_lookup_update_job.rb
+++ b/app/jobs/user_auth_lookup_update_job.rb
@@ -2,11 +2,21 @@
 class UserAuthLookupUpdateJob < ApplicationJob
   queue_as QueueNames::AUTH_LOOKUP
   queue_with_priority 0
+  BATCH_SIZE = 8000
 
-  def perform(user, type)
-    type.constantize.includes(policy: :permissions).find_each do |item|
+  # needs longer, otherwise the samples can time out
+  def timelimit
+    30.minutes
+  end
+
+  def perform(user, type, offset = 0)
+    type.constantize.offset(offset).limit(BATCH_SIZE).includes(policy: :permissions).find_each do |item|
       item.update_lookup_table(user)
     end
+
+    offset += BATCH_SIZE
+
+    self.class.perform_later(user, type, offset) if offset < type.constantize.count
   end
 end
 

--- a/app/jobs/user_auth_lookup_update_job.rb
+++ b/app/jobs/user_auth_lookup_update_job.rb
@@ -10,7 +10,7 @@ class UserAuthLookupUpdateJob < ApplicationJob
   end
 
   def perform(user, type, offset = 0)
-    type.constantize.offset(offset).limit(BATCH_SIZE).includes(policy: :permissions).find_each do |item|
+    type.constantize.offset(offset).limit(BATCH_SIZE).includes(policy: :permissions).each do |item|
       item.update_lookup_table(user)
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -337,7 +337,7 @@ class User < ApplicationRecord
 
   def queue_update_auth_table
     if saved_changes.keys.include?("person_id")
-      AuthLookupUpdateQueue.enqueue(self)
+      AuthLookupUpdateQueue.enqueue(self, priority: 1)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -67,7 +67,7 @@ class User < ApplicationRecord
   delegate :is_admin_or_project_administrator?, to: :person, allow_nil: true
   delegate :is_programme_administrator?, to: :person, allow_nil: true
 
-  after_commit :queue_update_auth_table, on: :create
+  after_save_commit :queue_update_auth_table
 
   after_destroy :queue_auth_lookup_delete_job
 
@@ -336,7 +336,9 @@ class User < ApplicationRecord
   end
 
   def queue_update_auth_table
-    AuthLookupUpdateQueue.enqueue(self)
+    if saved_changes.keys.include?("person_id")
+      AuthLookupUpdateQueue.enqueue(self)
+    end
   end
 
   def queue_auth_lookup_delete_job

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -47,6 +47,10 @@ every RegularMaintenanceJob::RUN_PERIOD, at: offset(1) do
   runner "RegularMaintenanceJob.perform_later"
 end
 
+every AuthLookupMaintenanceJob::RUN_PERIOD, at: offset(1) do
+  runner "AuthLookupMaintenanceJob.perform_later"
+end
+
 every LifeMonitorStatusJob::PERIOD, at: offset(2) do
   runner "LifeMonitorStatusJob.perform_later"
 end

--- a/test/integration/schedule_test.rb
+++ b/test/integration/schedule_test.rb
@@ -24,6 +24,11 @@ class ScheduleTest < ActionDispatch::IntegrationTest
     assert regular
     assert_equal [RegularMaintenanceJob::RUN_PERIOD, { at: '1:00am' }], regular[:every]
 
+    # AuthLookupMaintenanceJob
+    auth = pop_task(runners, "AuthLookupMaintenanceJob.perform_later")
+    assert auth
+    assert_equal [AuthLookupMaintenanceJob::RUN_PERIOD, { at: '1:00am' }], auth[:every]
+
     # LifeMonitor status
     lm_status = pop_task(runners, "LifeMonitorStatusJob.perform_later")
     assert lm_status

--- a/test/unit/jobs/auth_lookup_maintenance_job_test.rb
+++ b/test/unit/jobs/auth_lookup_maintenance_job_test.rb
@@ -2,6 +2,16 @@ require 'test_helper'
 
 class AuthLookupMaintenaceJobTest < ActiveSupport::TestCase
 
+  def setup
+    #ensure a consistent initial state
+    disable_authorization_checks do
+      Seek::Util.authorized_types.each(&:destroy_all)
+      Seek::Util.authorized_types.each(&:clear_lookup_table)
+    end
+
+    User.destroy_all
+  end
+
   test 'run period' do
     assert_equal 8.hours, AuthLookupMaintenanceJob::RUN_PERIOD
   end
@@ -16,13 +26,7 @@ class AuthLookupMaintenaceJobTest < ActiveSupport::TestCase
 
 
   test 'check authlookup consistency' do
-    #ensure a consistent initial state
-    disable_authorization_checks do
-      Seek::Util.authorized_types.each(&:destroy_all)
-      Seek::Util.authorized_types.each(&:clear_lookup_table)
-    end
 
-    User.destroy_all
     p = FactoryBot.create(:person)
     p2 = FactoryBot.create(:person)
     u = FactoryBot.create(:brand_new_user)
@@ -74,13 +78,7 @@ class AuthLookupMaintenaceJobTest < ActiveSupport::TestCase
   end
 
   test 'skip if user in the queue' do
-    #ensure a consistent initial state
-    disable_authorization_checks do
-      Seek::Util.authorized_types.each(&:destroy_all)
-      Seek::Util.authorized_types.each(&:clear_lookup_table)
-    end
 
-    User.destroy_all
     p = FactoryBot.create(:person)
 
     with_config_value(:auth_lookup_enabled, true) do
@@ -114,6 +112,49 @@ class AuthLookupMaintenaceJobTest < ActiveSupport::TestCase
       refute AuthLookupUpdateQueue.any?
 
       # queued after the user has been removed
+      assert_enqueued_jobs(1) do
+        assert_difference('AuthLookupUpdateQueue.count',1) do
+          AuthLookupMaintenanceJob.perform_now
+        end
+      end
+
+    end
+  end
+
+  test 'skip if particular type is on the queue' do
+    p = FactoryBot.create(:person)
+
+    with_config_value(:auth_lookup_enabled, true) do
+      assert AuthLookupUpdateQueue.queue_enabled?
+
+      doc1 = FactoryBot.create(:document)
+      AuthLookupUpdateJob.perform_now
+
+      assert Document.lookup_table_consistent?(p.user)
+
+      # delete a record
+      Document.lookup_class.where(user_id:p.user.id,asset_id:doc1.id).last.delete
+
+      refute Document.lookup_table_consistent?(p.user)
+
+      #gets immmediately updated for anonymous user
+      assert Document.lookup_table_consistent?(nil)
+
+      refute AuthLookupUpdateQueue.any?
+      AuthLookupUpdateQueue.create!(item: doc1)
+      assert AuthLookupUpdateQueue.any?
+
+      # nothing queued whilst doc1 is queued
+      assert_no_enqueued_jobs do
+        assert_no_difference('AuthLookupUpdateQueue.count') do
+          AuthLookupMaintenanceJob.perform_now
+        end
+      end
+
+      AuthLookupUpdateQueue.destroy_all
+      refute AuthLookupUpdateQueue.any?
+
+      # queued after the doc1 has been removed
       assert_enqueued_jobs(1) do
         assert_difference('AuthLookupUpdateQueue.count',1) do
           AuthLookupMaintenanceJob.perform_now

--- a/test/unit/jobs/auth_lookup_maintenance_job_test.rb
+++ b/test/unit/jobs/auth_lookup_maintenance_job_test.rb
@@ -1,0 +1,76 @@
+require 'test_helper'
+
+class AuthLookupMaintenaceJobTest < ActiveSupport::TestCase
+
+  test 'run period' do
+    assert_equal 8.hours, AuthLookupMaintenanceJob::RUN_PERIOD
+  end
+
+  test 'priority' do
+    assert_equal 3, AuthLookupMaintenanceJob.priority
+  end
+
+  test 'queue name' do
+    assert_equal QueueNames::AUTH_LOOKUP, AuthLookupMaintenanceJob.queue_name
+  end
+
+
+  test 'check authlookup consistency' do
+    #ensure a consistent initial state
+    disable_authorization_checks do
+      Seek::Util.authorized_types.each(&:destroy_all)
+      Seek::Util.authorized_types.each(&:clear_lookup_table)
+    end
+
+    User.destroy_all
+    p = FactoryBot.create(:person)
+    p2 = FactoryBot.create(:person)
+    u = FactoryBot.create(:brand_new_user)
+
+    assert_nil u.person
+
+    with_config_value(:auth_lookup_enabled, true) do
+      assert AuthLookupUpdateQueue.queue_enabled?
+
+      doc1 = FactoryBot.create(:document)
+      doc2 = FactoryBot.create(:document)
+      AuthLookupUpdateJob.perform_now
+
+      assert Document.lookup_table_consistent?(p.user)
+      assert Document.lookup_table_consistent?(p2.user)
+      assert Document.lookup_table_consistent?(nil)
+
+      assert_no_enqueued_jobs do
+        assert_no_difference('AuthLookupUpdateQueue.count') do
+          AuthLookupMaintenanceJob.perform_now
+        end
+      end
+
+      # delete a record
+      Document.lookup_class.where(user_id:p.user.id,asset_id:doc1.id).last.delete
+
+      #duplicate a record
+      Document.lookup_class.where(user_id:p2.user.id, asset_id:doc2.id).last.dup.save!
+
+      refute Document.lookup_table_consistent?(p.user)
+      refute Document.lookup_table_consistent?(p2.user)
+
+      #gets immmediately updated for anonymous user
+      assert Document.lookup_table_consistent?(nil)
+
+      assert_enqueued_jobs(1) do
+        assert_difference('AuthLookupUpdateQueue.count',1) do
+          AuthLookupMaintenanceJob.perform_now
+        end
+      end
+
+      # double check it will be fixed when the job runs
+      AuthLookupUpdateJob.perform_now
+      assert Document.lookup_table_consistent?(p.user)
+      assert Document.lookup_table_consistent?(p2.user)
+      assert Document.lookup_table_consistent?(nil)
+    end
+
+  end
+
+end

--- a/test/unit/jobs/regular_maintenace_job_test.rb
+++ b/test/unit/jobs/regular_maintenace_job_test.rb
@@ -154,65 +154,6 @@ class RegularMaintenaceJobTest < ActiveSupport::TestCase
     assert_equal [person3, person4].sort, logs.collect(&:subject).sort
   end
 
-  test 'check authlookup consistency' do
-    #ensure a consistent initial state
-    disable_authorization_checks do
-      Seek::Util.authorized_types.each(&:destroy_all)
-      Seek::Util.authorized_types.each(&:clear_lookup_table)
-    end
-
-    User.destroy_all
-    p = FactoryBot.create(:person)
-    p2 = FactoryBot.create(:person)
-    u = FactoryBot.create(:brand_new_user)
-
-    assert_nil u.person
-
-    with_config_value(:auth_lookup_enabled, true) do
-      assert AuthLookupUpdateQueue.queue_enabled?
-
-      doc1 = FactoryBot.create(:document)
-      doc2 = FactoryBot.create(:document)
-      AuthLookupUpdateJob.perform_now
-
-      assert Document.lookup_table_consistent?(p.user)
-      assert Document.lookup_table_consistent?(p2.user)
-      assert Document.lookup_table_consistent?(nil)
-
-      assert_no_enqueued_jobs do
-        assert_no_difference('AuthLookupUpdateQueue.count') do
-          RegularMaintenanceJob.perform_now
-        end
-      end
-
-      # delete a record
-      Document.lookup_class.where(user_id:p.user.id,asset_id:doc1.id).last.delete
-
-      #duplicate a record
-      Document.lookup_class.where(user_id:p2.user.id, asset_id:doc2.id).last.dup.save!
-
-      refute Document.lookup_table_consistent?(p.user)
-      refute Document.lookup_table_consistent?(p2.user)
-
-      #gets immmediately updated for anonymous user
-      assert Document.lookup_table_consistent?(nil)
-
-      assert_enqueued_jobs(1) do
-        assert_difference('AuthLookupUpdateQueue.count',1) do
-          RegularMaintenanceJob.perform_now
-        end
-      end
-
-      # double check it will be fixed when the job runs
-      AuthLookupUpdateJob.perform_now
-      assert Document.lookup_table_consistent?(p.user)
-      assert Document.lookup_table_consistent?(p2.user)
-      assert Document.lookup_table_consistent?(nil)
-    end
-
-
-  end
-
   test 'cleans redundant repositories' do
     redundant = FactoryBot.create(:blank_repository, created_at: 5.years.ago)
     redundant_but_in_grace = FactoryBot.create(:blank_repository, created_at: 1.second.ago)

--- a/test/unit/permissions/auth_lookup_update_queue_test.rb
+++ b/test/unit/permissions/auth_lookup_update_queue_test.rb
@@ -161,10 +161,17 @@ class AuthLookupUpdateQueueTest < ActiveSupport::TestCase
     end
   end
 
-  test 'updates when a user registers' do
+  test 'updates when a user registers but not until associated with a person' do
+    person = FactoryBot.create(:person)
+    user = assert_no_difference('AuthLookupUpdateQueue.count') do
+      FactoryBot.create(:brand_new_user)
+    end
     assert_difference('AuthLookupUpdateQueue.count', 1) do
-      user = FactoryBot.create(:brand_new_user)
-      assert_equal user, AuthLookupUpdateQueue.order(:id).last.item
+      user.person = person
+      user.save!
+      q = AuthLookupUpdateQueue.order(:id).last
+      assert_equal user, q.item
+      assert_equal 1, q.priority
     end
   end
 


### PR DESCRIPTION
* Moved check_authlookup_consistency into it's own job running low priority off the authlookup queue
* Now checks all types, but skips those that have an item on the queue
* Skips users that are listed on the queue
* Job for User is created when linked to a person, rather than immediately after creation, meaning jobs only created for those fully registered
* UserAuthLookupUpdateJob now has a longer timeout, and reintroduced processing in batches 

* fixes for #1866 