### PR TITLE
Prevent reindexing jobs when search disabled

### DIFF
--- a/app/jobs/reindexing_job.rb
+++ b/app/jobs/reindexing_job.rb
@@ -25,7 +25,7 @@ class ReindexingJob < BatchJob
   end
 
   def follow_on_job?
-    ReindexingQueue.any?
+    Seek::Config.solr_enabled && ReindexingQueue.any?
   end
 
   def timelimit

--- a/app/models/reindexing_queue.rb
+++ b/app/models/reindexing_queue.rb
@@ -1,7 +1,13 @@
 class ReindexingQueue < ApplicationRecord
   include ResourceQueue
 
+  def self.enqueue(*items, priority: DEFAULT_PRIORITY, queue_job: true)
+    return unless Seek::Config.solr_enabled
+    super(items, priority: priority, queue_job: queue_job)
+  end
+
   def self.job_class
     ReindexingJob
   end
+
 end


### PR DESCRIPTION
Don't queue items to be reindexed, queue jobs or create a follow_up_job if solr_enabled is false

* fix for #1874