### PR TITLE
Fix add assay between assays

### DIFF
--- a/app/controllers/assays_controller.rb
+++ b/app/controllers/assays_controller.rb
@@ -171,15 +171,11 @@ class AssaysController < ApplicationController
     return unless @assay.is_isa_json_compliant?
     return unless @assay.has_linked_child_assay?
 
-    previous_assay_linked_st_id = @assay.previous_linked_sample_type&.id
+    previous_st = @assay.sample_type&.previous_linked_sample_type
+    next_st = @assay.sample_type&.next_linked_sample_types&.first
+    return unless previous_st && next_st
 
-    next_assay = @assay.next_linked_child_assay
-
-    next_assay_st_attr = next_assay.sample_type&.sample_attributes&.detect(&:input_attribute?)
-
-    return unless next_assay && previous_assay_linked_st_id && next_assay_st_attr
-
-    next_assay_st_attr.update(linked_sample_type_id: previous_assay_linked_st_id)
+    next_st.sample_attributes.detect(&:input_attribute?).update_column(:linked_sample_type_id, previous_st&.id)
   end
 
   def rearrange_assay_positions_at_destroy

--- a/app/forms/isa_assay.rb
+++ b/app/forms/isa_assay.rb
@@ -21,7 +21,7 @@ class IsaAssay
     if valid?
       if @assay.new_record? && !@assay.is_assay_stream?
         # connect the sample type multi link attribute to the last sample type of the assay's study
-        input_attribute = @sample_type.sample_attributes.detect(&:seek_sample_multi?)
+        input_attribute = @sample_type.sample_attributes.detect(&:input_attribute?)
         input_attribute.linked_sample_type_id = @input_sample_type_id
         title = SampleType.find(@input_sample_type_id).sample_attributes.detect(&:is_title).title
         input_attribute.title = "Input (#{title})"


### PR DESCRIPTION
Small changes for the ISA assays controller:
- Linkage is now done after the assay and sample type are created, which is simpler and more robust.
- Fixes #1656 
- Sample type Linkage after destroy is also simplified