### PR TITLE
Fix random schedule test failures & possibly others

### DIFF
--- a/lib/seek/util.rb
+++ b/lib/seek/util.rb
@@ -169,7 +169,7 @@ module Seek
 
     def self.cache(name, &block)
       @cache ||= {}
-      if Rails.env.development? # Don't use caching in development mode
+      unless Rails.env.production? # Don't use caching in development or test mode
         block.call
       else
         @cache[name] ||= block.call

--- a/lib/seek/util.rb
+++ b/lib/seek/util.rb
@@ -169,7 +169,7 @@ module Seek
 
     def self.cache(name, &block)
       @cache ||= {}
-      unless Rails.env.production? # Don't use caching in development or test mode
+      if Rails.env.development? # Don't use caching in development mode
         block.call
       else
         @cache[name] ||= block.call

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -71,13 +71,13 @@ Kernel.class_eval do
   end
 
   def with_config_value(config, value)
-    Seek::Util.clear_cached if config.to_s.ends_with?('enabled')
+    Seek::Util.clear_cached
     oldval = Seek::Config.send(config)
     Seek::Config.send("#{config}=", value)
     yield
   ensure
     Seek::Config.send("#{config}=", oldval)
-    Seek::Util.clear_cached if config.to_s.ends_with?('enabled')
+    Seek::Util.clear_cached
   end
 
   def with_config_values(settings)


### PR DESCRIPTION
Always clear the config cache when calling `with_config_value` in the tests, instead of when it ends with "_enabled".

* fixes #1917 

Doesn't appear to have any impact on test run duration, time (31m) was about the same duration as tests before the change.
