### PR TITLE
Endpoint to retrieve `ro-crate-metadata.json` for a workflow

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -538,6 +538,7 @@ SEEK::Application.routes.draw do
     member do
       get :diagram
       get :ro_crate
+      get :ro_crate_metadata
       get :new_version
       get :new_git_version
       post :create_version_metadata

--- a/lib/seek/permissions/translator.rb
+++ b/lib/seek/permissions/translator.rb
@@ -12,7 +12,7 @@ module Seek
         download: Set.new(%i[
                             download named_download launch submit_job data execute plot explore
                             download_log download_results input output download_output download_input
-                            view_result compare_versions simulate diagram ro_crate
+                            view_result compare_versions simulate diagram ro_crate ro_crate_metadata
                           ]).freeze,
 
         edit: Set.new(%i[


### PR DESCRIPTION
Regardless of whether it is generated/stored