### PR TITLE
Update data_files_controller.rb

### DIFF
--- a/app/controllers/data_files_controller.rb
+++ b/app/controllers/data_files_controller.rb
@@ -169,7 +169,7 @@ class DataFilesController < ApplicationController
       SampleDataPersistJob.new(@data_file, @sample_type, User.current_user, assay_ids: params["assay_ids"]).queue_job
       flash[:notice] = 'Started creating extracted samples'
     else
-      @data_file.sample_persistence_task.update(status: "cancelled") if @data_file.sample_persistence_task&.success?
+      @data_file.sample_persistence_task.destroy if @data_file.sample_persistence_task&.success?
       SampleDataExtractionJob.new(@data_file, @sample_type).queue_job
     end
 

--- a/app/controllers/data_files_controller.rb
+++ b/app/controllers/data_files_controller.rb
@@ -169,6 +169,7 @@ class DataFilesController < ApplicationController
       SampleDataPersistJob.new(@data_file, @sample_type, User.current_user, assay_ids: params["assay_ids"]).queue_job
       flash[:notice] = 'Started creating extracted samples'
     else
+      @data_file.sample_persistence_task.update(status: "cancelled") if @data_file.sample_persistence_task&.success?
       SampleDataExtractionJob.new(@data_file, @sample_type).queue_job
     end
 


### PR DESCRIPTION
Set sample extraction status to 'cancelled' before re-extracting a datafile where samples have been deleted

Resolves #1900 