### PR TITLE
Issue 1891 fix isa json compliant assay creation

### DIFF
--- a/app/controllers/isa_assays_controller.rb
+++ b/app/controllers/isa_assays_controller.rb
@@ -212,7 +212,9 @@ class IsaAssaysController < ApplicationController
     end
 
     if @isa_assay.errors.any?
-      error_messages = @isa_assay.errors.full_messages.map { |msg| "<li>[#{t('isa_assay')}]: #{msg}</li>" }.join('')
+      error_messages = @isa_assay.errors.map do |error|
+        "<li>[<b>#{error.attribute.to_s}</b>]: #{error.message}</li>"
+      end.join('')
       flash[:error] = "<ul>#{error_messages}</ul>".html_safe
       redirect_to single_page_path(id: @isa_assay.assay.projects.first, item_type: 'assay',
                                    item_id: @isa_assay.assay)

--- a/app/controllers/isa_studies_controller.rb
+++ b/app/controllers/isa_studies_controller.rb
@@ -6,7 +6,7 @@ class IsaStudiesController < ApplicationController
   before_action :find_requested_item, only: %i[edit update]
 
   def new
-    @isa_study = IsaStudy.new
+    @isa_study = IsaStudy.new({ study: { investigation_id: params[:investigation_id] } })
   end
 
   def create

--- a/app/controllers/isa_studies_controller.rb
+++ b/app/controllers/isa_studies_controller.rb
@@ -36,12 +36,7 @@ class IsaStudiesController < ApplicationController
   end
 
   def edit
-    @isa_study.source = nil unless requested_item_authorized?(@isa_study.source)
-    @isa_study.sample_collection = nil unless requested_item_authorized?(@isa_study.sample_collection)
-
-    respond_to do |format|
-      format.html
-    end
+    respond_to(&:html)
   end
 
   def update
@@ -132,8 +127,20 @@ class IsaStudiesController < ApplicationController
   def find_requested_item
     @isa_study = IsaStudy.new
     @isa_study.populate(params[:id])
-    unless requested_item_authorized?(@isa_study.study)
-      flash[:error] = "You are not authorized to edit this #{t('isa_study')}"
+
+    @isa_study.errors.add(:study, "The #{t('isa_study')} was not found.") if @isa_study.study.nil?
+    @isa_study.errors.add(:study, "You are not authorized to edit this #{t('isa_study')}.") unless requested_item_authorized?(@isa_study.study)
+
+    @isa_study.errors.add(:sample_type, "'Study source' #{t('sample_type')} not found.") if @isa_study.source.nil?
+    @isa_study.errors.add(:sample_type, "You are not authorized to edit the 'study source' #{t('sample_type')}.") unless requested_item_authorized?(@isa_study.source)
+    @isa_study.errors.add(:sample_type, "'Study sample' #{t('sample_type')} not found.") if @isa_study.sample_collection.nil?
+    @isa_study.errors.add(:sample_type, "You are not authorized to edit the 'study sample' #{t('sample_type')}.") unless requested_item_authorized?(@isa_study.sample_collection)
+
+    if @isa_study.errors.any?
+      error_messages = @isa_study.errors.map do |error|
+        "<li>[<b>#{error.attribute.to_s}</b>]: #{error.message}</li>"
+      end.join('')
+      flash[:error] = "<ul>#{error_messages}</ul>".html_safe
       redirect_to single_page_path(id: @isa_study.study.projects.first, item_type: 'study',
                                    item_id: @isa_study.study)
     end

--- a/app/views/isa_assays/_form.html.erb
+++ b/app/views/isa_assays/_form.html.erb
@@ -15,7 +15,7 @@
     <%= assay_fields.text_area :description, rows: 5, class: "form-control rich-text-edit" -%>
   </div>
 
-  # Show extended metadata is assay is of class assay_stream
+  <%# Show extended metadata is assay is of class assay_stream %>
   <% if is_assay_stream %>
     <%= render partial: 'extended_metadata/extended_metadata_type_selection', locals:{f:assay_fields, resource:@isa_assay.assay} %>
     <%= render partial: 'extended_metadata/extended_metadata_attribute_input', locals:{f:assay_fields,resource:@isa_assay.assay, parent_resource: "isa_assay"} %>

--- a/app/views/isa_assays/_form.html.erb
+++ b/app/views/isa_assays/_form.html.erb
@@ -1,46 +1,6 @@
-<% assay = params[:isa_assay][:assay] if params.dig(:isa_assay, :assay) %>
-<% study = Study.find(params[:study_id] || assay[:study_id]) %>
-<% def first_assay_in_stream?
-    params[:source_assay_id].nil? || (params[:source_assay_id] == params[:assay_stream_id])
-   end
-%>
 <%
-  source_assay = Assay.find(params[:source_assay_id]) if params[:source_assay_id]
-  assay_stream_id = params[:assay_stream_id] if params[:assay_stream_id]
-
-  if @isa_assay.assay.new_record?
-    if params[:is_assay_stream]
-      assay_position = study.assay_streams.any? ? study.assay_streams.map(&:position).max + 1 : 0
-      assay_class_id = AssayClass.assay_stream.id
-      is_assay_stream = true
-    else
-      assay_position = first_assay_in_stream? ? 0 : source_assay.position + 1
-      assay_class_id = AssayClass.experimental.id
-      is_assay_stream = false
-    end
-  else
-    assay_position = @isa_assay.assay.position
-    assay_class_id = @isa_assay.assay.assay_class_id
-    is_assay_stream = @isa_assay.assay.is_assay_stream?
-  end
-
-  input_sample_type_id ||=
-    if is_assay_stream || source_assay&.assay_class&.is_assay_stream?
-      study.sample_types.second.id
-    else
-      source_assay.sample_type.id if source_assay
-    end
-
-  show_extended_metadata =
-    if is_assay_stream
-      true
-    elsif source_assay&.position&.zero? && !@isa_assay.assay.new_record?
-      true # Custom metadata should be shown in edit as well if assay position is 0.
-    else
-      false
-    end
+  is_assay_stream = @isa_assay.assay.is_assay_stream?
 %>
-
 <%= error_messages_for :isa_assay %>
 
 <%=  f.fields_for @isa_assay.assay do |assay_fields| %>
@@ -55,30 +15,28 @@
     <%= assay_fields.text_area :description, rows: 5, class: "form-control rich-text-edit" -%>
   </div>
 
-  <% if show_extended_metadata %>
+  # Show extended metadata is assay is of class assay_stream
+  <% if is_assay_stream %>
     <%= render partial: 'extended_metadata/extended_metadata_type_selection', locals:{f:assay_fields, resource:@isa_assay.assay} %>
     <%= render partial: 'extended_metadata/extended_metadata_attribute_input', locals:{f:assay_fields,resource:@isa_assay.assay, parent_resource: "isa_assay"} %>
   <% end %>
 
-  <div class="form-group hidden"  >
-    <label class="required"><%= t('study') -%></label>
-    <%= assay_study_selection('isa_assay[assay][study_id]',@isa_assay.assay.study) %>
-  </div>
+  <%= assay_fields.hidden_field :study_id %>
 
   <% if is_assay_stream %>
     <div class="form-group">
       <%= assay_fields.label "Assay position" -%><br/>
-      <%= assay_fields.number_field :position, rows: 5, class: "form-control", value: assay_position %>
+      <%= assay_fields.number_field :position, rows: 5, class: "form-control" %>
     </div>
   <% else %>
     <div class="hidden">
-      <%= assay_fields.hidden_field :position, value: assay_position -%>
+      <%= assay_fields.hidden_field :position -%>
     </div>
   <% end %>
 
 
-  <%= assay_fields.hidden_field :assay_stream_id, value: assay_stream_id -%>
-  <%= assay_fields.hidden_field :assay_class_id, value: assay_class_id -%>
+  <%= assay_fields.hidden_field :assay_stream_id -%>
+  <%= assay_fields.hidden_field :assay_class_id -%>
 
   <% if is_assay_stream %>
     <% if User.current_user  -%>
@@ -97,7 +55,7 @@
   <% end -%>
 <% end -%>
 
-<%= f.hidden_field :input_sample_type_id, value: input_sample_type_id  -%>
+<%= f.hidden_field :input_sample_type_id  -%>
 
 <% unless is_assay_stream %>
   <%= folding_panel("Define #{t(:sample_type)} for #{t(:assay)}") do %>
@@ -110,7 +68,8 @@
 
 <%= render partial: 'projects/implicit_project_selector', locals: { action: action,
                                                                     select_id: '#isa_assay_assay_study_id',
-                                                                    parents: Study.authorized_for('edit') } %>
+                                                                    parents: Study.authorized_for('edit'),
+                                                                    skip_on_page_load: true} %>
 
 
 <script>

--- a/app/views/isa_assays/_form.html.erb
+++ b/app/views/isa_assays/_form.html.erb
@@ -82,14 +82,6 @@
     }
 
     $j(document).ready(function () {
-      const urlSearchParams = new URLSearchParams(window.location.search);
-      const params = Object.fromEntries(urlSearchParams.entries());
-      const study_id = params["study_id"]
-      $j("option:enabled", "#isa_assay_input_sample_type_id").prop('selected', true);
-      // Prevent setting the hidden field on redirect (query string parameters are missing)
-      if(study_id)
-        $j("#isa_assay_assay_study_id").val(study_id).change();
-
       Templates.init($j('#template-attributes'));
     });
 </script>

--- a/app/views/isa_studies/_form.html.erb
+++ b/app/views/isa_studies/_form.html.erb
@@ -23,10 +23,6 @@
       </div>
     <% end %>
 
-    <div id="investigation_collection" class="hidden">
-      <%= render :partial=>"studies/investigation_list",:locals=>{study:@isa_study.study, :investigations=>Investigation.all.select {|i|current_user.person.member_of? i.projects}} -%>
-    </div>
-
     <div class="form-group">
       <%= study_fields.label "Study position" -%><br/>
       <%= study_fields.number_field :position, :rows => 5, :class=>"form-control"  -%>

--- a/app/views/isa_studies/_form.html.erb
+++ b/app/views/isa_studies/_form.html.erb
@@ -76,15 +76,6 @@
     }
 
     $j(document).ready(function () {
-      const urlSearchParams = new URLSearchParams(window.location.search);
-      const params = Object.fromEntries(urlSearchParams.entries());
-      const investigation_id = params["investigation_id"]
-      // Prevent setting the hidden field on redirect (query string parameters are missing)
-      if(investigation_id) {
-          $j("#isa_study_study_investigation_id").val(investigation_id);
-          $j("#study_investigation_id").val(investigation_id).change();
-      }
-
       if (templates.length > 0) {
         Templates.init($j('#template-attributes'));
       }

--- a/test/functional/isa_assays_controller_test.rb
+++ b/test/functional/isa_assays_controller_test.rb
@@ -76,8 +76,7 @@ class IsaAssaysControllerTest < ActionController::TestCase
     end
     isa_assay = assigns(:isa_assay)
     assert_redirected_to controller: 'single_pages', action: 'show', id: isa_assay.assay.projects.first.id,
-                         params: { notice: 'The ISA assay was created successfully!',
-                                   item_type: 'assay', item_id: Assay.last.id }
+                         params: { item_type: 'assay', item_id: Assay.last.id }
 
     sample_types = SampleType.last(2)
     title = sample_types[0].sample_attributes.detect(&:is_title).title
@@ -139,7 +138,7 @@ class IsaAssaysControllerTest < ActionController::TestCase
     assay = FactoryBot.create(:assay, study:, contributor: person)
     put :update, params: { id: assay, isa_assay: { assay: { title: 'assay title' } } }
     assert_redirected_to single_page_path(id: project, item_type: 'assay', item_id: assay.id)
-    assert flash[:error].include?('Resource not found.')
+    assert flash[:error].include?('Sample type not found.')
 
     assay = FactoryBot.create(:assay, study:, sample_type: assay_type, contributor: person)
 
@@ -359,7 +358,7 @@ class IsaAssaysControllerTest < ActionController::TestCase
     end
 
     isa_assay = assigns(:isa_assay)
-    assert_redirected_to single_page_path(id: project, item_type: 'assay', item_id: isa_assay.assay.id, notice: 'The ISA assay was created successfully!')
+    assert_redirected_to single_page_path(id: project, item_type: 'assay', item_id: isa_assay.assay.id)
 
     assert_equal isa_assay.assay.sample_type.previous_linked_sample_type, study.sample_types.second
     assert_equal isa_assay.assay.next_linked_child_assay, end_assay
@@ -455,7 +454,7 @@ class IsaAssaysControllerTest < ActionController::TestCase
     end
 
     isa_assay = assigns(:isa_assay)
-    assert_redirected_to single_page_path(id: project, item_type: 'assay', item_id: isa_assay.assay.id, notice: 'The ISA assay was created successfully!')
+    assert_redirected_to single_page_path(id: project, item_type: 'assay', item_id: isa_assay.assay.id)
 
     assert_equal begin_assay.previous_linked_sample_type, study.sample_types.second
     assert_equal isa_assay.assay.sample_type.previous_linked_sample_type, begin_assay.sample_type
@@ -619,7 +618,7 @@ class IsaAssaysControllerTest < ActionController::TestCase
     # New assay stream should have position 1 and is of type 'number'
     assert_select 'input[type=number][value=1]#isa_assay_assay_position', count: 1
 
-    assay_stream2 = FactoryBot.create(:assay_stream, study: , contributor: person, position: 5)
+    FactoryBot.create(:assay_stream, study: , contributor: person, position: 5)
     get :new, params: { study_id: study.id, is_assay_stream: true }
     assert_response :success
     # New assay stream should have position 6 and is of type 'number'


### PR DESCRIPTION
- Doesn't return a '404' anymore when making a mistake at creation time.
- Clean up the views:
  - All logic has been transferred to the controllers.
  - Remove JS clutter.
- Better errors for ISA-JSON compliant assays and studies.
- Fixes #1891 