### PR TITLE
when bives fails, correctly catch the exception and report the error

### DIFF
--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -38,7 +38,7 @@ class ModelsController < ApplicationController
         @crn = JSON.parse(json)["crnJson"]
         @comparison_html = JSON.parse(json)["reportHtml"]
       rescue Exception => e
-        #raise e unless Rails.env.production?
+        raise e unless Rails.env.production?
         flash.now[:error]="there was an error trying to compare the two versions - #{e.message.gsub(/[\s\S]*STDERR:/,'')}"
       end
     else

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -37,9 +37,9 @@ class ModelsController < ApplicationController
         json = compare @blob1.filepath, @blob2.filepath, ["reportHtml", "crnJson", "json", "SBML"]
         @crn = JSON.parse(json)["crnJson"]
         @comparison_html = JSON.parse(json)["reportHtml"]
-      rescue StandardError => e
-        raise e unless Rails.env.production?
-        flash.now[:error]="there was an error trying to compare the two versions - #{e.message}"
+      rescue Exception => e
+        #raise e unless Rails.env.production?
+        flash.now[:error]="there was an error trying to compare the two versions - #{e.message.gsub(/[\s\S]*STDERR:/,'')}"
       end
     else
       flash.now[:error]="One of the version files could not be found, or you are not authorized to examine it"


### PR DESCRIPTION
fixes the exception handling (Bives::ConversionError extends Exception, not StandardError) when model comparison fails.

Also reduce the error shown to just show the error and not the full STDOUT message from Bives.

* fix for #1921 