### PR TITLE
Copy and set sample policies when they are persisted

### DIFF
--- a/app/jobs/task_job.rb
+++ b/app/jobs/task_job.rb
@@ -21,7 +21,6 @@ class TaskJob < ApplicationJob
   end
 
   def handle_error(exception)
-    raise exception
     task.update_attribute(:status, Task::STATUS_FAILED)
     task.update_attribute(:exception, exception.full_message)
     report_exception(exception, "Error occurred with a Task for Job: #{self.class.name}")

--- a/app/jobs/task_job.rb
+++ b/app/jobs/task_job.rb
@@ -21,6 +21,7 @@ class TaskJob < ApplicationJob
   end
 
   def handle_error(exception)
+    raise exception
     task.update_attribute(:status, Task::STATUS_FAILED)
     task.update_attribute(:exception, exception.full_message)
     report_exception(exception, "Error occurred with a Task for Job: #{self.class.name}")

--- a/lib/seek/samples/extractor.rb
+++ b/lib/seek/samples/extractor.rb
@@ -24,14 +24,18 @@ module Seek
 
           if samples.any?
             Sample.transaction do
+              #copy policy and trigger callbacks
               samples.each do |sample|
+                policy = @data_file.policy.deep_copy
+                policy.save
+                sample.policy = policy
                 sample.run_callbacks(:save) { false }
                 sample.run_callbacks(:create) { false }
               end
 
               last_id = Sample.last.try(:id) || 0
               sample_type = samples.first.sample_type
-	      project_ids = samples.first.project_ids
+	            project_ids = samples.first.project_ids
               Sample.import(samples, validate: false, batch_size: 2000)
               SampleTypeUpdateJob.new(sample_type, false).queue_job
 

--- a/lib/seek/samples/extractor.rb
+++ b/lib/seek/samples/extractor.rb
@@ -27,7 +27,7 @@ module Seek
               #copy policy and trigger callbacks
               samples.each do |sample|
                 policy = @data_file.policy.deep_copy
-                policy.save
+                policy.save(validate: false)
                 sample.policy = policy
                 sample.run_callbacks(:save) { false }
                 sample.run_callbacks(:create) { false }

--- a/test/unit/jobs/sample_data_persist_job_test.rb
+++ b/test/unit/jobs/sample_data_persist_job_test.rb
@@ -54,7 +54,9 @@ class SampleDataPersistJobTest < ActiveSupport::TestCase
 
     assert_equal 3, @data_file.extracted_samples.count
 
-    @data_file.extracted_samples.each do |sample|
+    samples = @data_file.extracted_samples
+
+    samples.each do |sample|
       assert_equal @sample_type, sample.sample_type
       assert_equal @person, sample.contributor
       assert_equal [@project_id], sample.project_ids
@@ -63,6 +65,15 @@ class SampleDataPersistJobTest < ActiveSupport::TestCase
       assert_equal 1, sample.policy.permissions.count
       assert_equal Policy::EDITING, sample.policy.permissions.first.access_type
     end
+
+    #check the policy and permissions are all uniq and not referencing each other
+    refute_equal @data_file.policy_id, samples.first.policy_id
+    policy_ids = samples.collect { |s| s.policy.id }
+    permission_ids = samples.collect { |s| s.policy.permissions.first.id }
+    assert_equal 3, policy_ids.count
+    assert_equal policy_ids, policy_ids.uniq
+    assert_equal 3, permission_ids.count
+    assert_equal permission_ids, permission_ids.uniq
   end
 
   test 'persists samples and associate with assay' do


### PR DESCRIPTION
* fix for #1899 

Although they were being copied and set and extracted, they didn't survive the process of being marshalled and retreived from the cache (due to an unsaved association). Now also set when being persisted.

There will be a slight performance hit from saving individual policies. Did look at importing them, but then the permissions aren't saved meaning permssions would need importing first and then matching up - decided this was too error prone for the release branch, maybe something to look at as part of Bioindustry (or other ) work if it becomes an issue.