### PR TITLE
Don't show non-editable assays when extracting samples

### DIFF
--- a/app/helpers/data_files_helper.rb
+++ b/app/helpers/data_files_helper.rb
@@ -3,6 +3,10 @@ module DataFilesHelper
     authorised_assets(DataFile, projects)
   end
 
+  def authorised_assay_assets(data_file)
+    data_file.assay_assets.where(assay_id: authorised_assays.collect(&:id))
+  end
+
   def split_into_two(ahash = {})
     return [{}, {}] if ahash.nil?
     return [ahash, {}] if ahash.length < 2

--- a/app/views/data_files/confirm_extraction.html.erb
+++ b/app/views/data_files/confirm_extraction.html.erb
@@ -56,11 +56,11 @@
     <%= hidden_field_tag(:sample_type_id, @sample_type.id) if @sample_type %>
     <%= hidden_field_tag(:confirm, 'true') %>
 
-    <% if @data_file.assay_assets.any? %>
+    <% if authorised_assays.intersect?(@data_file.assays) %>
         <h3>Link to assays</h3>
         This data file is linked to the following assays.
         Check the corresponding checkbox to also link the above samples to that assay.
-        <% @data_file.assay_assets.each do |aa| %>
+        <% authorised_assay_assets(@data_file).each do |aa| %>
             <div class="checkbox">
               <label>
                 <%= check_box_tag('assay_ids[]', aa.assay_id, false, autocomplete: 'off') %>


### PR DESCRIPTION
- Add authorised_assays to datafiles_helper 
- Only show users authorised_assays when extracting samples

Resolves #1887 