### PR TITLE
report the arguments when a job fails

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -59,7 +59,7 @@ class ApplicationJob < ActiveJob::Base
   end
 
   def report_exception(exception, message = nil, data = {})
-    data.merge!({job_class: self.class.name})
+    data.merge!({job_class: self.class.name, arguments: arguments.inspect})
     message ||= "Error executing job for #{self.class.name}"
     Seek::Errors::ExceptionForwarder.send_notification(exception, data: data)
     Rails.logger.error(message)


### PR DESCRIPTION
Report the arguments in the exception email when a job fails

relates to resolving #1889