### PR TITLE
Bugfixes Sample Experiment Templates

### DIFF
--- a/app/assets/javascripts/templates.js
+++ b/app/assets/javascripts/templates.js
@@ -293,9 +293,12 @@ const applyTemplate = () => {
   const template_id_tag = $j(`#isa_study${suffix}template_parent_id`);
   if (template_id_tag) $j(template_id_tag).val(id);
 
+  // Removes the hidden from the new attribute button
+  $j(`${attribute_table} ${addAttributeRow}`).find('#add-attribute').removeClass("hidden");
+
   SampleTypes.recalculatePositions();
   SampleTypes.bindSortable();
-	$j(".sample-type-attribute-type").trigger("change", [false]);
+  $j(".sample-type-attribute-type").trigger("change", [false]);
 };
 
 // Shows the modal form

--- a/app/assets/javascripts/templates.js
+++ b/app/assets/javascripts/templates.js
@@ -267,7 +267,10 @@ const applyTemplate = () => {
         .addClass("disabled");
     $j(newRow).find('[data-attr="template_attribute_id"]').val(row[14]); // In case of a sample type
     $j(newRow).find('[data-attr="parent_attribute_id"]').val(row[14]); // In case of a template
-    if (isRequired) {
+
+    // Hide the remove button if the attribute is required and it is applied to a sample type.
+    // Template attributes should always be removeable
+    if (isRequired && appliedToSampleType) {
       $j(newRow).find('label.btn.btn-danger').addClass("hidden");
     }
 

--- a/app/assets/javascripts/templates.js
+++ b/app/assets/javascripts/templates.js
@@ -222,6 +222,7 @@ const applyTemplate = () => {
   $j('#template_level').val(data.level);
   $j('#template_parent_id').val(data.template_id);
 
+  const appliedToSampleType = $j('#template_level')[0] === undefined || $j('#template_level')[0] === null;
   // Make sure default sorted attributes are added to the table
   Templates.table.order([9, "asc"]).draw();
   $j.each(Templates.table.rows().data(), (i, row) => {
@@ -239,24 +240,25 @@ const applyTemplate = () => {
         row[7] === "Registered Sample List" &&
         row[1].includes("Input") &&
         row[11] === null;
-    const isInherited = row[14] !== "undefined" || row[14] !== null;
     const isRequired = row[0] ? "checked" : "";
     newRow = $j(newRow.replace(/replace-me/g, index));
     $j(newRow).find('[data-attr="required"]').prop("checked", row[0]);
+    if (appliedToSampleType) $j(newRow).find('[data-attr="required"]').prop("disabled", true);
+    $j(newRow).find(".sample-type-is-title").prop("checked", row[8]);
+    if (appliedToSampleType) $j(newRow).find('.sample-type-is-title').prop("disabled", true);
     $j(newRow).find('[data-attr="title"]').val(row[1]);
-    $j(newRow).find('[data-attr="title"]').addClass("disabled");
+    if (appliedToSampleType) $j(newRow).find('[data-attr="title"]').addClass("disabled");
     $j(newRow).find('[data-attr="description"]').val(row[2]);
     $j(newRow).find('[data-attr="type"]').val(row[3]);
-    $j(newRow).find('[data-attr="type"]').addClass("disabled");
+    if (appliedToSampleType) $j(newRow).find('[data-attr="type"]').addClass("disabled");
     $j(newRow).find('[data-attr="cv_id"]').val(row[4]);
-    $j(newRow).find('[data-attr="cv_id"]').parent().addClass("disabled");
+    if (appliedToSampleType) $j(newRow).find('[data-attr="cv_id"]').parent().addClass("disabled");
     $j(newRow).find('[data-attr="allow_cv_free_text"]').prop("checked", row[5]);
-    $j(newRow)
-        .find('[data-attr="allow_cv_free_text"]')
-        .addClass("disabled");
+    if (appliedToSampleType) $j(newRow)
+                                .find('[data-attr="allow_cv_free_text"]')
+                                .addClass("disabled");
     $j(newRow).find('[data-attr="unit"]').val(row[6]);
-    $j(newRow).find('[data-attr="unit"]').addClass("disabled");
-    $j(newRow).find(".sample-type-is-title").prop("checked", row[8]);
+    if (appliedToSampleType)  $j(newRow).find('[data-attr="unit"]').addClass("disabled");
     $j(newRow).find('[data-attr="pid"]').val(row[9]);
     $j(newRow).find('[data-attr="isa_tag_id"]').val(row[11]);
     $j(newRow).find('[data-attr="isa_tag_title"]').val(row[11]);

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -54,6 +54,7 @@ class ApplicationController < ActionController::Base
   def current_person
     current_user.try(:person)
   end
+  helper_method :current_person
 
   def partially_registered?
     redirect_to register_people_path if current_user && !current_user.registration_complete?

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -24,8 +24,7 @@ class Template < ApplicationRecord
   end
 
   def self.can_create?
-    can = User.logged_in_and_member? && Seek::Config.samples_enabled
-    can && User.current_user.is_admin_or_project_administrator?
+    super && Seek::Config.samples_enabled && User.current_user.is_admin_or_project_administrator?
   end
 
   def resolve_inconsistencies

--- a/app/views/projects/_project_selector.html.erb
+++ b/app/views/projects/_project_selector.html.erb
@@ -6,6 +6,7 @@
 <%
   allow_nil ||= false
   allow_all ||= false
+  allow_only_administered ||= false
   resource ||= nil
 
   selected_projects = resource ? resource.projects : []
@@ -13,10 +14,18 @@
     possible_projects = Project.all
   else
     possible_projects = []
-    possible_projects |= User.current_user.person.current_projects
     if resource
-      possible_projects |= resource.projects
-      possible_projects |= resource.contributor.current_projects if resource.respond_to?(:contributor) && resource.contributor
+      if resource.respond_to?(:contributor) && resource.contributor
+        if allow_only_administered
+          possible_projects |= resource.contributor.current_projects.select{ |p| @current_user.person.is_project_administrator? p }
+        else
+          possible_projects |= resource.contributor.current_projects
+        end
+        else
+          possible_projects |= resource.projects
+      end
+    else
+      possible_projects |= @current_user.person.current_projects
     end
   end
 

--- a/app/views/projects/_project_selector.html.erb
+++ b/app/views/projects/_project_selector.html.erb
@@ -14,21 +14,14 @@
     possible_projects = Project.all
   else
     possible_projects = []
+    possible_projects |= current_person.current_projects
     if resource
-      if resource.respond_to?(:contributor) && resource.contributor
-        if allow_only_administered
-          possible_projects |= resource.contributor.current_projects.select{ |p| @current_user.person.is_project_administrator? p }
-        else
-          possible_projects |= resource.contributor.current_projects
-        end
-        else
-          possible_projects |= resource.projects
-      end
-    else
-      possible_projects |= @current_user.person.current_projects
+      possible_projects |= resource.projects
+      possible_projects |= resource.contributor.current_projects if resource.respond_to?(:contributor) && resource.contributor
     end
   end
 
+  possible_projects = possible_projects.select { |p| current_person.is_project_administrator? p } if allow_only_administered
   possible_projects = possible_projects - selected_projects
 
   possible_projects_json, selected_projects_json = [possible_projects, selected_projects].map do |projects|

--- a/app/views/templates/_form.html.erb
+++ b/app/views/templates/_form.html.erb
@@ -27,12 +27,6 @@
 
                 <h3>Template Information</h3>
 
-                <% if @template.new_record? %>
-                    <div class="form-group">
-                        <input type="button" value="Choose from existing templates" class="btn btn-primary" onClick="showTemplateModal()">
-                    </div>
-                <% end %>
-
                 <div class="form-group">
                     <%= f.label :level, 'ISA Level' %>
                     <%= f.text_field :level, { class: 'form-control', readonly: true } %>
@@ -61,7 +55,13 @@
                 <b class="text-danger">To ensure compliance with the original template, please do not modify the existing ISA-tags and attributes in the form below. You can always add new attributes.</b>
             </div>
 
-            <table class="table" id="attribute-table">
+          <% if @template.new_record? %>
+            <div class="form-group">
+              <input type="button" value="Choose from existing templates" class="btn btn-primary" onClick="showTemplateModal()">
+            </div>
+          <% end %>
+
+          <table class="table" id="attribute-table">
                 <thead>
                     <tr>
                         <th width="5em">Order</th>
@@ -85,7 +85,7 @@
                     <% if @template.children.none? %>
                         <tr id="add-attribute-row">
                             <td colspan="6">
-                                <%= button_link_to('Add new attribute', 'add', '#', id: 'add-attribute') if  @template.level %>
+                                <%= button_link_to('Add new attribute', 'add', '#', id: 'add-attribute', class: @template.new_record? ? 'hidden' : '') %>
                             </td>
                         </tr>
                     <% end %>

--- a/app/views/templates/_form.html.erb
+++ b/app/views/templates/_form.html.erb
@@ -15,7 +15,7 @@
         <%= f.text_area :description, class: "form-control rich-text-edit", rows: 5, id: "template-description" -%>
     </div>
 
-    <%= render partial: "projects/project_selector", locals: { resource: @template } -%>
+    <%= render partial: "projects/project_selector", locals: { resource: @template, allow_only_administered: true } -%>
 
     <%= render partial: 'assets/manage_specific_attributes', locals:{f:f} if show_form_manage_specific_attributes? %>
 
@@ -85,7 +85,7 @@
                     <% if @template.children.none? %>
                         <tr id="add-attribute-row">
                             <td colspan="6">
-                                <%= button_link_to('Add new attribute', 'add', '#', id: 'add-attribute') %>
+                                <%= button_link_to('Add new attribute', 'add', '#', id: 'add-attribute') if  @template.level %>
                             </td>
                         </tr>
                     <% end %>


### PR DESCRIPTION
- Makes sure users cannot create new templates from scratch. Closes #1757 
- Template behavior is now different from Sample type behavior. Some limitations of the Sample Type are not applied on templates anymore:
  - Template attributes can be removed when inherrited from another template
  - All fields (except ISA tag) are editable again for inherrited attributes
  - Closes #1758 
- Users can only create templates and link them to projects they administer instead of all projects they are member of. Closes #1880 