### PR TITLE
Unzip datafiles feature

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -50,6 +50,7 @@
 //= require DataTables-1.11.3/buttons.html5
 //= require DataTables-1.11.3/autoFill.bootstrap
 //= require samples
+//= require datafiles
 //= require jstree
 //= require clipboard
 //= require openbis

--- a/app/assets/javascripts/datafiles.js
+++ b/app/assets/javascripts/datafiles.js
@@ -1,8 +1,7 @@
 var Datafiles = {};
 
-Datafiles.initTable = function (selector, enableRowSelection, opts) {
+Datafiles.initTable = function (selector, opts) {
     var table;
-    enableRowSelection = enableRowSelection || false;
     opts = opts || {};
 
     $j('table tfoot th', selector).each( function () {
@@ -13,148 +12,8 @@ Datafiles.initTable = function (selector, enableRowSelection, opts) {
     var options = $j.extend({}, opts, {
         "lengthMenu": [ 5, 10, 25, 50, 75, 100 ],
         "pageLength": 10,
-        dom: '<"row"<"col-sm-10"lr><"col-sm-2 text-right"B>><"datafiles-table-container"t>ip', // Needed to place the buttons
-        "columnDefs": [{
-            "targets": [ 0, 1 ],
-            "visible": false,
-            "searchable": false
-        }],
-				buttons: [
-					{
-							extend: 'csvHtml5',
-							text: 'Export table',
-							exportOptions: {
-									columns: [':visible']
-							}
-					}
-				],
-				initComplete: function () {
-					if(opts.hideEmptyColumns) hideEmptyColumns(this);
-				}
-        //"initComplete": function () {  // THIS IS TOO SLOW - CRASHES BROWSER
-        //    console.log("Hiding empty columns");
-        //    table.columns().flatten().each(function (columnIndex) {
-        //        console.log("Col " + columnIndex);
-        //        if(table.columns(columnIndex).data()[0].every(function(v) { return v === null; }))
-        //            table.column(columnIndex).visible(false);
-        //    });
-        //}
+        dom: '<"row"<"col-sm-10"lr>><"datafiles-table-container"t>ip' // Needed to place the buttons
     });
-
-    if($j('table', selector).data('sourceUrl'))
-        options.ajax = $j('table', selector).data('sourceUrl');
-
-    if(options.ajax) {
-        options.columns = [{ data: 'id'},{ data: 'title'}];
-        $j('table thead th', selector).each(function (index, column) {
-            if($j(column).data('accessorName'))
-                options.columns.push({ data: 'data.' + $j(column).data('accessorName') });
-        });
-    }
-
-    // Date Columns
-    var dateColumns = [];
-    $j('table thead th', selector).each(function (index, column) {
-        if($j(column).data('columnType') == 'Date' ||
-           $j(column).data('columnType') == 'DateTime') {
-            dateColumns.push(index);
-        }
-    });
-    if(dateColumns.length > 0) {
-        options["columnDefs"].push({
-            "targets": dateColumns,
-            "type": "date"
-        });
-    }
-    // The following only needed if we're loading the data from ajax
-
-    if($j('table', selector).data('sourceUrl')) {
-        // Strain columns
-        var strainColumns = [];
-        $j('table thead th', selector).each(function (index, column) {
-            if($j(column).data('columnType') == 'SeekStrain') {
-                strainColumns.push(index);
-            }
-        });
-        if(strainColumns.length > 0) {
-            options["columnDefs"].push({
-                "targets": strainColumns,
-                "render": function (data, type, row) {
-                    if(data && data.id) {
-                        if (data.title)
-                            return '<a href="/strains/' + data.id + '">' + data.title + '</a>';
-                        else
-                            return '<span class="none_text">' + data.id + '</span>';
-                    } else {
-                        return '<span class="none_text">Not specified</span>';
-                    }
-                }
-            });
-        }
-        // SEEK datafile columns
-        var seekDatafileColumns = [];
-        $j('table thead th', selector).each(function (index, column) {
-            if(['SeekDatafile','SeekDatafileMulti'].includes($j(column).data('columnType'))) {
-                seekDatafileColumns.push(index);
-            }
-        });
-        if(seekDatafileColumns.length > 0) {
-            options["columnDefs"].push({
-                "targets": seekDatafileColumns,
-                "render": function (data, type, row) {
-                    var values = Array.isArray(data) ? data : [data];
-                    var result = $j.map(values, function(value, i) {
-                        if(value && value.id) {
-                            if (value.title)
-                                return '<a href="/datafiles/' + value.id + '">' + value.title + '</a>';
-                            else
-                                return '<span class="none_text">' + (value.id || value.title) + '</span>';
-                        } else {
-                            return '<span class="none_text">Not specified</span>';
-                        }
-                    })
-                    return result.join(", ")
-                }
-            });
-        }
-
-        // Title column
-        $j('table thead th', selector).each(function (index, column) {
-            if($j(column).data('titleColumn')) {
-                options["columnDefs"].push({
-                    "targets": [index],
-                    "render": function (data, type, row) {
-                        return '<a href="/datafiles/' + row.id + '">' + row.title + '</a>';
-                    }
-                });
-            }
-        });
-    }
-
-    if(enableRowSelection) {
-        $j.extend(options, options, {
-            dom: '<"row"<"col-sm-6"l><"col-sm-6 text-right"B>>r<"datafiles-table-container"t>ip', // Needed to place the buttons
-            buttons: [
-            {
-                text: 'Select All',
-                action: function () {
-                    table.rows().deselect();
-                    table.rows( {search:'applied'} ).select();
-                }
-            },
-            'selectNone'
-        ],
-            language: {
-            buttons: {
-                selectNone: "Clear Selection"
-            }
-        },
-            "select": {
-            style: 'multi'
-        }});
-
-        $j('table tbody tr', selector).addClass('clickable');
-    }
 
     table = $j('table', selector).DataTable(options);
 
@@ -180,10 +39,3 @@ Datafiles.initTable = function (selector, enableRowSelection, opts) {
     });
     return table;
 };
-
-function hideEmptyColumns(selector) {
-	const table = $j(selector).DataTable()
-	table.columns().every(function(idx) {
-		if (!this.data().toArray().some(x=>x)) table.column(idx).visible(false)
-	});
-}

--- a/app/assets/javascripts/datafiles.js
+++ b/app/assets/javascripts/datafiles.js
@@ -1,0 +1,189 @@
+var Datafiles = {};
+
+Datafiles.initTable = function (selector, enableRowSelection, opts) {
+    var table;
+    enableRowSelection = enableRowSelection || false;
+    opts = opts || {};
+
+    $j('table tfoot th', selector).each( function () {
+        var title = $j(this).data().searchTitle;
+        $j(this).html('<input type="text" class="form-control" placeholder="Search '+title+'" />');
+    });
+
+    var options = $j.extend({}, opts, {
+        "lengthMenu": [ 5, 10, 25, 50, 75, 100 ],
+        "pageLength": 10,
+        dom: '<"row"<"col-sm-10"lr><"col-sm-2 text-right"B>><"samples-table-container"t>ip', // Needed to place the buttons
+        "columnDefs": [{
+            "targets": [ 0, 1 ],
+            "visible": false,
+            "searchable": false
+        }],
+				buttons: [
+					{
+							extend: 'csvHtml5',
+							text: 'Export table',
+							exportOptions: {
+									columns: [':visible']
+							}
+					}
+				],
+				initComplete: function () {
+					if(opts.hideEmptyColumns) hideEmptyColumns(this);
+				}
+        //"initComplete": function () {  // THIS IS TOO SLOW - CRASHES BROWSER
+        //    console.log("Hiding empty columns");
+        //    table.columns().flatten().each(function (columnIndex) {
+        //        console.log("Col " + columnIndex);
+        //        if(table.columns(columnIndex).data()[0].every(function(v) { return v === null; }))
+        //            table.column(columnIndex).visible(false);
+        //    });
+        //}
+    });
+
+    if($j('table', selector).data('sourceUrl'))
+        options.ajax = $j('table', selector).data('sourceUrl');
+
+    if(options.ajax) {
+        options.columns = [{ data: 'id'},{ data: 'title'}];
+        $j('table thead th', selector).each(function (index, column) {
+            if($j(column).data('accessorName'))
+                options.columns.push({ data: 'data.' + $j(column).data('accessorName') });
+        });
+    }
+
+    // Date Columns
+    var dateColumns = [];
+    $j('table thead th', selector).each(function (index, column) {
+        if($j(column).data('columnType') == 'Date' ||
+           $j(column).data('columnType') == 'DateTime') {
+            dateColumns.push(index);
+        }
+    });
+    if(dateColumns.length > 0) {
+        options["columnDefs"].push({
+            "targets": dateColumns,
+            "type": "date"
+        });
+    }
+    // The following only needed if we're loading the data from ajax
+
+    if($j('table', selector).data('sourceUrl')) {
+        // Strain columns
+        var strainColumns = [];
+        $j('table thead th', selector).each(function (index, column) {
+            if($j(column).data('columnType') == 'SeekStrain') {
+                strainColumns.push(index);
+            }
+        });
+        if(strainColumns.length > 0) {
+            options["columnDefs"].push({
+                "targets": strainColumns,
+                "render": function (data, type, row) {
+                    if(data && data.id) {
+                        if (data.title)
+                            return '<a href="/strains/' + data.id + '">' + data.title + '</a>';
+                        else
+                            return '<span class="none_text">' + data.id + '</span>';
+                    } else {
+                        return '<span class="none_text">Not specified</span>';
+                    }
+                }
+            });
+        }
+        // SEEK sample columns
+        var seekSampleColumns = [];
+        $j('table thead th', selector).each(function (index, column) {
+            if(['SeekSample','SeekSampleMulti'].includes($j(column).data('columnType'))) {
+                seekSampleColumns.push(index);
+            }
+        });
+        if(seekSampleColumns.length > 0) {
+            options["columnDefs"].push({
+                "targets": seekSampleColumns,
+                "render": function (data, type, row) {
+                    var values = Array.isArray(data) ? data : [data];
+                    var result = $j.map(values, function(value, i) {
+                        if(value && value.id) {
+                            if (value.title)
+                                return '<a href="/samples/' + value.id + '">' + value.title + '</a>';
+                            else
+                                return '<span class="none_text">' + (value.id || value.title) + '</span>';
+                        } else {
+                            return '<span class="none_text">Not specified</span>';
+                        }
+                    })
+                    return result.join(", ")
+                }
+            });
+        }
+
+        // Title column
+        $j('table thead th', selector).each(function (index, column) {
+            if($j(column).data('titleColumn')) {
+                options["columnDefs"].push({
+                    "targets": [index],
+                    "render": function (data, type, row) {
+                        return '<a href="/samples/' + row.id + '">' + row.title + '</a>';
+                    }
+                });
+            }
+        });
+    }
+
+    if(enableRowSelection) {
+        $j.extend(options, options, {
+            dom: '<"row"<"col-sm-6"l><"col-sm-6 text-right"B>>r<"samples-table-container"t>ip', // Needed to place the buttons
+            buttons: [
+            {
+                text: 'Select All',
+                action: function () {
+                    table.rows().deselect();
+                    table.rows( {search:'applied'} ).select();
+                }
+            },
+            'selectNone'
+        ],
+            language: {
+            buttons: {
+                selectNone: "Clear Selection"
+            }
+        },
+            "select": {
+            style: 'multi'
+        }});
+
+        $j('table tbody tr', selector).addClass('clickable');
+    }
+
+    table = $j('table', selector).DataTable(options);
+
+    // DataTable
+    table.columns().every(function () {
+        var column = this;
+
+        $j('input', this.footer()).on('keyup change', function () {
+            if (column.search() !== this.value)
+                column.search(this.value).draw();
+        }).on('keydown', function (event) { // Stop enter key submitting form
+            if(event.keyCode == 13) {
+                event.preventDefault();
+                return false;
+            }
+        });
+    });
+
+    $j('table tbody td.sample-field-error div', selector).popover({
+        html: true,
+        placement: 'top',
+        trigger: 'hover'
+    });
+    return table;
+};
+
+function hideEmptyColumns(selector) {
+	const table = $j(selector).DataTable()
+	table.columns().every(function(idx) {
+		if (!this.data().toArray().some(x=>x)) table.column(idx).visible(false)
+	});
+}

--- a/app/assets/javascripts/datafiles.js
+++ b/app/assets/javascripts/datafiles.js
@@ -13,7 +13,7 @@ Datafiles.initTable = function (selector, enableRowSelection, opts) {
     var options = $j.extend({}, opts, {
         "lengthMenu": [ 5, 10, 25, 50, 75, 100 ],
         "pageLength": 10,
-        dom: '<"row"<"col-sm-10"lr><"col-sm-2 text-right"B>><"samples-table-container"t>ip', // Needed to place the buttons
+        dom: '<"row"<"col-sm-10"lr><"col-sm-2 text-right"B>><"datafiles-table-container"t>ip', // Needed to place the buttons
         "columnDefs": [{
             "targets": [ 0, 1 ],
             "visible": false,
@@ -91,22 +91,22 @@ Datafiles.initTable = function (selector, enableRowSelection, opts) {
                 }
             });
         }
-        // SEEK sample columns
-        var seekSampleColumns = [];
+        // SEEK datafile columns
+        var seekDatafileColumns = [];
         $j('table thead th', selector).each(function (index, column) {
-            if(['SeekSample','SeekSampleMulti'].includes($j(column).data('columnType'))) {
-                seekSampleColumns.push(index);
+            if(['SeekDatafile','SeekDatafileMulti'].includes($j(column).data('columnType'))) {
+                seekDatafileColumns.push(index);
             }
         });
-        if(seekSampleColumns.length > 0) {
+        if(seekDatafileColumns.length > 0) {
             options["columnDefs"].push({
-                "targets": seekSampleColumns,
+                "targets": seekDatafileColumns,
                 "render": function (data, type, row) {
                     var values = Array.isArray(data) ? data : [data];
                     var result = $j.map(values, function(value, i) {
                         if(value && value.id) {
                             if (value.title)
-                                return '<a href="/samples/' + value.id + '">' + value.title + '</a>';
+                                return '<a href="/datafiles/' + value.id + '">' + value.title + '</a>';
                             else
                                 return '<span class="none_text">' + (value.id || value.title) + '</span>';
                         } else {
@@ -124,7 +124,7 @@ Datafiles.initTable = function (selector, enableRowSelection, opts) {
                 options["columnDefs"].push({
                     "targets": [index],
                     "render": function (data, type, row) {
-                        return '<a href="/samples/' + row.id + '">' + row.title + '</a>';
+                        return '<a href="/datafiles/' + row.id + '">' + row.title + '</a>';
                     }
                 });
             }
@@ -133,7 +133,7 @@ Datafiles.initTable = function (selector, enableRowSelection, opts) {
 
     if(enableRowSelection) {
         $j.extend(options, options, {
-            dom: '<"row"<"col-sm-6"l><"col-sm-6 text-right"B>>r<"samples-table-container"t>ip', // Needed to place the buttons
+            dom: '<"row"<"col-sm-6"l><"col-sm-6 text-right"B>>r<"datafiles-table-container"t>ip', // Needed to place the buttons
             buttons: [
             {
                 text: 'Select All',
@@ -173,7 +173,7 @@ Datafiles.initTable = function (selector, enableRowSelection, opts) {
         });
     });
 
-    $j('table tbody td.sample-field-error div', selector).popover({
+    $j('table tbody td.datafile-field-error div', selector).popover({
         html: true,
         placement: 'top',
         trigger: 'hover'

--- a/app/controllers/data_files_controller.rb
+++ b/app/controllers/data_files_controller.rb
@@ -174,6 +174,13 @@ class DataFilesController < ApplicationController
     end
   end
 
+  def unzip_status
+    job_status = @data_file.unzip_task.status
+    respond_to do |format|
+      format.html { render partial: 'data_files/unzip_status', locals: { data_file: @data_file, job_status: job_status } }
+    end
+  end
+
   def extract_samples
     if params[:confirm]
       SampleDataPersistJob.new(@data_file, @sample_type, User.current_user, assay_ids: params["assay_ids"]).queue_job

--- a/app/controllers/data_files_controller.rb
+++ b/app/controllers/data_files_controller.rb
@@ -170,7 +170,7 @@ class DataFilesController < ApplicationController
       UnzipDataFilePersistJob.new(@data_file, User.current_user, assay_ids: params["assay_ids"]).queue_job
       flash[:notice] = 'Started creating unzipped data files'
     else
-      @data_file.unzip_persistence_task.update(status: "cancelled") if @data_file.unzip_persistence_task&.success?
+      @data_file.unzip_persistence_task.destroy if @data_file.unzip_persistence_task&.success?
       UnzipDataFileJob.new(@data_file).queue_job
 
     end

--- a/app/controllers/data_files_controller.rb
+++ b/app/controllers/data_files_controller.rb
@@ -180,6 +180,21 @@ class DataFilesController < ApplicationController
       format.html { render partial: 'data_files/unzip_status', locals: { data_file: @data_file, job_status: job_status } }
     end
   end
+  def confirm_unzip
+    @datafiles, @unused = Seek::DataFiles::Unzipper.new(@data_file).fetch.partition(&:valid?)
+    respond_to do |format|
+      format.html
+    end
+  end
+
+  def cancel_unzip
+    Seek::DataFiles::Unzipper.new(@data_file).clear
+
+    respond_to do |format|
+      flash[:notice] = 'Unzip cancelled'
+      format.html { redirect_to @data_file }
+    end
+  end
 
   def extract_samples
     if params[:confirm]

--- a/app/controllers/data_files_controller.rb
+++ b/app/controllers/data_files_controller.rb
@@ -165,9 +165,14 @@ class DataFilesController < ApplicationController
   end
   
   def unzip
-
+    if params[:confirm]
+      UnzipDataFilePersistJob.new(@data_file, User.current_user, assay_ids: params["assay_ids"]).queue_job
+      flash[:notice] = 'Started creating unzipped data files'
+    else
+      @data_file.unzip_persistence_task.update(status: "cancelled") if @data_file.unzip_persistence_task&.success?
       UnzipDataFileJob.new(@data_file).queue_job
 
+    end
 
     respond_to do |format|
       format.html { redirect_to @data_file }

--- a/app/controllers/data_files_controller.rb
+++ b/app/controllers/data_files_controller.rb
@@ -16,6 +16,7 @@ class DataFilesController < ApplicationController
   before_action :find_display_asset, only: [:show, :explore, :download]
   before_action :get_sample_type, only: :extract_samples
   before_action :check_already_extracted, only: :extract_samples
+  before_action :check_already_unzipped, only: :unzip
   before_action :forbid_new_version_if_samples, :only => :create_version
 
   before_action :oauth_client, only: :retrieve_nels_sample_metadata
@@ -508,6 +509,15 @@ class DataFilesController < ApplicationController
   def forbid_new_version_if_samples
     if @data_file.extracted_samples.any?
       flash[:error] = "Cannot upload a new version if samples have been extracted"
+      respond_to do |format|
+        format.html { redirect_to @data_file }
+      end
+    end
+  end
+
+  def check_already_unzipped
+    if @data_file.unzipped_files.any?
+      flash[:error] = 'Already unzipped this data file'
       respond_to do |format|
         format.html { redirect_to @data_file }
       end

--- a/app/controllers/data_files_controller.rb
+++ b/app/controllers/data_files_controller.rb
@@ -196,7 +196,7 @@ class DataFilesController < ApplicationController
   end
 
   def confirm_unzip
-    @datafiles, @unused = Seek::DataFiles::Unzipper.new(@data_file).fetch.partition(&:valid?)
+    @datafiles, @rejected_datafiles = Seek::DataFiles::Unzipper.new(@data_file).fetch.partition(&:valid?)
     respond_to do |format|
       format.html
     end

--- a/app/controllers/data_files_controller.rb
+++ b/app/controllers/data_files_controller.rb
@@ -163,6 +163,16 @@ class DataFilesController < ApplicationController
       format.html
     end
   end
+  
+  def unzip
+
+      UnzipDataFileJob.new(@data_file).queue_job
+
+
+    respond_to do |format|
+      format.html { redirect_to @data_file }
+    end
+  end
 
   def extract_samples
     if params[:confirm]

--- a/app/controllers/data_files_controller.rb
+++ b/app/controllers/data_files_controller.rb
@@ -185,6 +185,15 @@ class DataFilesController < ApplicationController
       format.html { render partial: 'data_files/unzip_status', locals: { data_file: @data_file, job_status: job_status } }
     end
   end
+
+  def unzip_persistence_status
+    job_status = @data_file.unzip_persistence_task.status
+
+    respond_to do |format|
+      format.html { render partial: 'data_files/unzip_persistence_status', locals: { data_file: @data_file, job_status: job_status, previous_status: params[:previous_status] } }
+    end
+  end
+
   def confirm_unzip
     @datafiles, @unused = Seek::DataFiles::Unzipper.new(@data_file).fetch.partition(&:valid?)
     respond_to do |format|

--- a/app/helpers/data_files_helper.rb
+++ b/app/helpers/data_files_helper.rb
@@ -70,6 +70,6 @@ module DataFilesHelper
     # there is permission and a task
     return false unless data_file.can_manage? && data_file.unzip_task&.persisted?
     # persistence isn't currently running or already taken place
-    return true
+    return !( data_file.unzip_persistence_task&.success? || data_file.unzip_persistence_task&.in_progress? )
   end
 end

--- a/app/helpers/data_files_helper.rb
+++ b/app/helpers/data_files_helper.rb
@@ -65,4 +65,11 @@ module DataFilesHelper
     rescue Seek::DataFiles::FetchException
       return true # allows to try again
   end
+  
+  def show_unzip_folder_status?(data_file)
+    # there is permission and a task
+    return false unless data_file.can_manage? && data_file.unzip_task&.persisted?
+    # persistence isn't currently running or already taken place
+    return true
+  end
 end

--- a/app/helpers/data_files_helper.rb
+++ b/app/helpers/data_files_helper.rb
@@ -60,7 +60,7 @@ module DataFilesHelper
   end
 
   def show_unzip_folder_button?(asset, display_asset)
-    return false unless ( asset.can_manage? && (display_asset.version == asset.version) && asset.zipped_folder?)
+    return false unless ( asset.can_manage? && (display_asset.version == asset.version) && asset.zipped_folder? && asset.unzipped_files.empty? )
     return ! ( asset.unzip_task&.in_progress? || ( asset.unzip_task&.success? && Seek::DataFiles::Unzipper.new(asset).fetch.present? ) )
     rescue Seek::DataFiles::FetchException
       return true # allows to try again

--- a/app/helpers/data_files_helper.rb
+++ b/app/helpers/data_files_helper.rb
@@ -58,4 +58,11 @@ module DataFilesHelper
     return if message.blank?
     render partial: 'data_files/multi-steps/exception_message', object: message
   end
+
+  def show_unzip_folder_button?(asset, display_asset)
+    return false unless ( asset.can_manage? && (display_asset.version == asset.version) && asset.zipped_folder?)
+    return ! ( asset.unzip_task&.in_progress? || ( asset.unzip_task&.success? && Seek::DataFiles::Unzipper.new(asset).fetch.present? ) )
+    rescue Seek::DataFiles::FetchException
+      return true # allows to try again
+  end
 end

--- a/app/jobs/queue_names.rb
+++ b/app/jobs/queue_names.rb
@@ -1,5 +1,6 @@
 class QueueNames
   SAMPLES = 'samples'.freeze
+  DATAFILES = 'datafiles'.freeze
   REMOTE_CONTENT = 'remotecontent'.freeze
   AUTH_LOOKUP = 'authlookup'.freeze
   DEFAULT = Delayed::Worker.default_queue_name

--- a/app/jobs/unzip_data_file_job.rb
+++ b/app/jobs/unzip_data_file_job.rb
@@ -2,10 +2,10 @@ class UnzipDataFileJob < TaskJob
     queue_as QueueNames::DATAFILES
   
     attr_reader :unzipper
-    def perform(data_file, overwrite: false)
+    def perform(data_file)
       @unzipper = Seek::DataFiles::Unzipper.new(data_file)
       @unzipper.clear
-      @unzipper.unzip(overwrite)
+      @unzipper.unzip
     end
   
     def task

--- a/app/jobs/unzip_data_file_job.rb
+++ b/app/jobs/unzip_data_file_job.rb
@@ -1,0 +1,20 @@
+class UnzipDataFileJob < TaskJob
+    queue_as QueueNames::DATAFILES
+  
+    attr_reader :unzipper
+    def perform(data_file, overwrite: false)
+      @unzipper = Seek::DataFiles::Unzipper.new(data_file)
+      @unzipper.clear
+      @unzipper.unzip(overwrite)
+    end
+  
+    def task
+      arguments[0].unzip_task
+    end
+  
+    def handle_error(exception)
+      super
+      @unzipper.clear if @unzipper
+    end
+  end
+  

--- a/app/jobs/unzip_data_file_persist_job.rb
+++ b/app/jobs/unzip_data_file_persist_job.rb
@@ -1,0 +1,29 @@
+class UnzipDataFilePersistJob < TaskJob
+  queue_as QueueNames::DATAFILES
+
+  attr_accessor :unzipper
+
+  def perform(data_file, user, assay_ids: [])
+    @unzipper = Seek::DataFiles::Unzipper.new(data_file)
+    Rails.logger.info('Starting to persist data_files')
+    time = Benchmark.measure do
+      User.with_current_user(user) do
+        datafiles = unzipper.persist(user).select(&:persisted?)
+        unzipper.clear
+        data_file.copy_assay_associations(datafiles, assay_ids) unless assay_ids.blank?
+      end
+    end
+
+    Rails.logger.info("Benchmark for persist: #{time}")
+  end
+
+  def task
+    arguments[0].unzip_persistence_task
+  end
+
+  def handle_error(exception)
+    super
+    @unzipper.clear if @unzipper
+  end
+
+end

--- a/app/models/data_file.rb
+++ b/app/models/data_file.rb
@@ -22,6 +22,9 @@ class DataFile < ApplicationRecord
   has_many :extracted_samples, class_name: 'Sample', foreign_key: :originating_data_file_id
   has_many :sample_resource_links, -> { where(resource_type: 'DataFile') }, class_name: 'SampleResourceLink', foreign_key: :resource_id
   has_many :linked_samples, through: :sample_resource_links, source: :sample
+  
+  has_many :unzipped_files, class_name: 'DataFile', foreign_key: :zip_origin_id
+  belongs_to :zip_origin, class_name: 'DataFile', optional: true
 
   has_many :workflow_data_files, dependent: :destroy, autosave: true
   has_many :workflows, ->{ distinct }, through: :workflow_data_files
@@ -131,6 +134,12 @@ class DataFile < ApplicationRecord
   def related_samples
     extracted_samples + linked_samples
   end
+
+  
+  def related_data_files
+    zip_origin.nil? ? unzipped_files : [zip_origin] + unzipped_files
+  end
+
   def unzip(overwrite, tmp_dir, confirm=false)
     unzip_folder = Zip::File.open(content_blob.filepath)
     FileUtils.rm_r(tmp_dir) if File.exist?(tmp_dir)

--- a/app/models/data_file.rb
+++ b/app/models/data_file.rb
@@ -22,9 +22,6 @@ class DataFile < ApplicationRecord
   has_many :extracted_samples, class_name: 'Sample', foreign_key: :originating_data_file_id
   has_many :sample_resource_links, -> { where(resource_type: 'DataFile') }, class_name: 'SampleResourceLink', foreign_key: :resource_id
   has_many :linked_samples, through: :sample_resource_links, source: :sample
-  
-  has_many :unzipped_files, class_name: 'DataFile', foreign_key: :zip_origin_id
-  belongs_to :zip_origin, class_name: 'DataFile', optional: true
 
   has_many :workflow_data_files, dependent: :destroy, autosave: true
   has_many :workflows, ->{ distinct }, through: :workflow_data_files
@@ -133,11 +130,6 @@ class DataFile < ApplicationRecord
 
   def related_samples
     extracted_samples + linked_samples
-  end
-
-  
-  def related_data_files
-    zip_origin.nil? ? unzipped_files : [zip_origin] + unzipped_files
   end
 
   def unzip(tmp_dir)

--- a/app/models/data_file.rb
+++ b/app/models/data_file.rb
@@ -110,6 +110,11 @@ class DataFile < ApplicationRecord
   def supports_spreadsheet_explore?
     true
   end
+  
+  def zipped_folder?
+    return false if external_asset.is_a? OpenbisExternalAsset
+    content_blob.is_unzippable_datafile?
+  end
 
   def matching_sample_type?
     return false if external_asset.is_a? OpenbisExternalAsset
@@ -231,4 +236,5 @@ class DataFile < ApplicationRecord
 
   has_task :sample_extraction
   has_task :sample_persistence
+  has_task :unzip
 end

--- a/app/models/data_file.rb
+++ b/app/models/data_file.rb
@@ -140,7 +140,7 @@ class DataFile < ApplicationRecord
     zip_origin.nil? ? unzipped_files : [zip_origin] + unzipped_files
   end
 
-  def unzip(overwrite, tmp_dir, confirm=false)
+  def unzip(tmp_dir)
     unzip_folder = Zip::File.open(content_blob.filepath)
     FileUtils.rm_r(tmp_dir) if File.exist?(tmp_dir)
     Dir.mkdir(tmp_dir)

--- a/app/models/data_file.rb
+++ b/app/models/data_file.rb
@@ -22,6 +22,9 @@ class DataFile < ApplicationRecord
   has_many :extracted_samples, class_name: 'Sample', foreign_key: :originating_data_file_id
   has_many :sample_resource_links, -> { where(resource_type: 'DataFile') }, class_name: 'SampleResourceLink', foreign_key: :resource_id
   has_many :linked_samples, through: :sample_resource_links, source: :sample
+  
+  has_many :unzipped_files, class_name: 'DataFile', foreign_key: :zip_origin_id
+  belongs_to :zip_origin, class_name: 'DataFile', optional: true
 
   has_many :workflow_data_files, dependent: :destroy, autosave: true
   has_many :workflows, ->{ distinct }, through: :workflow_data_files
@@ -130,6 +133,11 @@ class DataFile < ApplicationRecord
 
   def related_samples
     extracted_samples + linked_samples
+  end
+
+  
+  def related_data_files
+    zip_origin.nil? ? unzipped_files : [zip_origin] + unzipped_files
   end
 
   def unzip(tmp_dir)

--- a/app/models/data_file.rb
+++ b/app/models/data_file.rb
@@ -259,4 +259,5 @@ class DataFile < ApplicationRecord
   has_task :sample_extraction
   has_task :sample_persistence
   has_task :unzip
+  has_task :unzip_persistence
 end

--- a/app/models/data_file.rb
+++ b/app/models/data_file.rb
@@ -131,6 +131,28 @@ class DataFile < ApplicationRecord
   def related_samples
     extracted_samples + linked_samples
   end
+  def unzip(overwrite, tmp_dir, confirm=false)
+    unzip_folder = Zip::File.open(content_blob.filepath)
+    FileUtils.rm_r(tmp_dir) if File.exist?(tmp_dir)
+    Dir.mkdir(tmp_dir)
+    unzipped =[]
+    unzip_folder.entries.each do |file|
+      if file.ftype == :file
+        file_name = File.basename(file.name)
+        file.extract("#{tmp_dir}#{file_name}") unless File.exist? "#{tmp_dir}#{file_name}"
+        data_file_params = {
+          title: file_name,
+            license: license,
+            projects: projects,
+            description: '',
+            contributor_id: contributor.id,
+            zip_origin_id: self.id
+        }
+        unzipped << DataFile.new(data_file_params)
+      end
+    end
+    unzipped
+  end
 
   # Extracts samples using the given sample_type
   # Returns a list of extracted samples, including

--- a/app/views/assets/_asset_buttons.html.erb
+++ b/app/views/assets/_asset_buttons.html.erb
@@ -27,6 +27,9 @@
       <%= render partial: 'data_files/extract_samples_button' %>
   <% end %>
 
+  <% if show_unzip_folder_button?(asset, display_asset) %>
+      <%= button_link_to('Unzip datafile', 'unzip_folder', unzip_data_file_path(@data_file), method: :post) %>
+  <% end %>
 <% end %>
 
 <% if asset.is_downloadable? -%>

--- a/app/views/assets/_upload_box.html.erb
+++ b/app/views/assets/_upload_box.html.erb
@@ -8,7 +8,7 @@
 <%= panel(title, id: id) do %>
   <div>
     <p>
-      You can register a <%= asset_name -%> by either directly uploading a file,
+      You can register a <%= asset_name -%> by either directly uploading a file<%= ' or zipped folder' if asset_name == 'Data file' %>,
       or registering a URL to a remote file or web page.
     </p>
   </div>

--- a/app/views/data_files/_table_view.html.erb
+++ b/app/views/data_files/_table_view.html.erb
@@ -1,0 +1,34 @@
+<% link ||= false %>
+
+
+
+<div data-role="seek-association-candidate-list">
+  <div class="table-responsive">
+    <table class="table table-bordered datafiles-table" style="width: 100%">
+      <% [:thead, :tfoot].each do |section| %>
+          <%= content_tag(section) do %>
+              <tr>
+                <th>ID</th>
+                <th>Title</th>
+
+              </tr>
+          <% end %>
+      <% end %>
+      <tbody>
+      <% datafiles.each do |datafiles| %>
+          <%= content_tag(:tr) do %>
+              <td><%= datafiles.id %></td>
+              <td><%= datafiles.title %></td>
+          <% end %>
+
+      <% end %>
+      </tbody>
+    </table>
+  </div>
+  <% if datafiles.map { |s| s.errors.any? }.all? %>
+      <%= modal(id: 'datafiles-error-modal') do %>
+          <%= modal_header 'Errors' %>
+          <%= modal_body {} %>
+      <% end %>
+  <% end %>
+</div>

--- a/app/views/data_files/_table_view.html.erb
+++ b/app/views/data_files/_table_view.html.erb
@@ -1,26 +1,20 @@
 <% link ||= false %>
 
-
-
 <div data-role="seek-association-candidate-list">
   <div class="table-responsive">
     <table class="table table-bordered datafiles-table" style="width: 100%">
       <% [:thead, :tfoot].each do |section| %>
           <%= content_tag(section) do %>
               <tr>
-                <th>ID</th>
-                <th>Title</th>
-
+                <th data-column-type="String" data-search-title="Filename">Filename</th>
               </tr>
           <% end %>
       <% end %>
       <tbody>
       <% datafiles.each do |datafiles| %>
           <%= content_tag(:tr) do %>
-              <td><%= datafiles.id %></td>
               <td><%= datafiles.title %></td>
           <% end %>
-
       <% end %>
       </tbody>
     </table>

--- a/app/views/data_files/_unzip_persistence_status.html.erb
+++ b/app/views/data_files/_unzip_persistence_status.html.erb
@@ -1,0 +1,52 @@
+<% return unless data_file.can_manage? %>
+<% task =  data_file.unzip_persistence_task %>
+<% return unless task&.persisted? %>
+
+<% job_status ||= task.status %>
+<% previous_status ||= params[:previous_status] %>
+<% in_progress = task.in_progress? %>
+<% just_failed = task.failed? && Task.status_in_progress?(previous_status) %>
+<% just_finished = task.completed? && task.success? && Task.status_in_progress?(previous_status) %>
+
+<%
+  alert_style = 'alert-info'
+  alert_style = 'alert-warning' if just_failed
+  alert_style = 'alert-success' if just_finished
+%>
+
+<div id="unzip-persistence-status">
+  <% if (in_progress || just_finished || just_failed) %>
+    <div class="alert <%= alert_style %>" role="alert">
+      <strong>Creating unzipped datafiles:</strong>
+      <% if in_progress %>
+        <%= job_status.to_s.humanize %>
+        <%= image 'spinner' %>
+        <script>
+            setTimeout(function () {
+                $j.ajax('<%= unzip_persistence_status_data_file_path(data_file) %>', {
+                        data: { 'previous_status': '<%= job_status -%>' },
+                        success: function (html) {
+                            $j('#unzip-persistence-status').replaceWith(html);
+                        }
+                    }
+                );
+            }, 5000);
+        </script>
+      <% end %>
+      <% if just_failed %>
+        Failed. An administrator will have been notified of the problem
+      <% end %>
+      <% if just_finished %>
+        <% if task.success? %>
+          Data file unzip complete.
+          <p>
+            You can view the new data files by clicking the button below.
+          </p>
+          <%= link_to('View Created Data Files', data_file_data_files_path(data_file),
+                      class: 'btn btn-primary') %>
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
+
+</div>

--- a/app/views/data_files/_unzip_status.html.erb
+++ b/app/views/data_files/_unzip_status.html.erb
@@ -1,0 +1,53 @@
+
+<% return unless show_unzip_folder_status?(data_file) %>
+
+<%
+  task = data_file.unzip_task
+  job_status ||= task.status
+  in_progress = task.in_progress?
+  failed = task.failed?
+  begin
+    success = task.success? && Seek::DataFiles::Unzipper.new(data_file).fetch.present?
+  rescue Seek::DataFiles::FetchException
+    success = false
+  end
+%>
+
+<%
+  alert_style = 'alert-info'
+  alert_style = 'alert-warning' if failed
+  alert_style = 'alert-success' if success
+%>
+
+<div id="unzip-status">
+  <% if in_progress || failed || success %>
+      <div class="alert <%= alert_style %>" role="alert">
+        <strong>Unzip:</strong>
+        <% if in_progress %>
+            <%= job_status.to_s.humanize %>
+            <%= image 'spinner' %>
+            <script>
+              setTimeout(function () {
+                $j.ajax('<%= unzip_status_data_file_path(data_file) %>', {
+                      data: { 'previous_status': '<%= job_status -%>' },
+                      success: function (html) {
+                        $j('#unzip-status').replaceWith(html);
+                      }
+                    }
+                );
+              }, 5000);
+            </script>
+        <% elsif failed %>
+          Failed. An administrator will have been notified of the problem, but you could try again.
+        <% elsif success  %>
+            Waiting for confirmation
+            <p>
+              Please review the unzipped files by clicking the button below, and decide whether to continue or cancel
+              the unzip process.
+            </p>
+            <%= link_to('Review Unzipped Datafiles', confirm_unzip_data_file_path(data_file),
+                        class: 'btn btn-primary') %>
+        <% end %>
+      </div>
+  <% end %>
+</div>

--- a/app/views/data_files/confirm_unzip.html.erb
+++ b/app/views/data_files/confirm_unzip.html.erb
@@ -30,7 +30,7 @@
           <%= render partial: 'data_files/table_view', locals: { datafiles: @datafiles } %>
           <script>
             $j(document).ready(function () {
-              DataFiles.initTable($j('#accepted'));
+              Datafiles.initTable($j('#accepted'));
             });
           </script>
         </div>  
@@ -40,7 +40,7 @@
               <%= render partial: 'data_files/table_view', locals: { datafiles: @rejected_datafiles } %>
               <script>
                 $j(document).ready(function () {
-                  DataFiles.initTable($j('#rejected'));
+                  Datafiles.initTable($j('#rejected'));
                 });
               </script>
             </div>

--- a/app/views/data_files/confirm_unzip.html.erb
+++ b/app/views/data_files/confirm_unzip.html.erb
@@ -1,0 +1,46 @@
+<% total = @datafiles.count%>
+
+<% if total > 0 %>
+    <div class="alert alert-info">
+      The following datafiles were detected in the zipped file.
+      Please review them, then click "Confirm" below to complete the process, or "Cancel Unzip" to cancel
+      the extraction process.
+    </div>
+    <div class="tab-content">
+      <% if @datafiles.any? %>
+        <%= render partial: 'data_files/table_view', locals: { datafiles: @datafiles } %>
+        <script>
+          $j(document).ready(function () {
+            DataFiles.initTable($j('#accepted'));
+          });
+        </script>
+      <% end %>
+    </div>
+<% else %>
+    <span class="none_text">No files were unzipped</span>
+<% end %>
+
+<hr/>
+<%= form_tag(unzip_data_file_path(@data_file)) do %>
+    <%= hidden_field_tag(:confirm, 'true') %>
+
+    <% if authorised_assays.intersect?(@data_file.assays) %>
+        <h3>Link to assays</h3>
+        The zipped data file is linked to the following assays.
+        Check the corresponding checkbox to link the new data files to each assay.
+        <% authorised_assays.intersection(@data_file.assays).each do |aa| %>
+            <div class="checkbox">
+              <label>
+                <%= check_box_tag('assay_ids[]', aa.id, false, autocomplete: 'off') %>
+                <%= aa.title %>
+              </label>
+            </div>
+        <% end %>
+
+        <hr/>
+    <% end %>
+
+    <%= submit_tag "Confirm", :class => 'btn btn-primary',disabled: @datafiles.empty? -%>
+    or <%= cancel_button(cancel_unzip_data_file_path(@data_file), button_text: 'Cancel Unzip', method: :delete) -%>
+<% end %>
+

--- a/app/views/data_files/confirm_unzip.html.erb
+++ b/app/views/data_files/confirm_unzip.html.erb
@@ -1,4 +1,4 @@
-<% total = @datafiles.count%>
+<% total = @datafiles.count + @rejected_datafiles.count %>
 
 <% if total > 0 %>
     <div class="alert alert-info">
@@ -6,15 +6,45 @@
       Please review them, then click "Confirm" below to complete the process, or "Cancel Unzip" to cancel
       the extraction process.
     </div>
+        <div>
+      <ul class="nav nav-tabs" role="tablist">
+        <% if @datafiles.any? %>
+            <li role="presentation" class="active">
+              <a href="#accepted" aria-controls="home" role="tab" data-toggle="tab">
+                Accepted (<%= @datafiles.count -%>/<%= total %>)
+              </a>
+            </li>
+        <% end %>
+        <% if @rejected_datafiles.any? %>
+            <li role="presentation" class="<%= 'active' if @samples.none? -%>">
+              <a href="#rejected" aria-controls="profile" role="tab" data-toggle="tab">
+                Rejected (<%= @rejected_datafiles.count -%>/<%= total %>)
+              </a>
+            </li>
+        <% end %>
+      </ul>
+
     <div class="tab-content">
       <% if @datafiles.any? %>
-        <%= render partial: 'data_files/table_view', locals: { datafiles: @datafiles } %>
-        <script>
-          $j(document).ready(function () {
-            DataFiles.initTable($j('#accepted'));
-          });
-        </script>
+        <div role="tabpanel" class="tab-pane active" id="accepted">
+          <%= render partial: 'data_files/table_view', locals: { datafiles: @datafiles } %>
+          <script>
+            $j(document).ready(function () {
+              DataFiles.initTable($j('#accepted'));
+            });
+          </script>
+        </div>  
       <% end %>
+        <% if @rejected_datafiles.any? %>
+            <div role="tabpanel" class="tab-pane <%= 'active' if @datafiles.none? -%>" id="rejected">
+              <%= render partial: 'data_files/table_view', locals: { datafiles: @rejected_datafiles } %>
+              <script>
+                $j(document).ready(function () {
+                  DataFiles.initTable($j('#rejected'));
+                });
+              </script>
+            </div>
+        <% end %>
     </div>
 <% else %>
     <span class="none_text">No files were unzipped</span>

--- a/app/views/data_files/show.html.erb
+++ b/app/views/data_files/show.html.erb
@@ -12,6 +12,7 @@
         <%= render :partial => "data_files/sample_extraction_status", :locals => {:data_file => @data_file} %>
         <%= render :partial => "data_files/sample_persistence_status", :locals => {:data_file => @data_file} %>
         <%= render :partial => "data_files/unzip_status", :locals => {:data_file => @data_file} %>
+        <%= render :partial => "data_files/unzip_persistence_status", :locals => {:data_file => @data_file} %>
 
         <%= item_description @display_data_file.description -%>
 

--- a/app/views/data_files/show.html.erb
+++ b/app/views/data_files/show.html.erb
@@ -11,6 +11,7 @@
       <div class="col-md-9 col-sm-8 box_about_actor">
         <%= render :partial => "data_files/sample_extraction_status", :locals => {:data_file => @data_file} %>
         <%= render :partial => "data_files/sample_persistence_status", :locals => {:data_file => @data_file} %>
+        <%= render :partial => "data_files/unzip_status", :locals => {:data_file => @data_file} %>
 
         <%= item_description @display_data_file.description -%>
 

--- a/config/image_files/image_file_dictionary.yml
+++ b/config/image_files/image_file_dictionary.yml
@@ -171,6 +171,8 @@ extract_samples: 'famfamfam_silk/table_go.png'
 view_samples: 'famfamfam_silk/table.png'
 external_link: 'famfamfam_silk/arrow_right.png'
 
+unzip_folder: 'famfamfam_silk/folder_page_white.png'
+
 # avatars
 specimen_avatar: 'misc_icons/green_virus-64x64.png'
 strain_avatar: 'misc_icons/enterococcus_faecalis64-64.jpg'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -504,7 +504,7 @@ SEEK::Application.routes.draw do
       delete :cancel_unzip
       get :unzip_persistence_status
     end
-    resources :people, :programmes, :projects, :investigations, :assays, :data_files, :samples, :studies, :publications, :events, :collections, :workflows, :file_templates, :placeholders, only: [:index]
+    resources :people, :programmes, :projects, :investigations, :assays, :samples, :studies, :publications, :events, :collections, :workflows, :file_templates, :placeholders, only: [:index]
   end
 
   resources :presentations, concerns: [:has_content_blobs, :publishable, :has_versions, :asset, :explorable_spreadsheet] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -500,6 +500,8 @@ SEEK::Application.routes.draw do
       get :has_matching_sample_type
       post :unzip
       get :unzip_status
+      get :confirm_unzip
+      delete :cancel_unzip
     end
     resources :people, :programmes, :projects, :investigations, :assays, :samples, :studies, :publications, :events, :collections, :workflows, :file_templates, :placeholders, only: [:index]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -504,7 +504,7 @@ SEEK::Application.routes.draw do
       delete :cancel_unzip
       get :unzip_persistence_status
     end
-    resources :people, :programmes, :projects, :investigations, :assays, :samples, :studies, :publications, :events, :collections, :workflows, :file_templates, :placeholders, only: [:index]
+    resources :people, :programmes, :projects, :investigations, :assays, :data_files, :samples, :studies, :publications, :events, :collections, :workflows, :file_templates, :placeholders, only: [:index]
   end
 
   resources :presentations, concerns: [:has_content_blobs, :publishable, :has_versions, :asset, :explorable_spreadsheet] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -499,6 +499,7 @@ SEEK::Application.routes.draw do
       get :retrieve_nels_sample_metadata
       get :has_matching_sample_type
       post :unzip
+      get :unzip_status
     end
     resources :people, :programmes, :projects, :investigations, :assays, :samples, :studies, :publications, :events, :collections, :workflows, :file_templates, :placeholders, only: [:index]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -498,6 +498,7 @@ SEEK::Application.routes.draw do
       post :retrieve_nels_sample_metadata
       get :retrieve_nels_sample_metadata
       get :has_matching_sample_type
+      post :unzip
     end
     resources :people, :programmes, :projects, :investigations, :assays, :samples, :studies, :publications, :events, :collections, :workflows, :file_templates, :placeholders, only: [:index]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -502,6 +502,7 @@ SEEK::Application.routes.draw do
       get :unzip_status
       get :confirm_unzip
       delete :cancel_unzip
+      get :unzip_persistence_status
     end
     resources :people, :programmes, :projects, :investigations, :assays, :samples, :studies, :publications, :events, :collections, :workflows, :file_templates, :placeholders, only: [:index]
   end

--- a/db/migrate/20240403114645_add_zip_origin_id_to_data_files.rb
+++ b/db/migrate/20240403114645_add_zip_origin_id_to_data_files.rb
@@ -1,6 +1,0 @@
-class AddZipOriginIdToDataFiles < ActiveRecord::Migration[6.1]
-    def change
-      add_column :data_files, :zip_origin_id, :integer
-    end
-  end
-  

--- a/db/migrate/20240403114645_add_zip_origin_id_to_data_files.rb
+++ b/db/migrate/20240403114645_add_zip_origin_id_to_data_files.rb
@@ -1,0 +1,6 @@
+class AddZipOriginIdToDataFiles < ActiveRecord::Migration[6.1]
+    def change
+      add_column :data_files, :zip_origin_id, :integer
+    end
+  end
+  

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_03_11_113858) do
+ActiveRecord::Schema.define(version: 2024_04_03_114645) do
 
   create_table "activity_logs", id: :integer, force: :cascade do |t|
     t.string "action"
@@ -425,6 +425,7 @@ ActiveRecord::Schema.define(version: 2024_03_11_113858) do
     t.boolean "simulation_data", default: false
     t.string "deleted_contributor"
     t.integer "file_template_id"
+    t.integer "zip_origin_id"
     t.index ["contributor_id"], name: "index_data_files_on_contributor"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_03_11_113858) do
+ActiveRecord::Schema.define(version: 2024_04_03_114645) do
 
   create_table "activity_logs", id: :integer, force: :cascade do |t|
     t.string "action"
@@ -425,6 +425,7 @@ ActiveRecord::Schema.define(version: 2024_03_11_113858) do
     t.boolean "simulation_data", default: false
     t.string "deleted_contributor"
     t.integer "file_template_id"
+    t.integer "zip_origin_id"
     t.index ["contributor_id"], name: "index_data_files_on_contributor"
   end
 
@@ -1751,10 +1752,19 @@ ActiveRecord::Schema.define(version: 2024_03_11_113858) do
     t.datetime "updated_at", null: false
     t.string "first_letter", limit: 1
     t.string "source_ontology"
+<<<<<<< HEAD
     t.string "ols_root_term_uris"
     t.string "short_name"
     t.string "key"
     t.integer "template_id"
+=======
+    t.string "ols_root_term_uri"
+    t.string "short_name"
+    t.string "key"
+    t.integer "template_id"
+    t.boolean "required"
+    t.boolean "custom_input", default: false
+>>>>>>> a9173fb24b (Add unzipped files as related datafiles)
   end
 
   create_table "sample_resource_links", id: :integer, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_04_03_114645) do
+ActiveRecord::Schema.define(version: 2024_03_11_113858) do
 
   create_table "activity_logs", id: :integer, force: :cascade do |t|
     t.string "action"
@@ -425,7 +425,6 @@ ActiveRecord::Schema.define(version: 2024_04_03_114645) do
     t.boolean "simulation_data", default: false
     t.string "deleted_contributor"
     t.integer "file_template_id"
-    t.integer "zip_origin_id"
     t.index ["contributor_id"], name: "index_data_files_on_contributor"
   end
 
@@ -1752,19 +1751,10 @@ ActiveRecord::Schema.define(version: 2024_04_03_114645) do
     t.datetime "updated_at", null: false
     t.string "first_letter", limit: 1
     t.string "source_ontology"
-<<<<<<< HEAD
     t.string "ols_root_term_uris"
     t.string "short_name"
     t.string "key"
     t.integer "template_id"
-=======
-    t.string "ols_root_term_uri"
-    t.string "short_name"
-    t.string "key"
-    t.integer "template_id"
-    t.boolean "required"
-    t.boolean "custom_input", default: false
->>>>>>> a9173fb24b (Add unzipped files as related datafiles)
   end
 
   create_table "sample_resource_links", id: :integer, force: :cascade do |t|

--- a/lib/seek/content_type_detection.rb
+++ b/lib/seek/content_type_detection.rb
@@ -53,9 +53,18 @@ module Seek
     def is_extractable_spreadsheet?(blob = self)
       blob.file_exists? && (is_extractable_excel?(blob) || is_csv?(blob) || is_tsv?(blob))
     end
+    
+    # is any zipped format, that can be extracted from
+    def is_unzippable_datafile?(blob = self)
+      blob.file_exists? && (is_zip?(blob))
+    end
 
     def is_in_simulatable_size_limit?(blob = self)
       !blob.file_size.nil? && blob.file_size < MAX_SIMULATABLE_SIZE
+    end
+    
+    def is_zip?(blob = self)
+      blob.content_type_file_extensions.include?('zip')
     end
 
     def is_xlsx?(blob = self)

--- a/lib/seek/data_files/unzipper.rb
+++ b/lib/seek/data_files/unzipper.rb
@@ -18,7 +18,7 @@ module Seek
         # Persist the extracted datafiles to the database
         def persist(user = User.current_user)
           User.with_current_user(user) do
-            data_files = unzip.select(&:valid?) # Re-extracts samples if cache expired, otherwise returns the cached samples
+            data_files = unzip.select(&:valid?) # Re-unzips datafiles if cache expired, otherwise returns the cached datafiles
   
             if data_files.any?
               DataFile.transaction do
@@ -54,13 +54,13 @@ module Seek
           end
         end
   
-        # Clear the temporarily-stored samples
+        # Clear the temporarily-stored datafiles
         def clear
           File.delete(cache_path) if File.exist?(cache_path)
           FileUtils.rm_r(tmp_file_path) if File.exist?(tmp_file_path)
         end
   
-        # Return the temporarily-stored samples if they exist (nil if not)
+        # Return the temporarily-stored datafiles if they exist (nil if not)
         def fetch
           self.class.decode(cache)
         rescue ArgumentError=>exception

--- a/lib/seek/data_files/unzipper.rb
+++ b/lib/seek/data_files/unzipper.rb
@@ -70,19 +70,19 @@ module Seek
         private
   
         def cache_path
-          "#{Seek::Config.temporary_filestore_path}/#{cache_key}"
-        end
-  
-        def cache_key
-          "unzipped-datafiles-#{@data_file.id}"
+          "#{cache_key}-metadata"
         end
 
         def tmp_file_path
-          tmp_dir = "#{Rails.root}/tmp/#{cache_key}/"
+          "#{cache_key}-files/"
+        end
+  
+        def cache_key
+          "#{Seek::Config.temporary_filestore_path}/unzipped-datafiles-#{@data_file.id}"
         end
 
         def cache(&block)
-          if File.exist?(cache_path) & File.exist?(tmp_file_path)
+          if File.exist?(cache_path) & Dir.exist?(tmp_file_path)
             Marshal.load(File.binread(cache_path))
           elsif block_given?
             v = block.call

--- a/lib/seek/data_files/unzipper.rb
+++ b/lib/seek/data_files/unzipper.rb
@@ -1,0 +1,75 @@
+module Seek
+
+    module DataFiles
+  
+      class FetchException < StandardError; end
+  
+      # Class to handle the extraction and temporary storage of samples from a data file
+      class Unzipper
+        def initialize(data_file)
+          @data_file = data_file
+        end
+  
+        # Unzip datafiles and store in the filesystem temporarily
+        def unzip(overwrite = false)
+          self.class.decode(cache { self.class.encode(@data_file.unzip(overwrite, tmp_file_path, confirm=false)) })
+        end
+  
+  
+        # Clear the temporarily-stored samples
+        def clear
+          File.delete(cache_path) if File.exist?(cache_path)
+          FileUtils.rm_r(tmp_file_path) if File.exist?(tmp_file_path)
+        end
+  
+        # Return the temporarily-stored samples if they exist (nil if not)
+        def fetch
+          self.class.decode(cache)
+        rescue ArgumentError=>exception
+          raise FetchException.new(exception.message)
+        end
+  
+        private
+  
+        def cache_path
+          "#{Seek::Config.temporary_filestore_path}/#{cache_key}"
+        end
+  
+        def cache_key
+          "unzipped-datafiles-#{@data_file.id}"
+        end
+
+        def tmp_file_path
+          tmp_dir = "#{Rails.root}/tmp/#{cache_key}/"
+        end
+
+        def cache(&block)
+          if File.exist?(cache_path)
+            Marshal.load(File.binread(cache_path))
+          elsif block_given?
+            v = block.call
+            File.open(cache_path, 'wb') do |f|
+              f.write(Marshal.dump(v))
+              v
+            end
+          end
+        end
+  
+        def self.encode(values)
+          values.map do |value|
+            value.attributes.merge(project_ids: value.project_ids) # Associations aren't included in `attributes`
+          end
+        end
+  
+        def self.decode(values)
+          if values
+            values.map do |value|
+              (value['id'] ? DataFile.find(value['id']) : DataFile.new).tap do |d|
+                d.assign_attributes(value)
+              end
+            end
+          end
+        end
+      end
+    end
+  end

--- a/lib/seek/data_files/unzipper.rb
+++ b/lib/seek/data_files/unzipper.rb
@@ -26,12 +26,16 @@ module Seek
 
                 data_files.each do |data_file|
                   data_file_content_blob = ContentBlob.new
-                  data_file_content_blob.tmp_io_object = File.open("#{tmp_file_path}#{data_file.title}")
-                  data_file_content_blob.original_filename = "#{data_file.title}"
-                  data_file_content_blob.save
-                  data_file.content_blob = data_file_content_blob
-                  data_file.policy = data_file.zip_origin.policy.deep_copy
-                  data_file.save
+                  file_path = "#{tmp_file_path}#{data_file.title}"
+
+                  File.open(file_path) do |file|
+                    data_file_content_blob.tmp_io_object = file
+                    data_file_content_blob.original_filename = data_file.title.to_s
+                    data_file_content_blob.save
+                    data_file.content_blob = data_file_content_blob
+                    data_file.policy = data_file.zip_origin.policy.deep_copy
+                    data_file.save
+                  end
                 end
   
                 project_ids = data_files.first.project_ids

--- a/lib/seek/data_files/unzipper.rb
+++ b/lib/seek/data_files/unzipper.rb
@@ -49,7 +49,6 @@ module Seek
                 AuthLookupUpdateQueue.enqueue(data_files)
               end
             end
-            FileUtils.rm_r(tmp_file_path)
             data_files
           end
         end

--- a/lib/seek/data_files/unzipper.rb
+++ b/lib/seek/data_files/unzipper.rb
@@ -82,7 +82,7 @@ module Seek
         end
 
         def cache(&block)
-          if File.exist?(cache_path)
+          if File.exist?(cache_path) & File.exist?(tmp_file_path)
             Marshal.load(File.binread(cache_path))
           elsif block_given?
             v = block.call

--- a/lib/seek/data_files/unzipper.rb
+++ b/lib/seek/data_files/unzipper.rb
@@ -11,8 +11,8 @@ module Seek
         end
   
         # Unzip datafiles and store in the filesystem temporarily
-        def unzip(overwrite = false)
-          self.class.decode(cache { self.class.encode(@data_file.unzip(overwrite, tmp_file_path, confirm=false)) })
+        def unzip
+          self.class.decode(cache { self.class.encode(@data_file.unzip(tmp_file_path)) })
         end
   
         # Persist the extracted datafiles to the database

--- a/lib/seek/permissions/translator.rb
+++ b/lib/seek/permissions/translator.rb
@@ -29,7 +29,7 @@ module Seek
         manage: Set.new(%i[
                           manage manage_update notification read_interaction write_interaction report_problem storage_report
                           select_sample_type extraction_status persistence_status extract_samples confirm_extraction cancel_extraction
-                          upload_fulltext upload_pdf soft_delete_fulltext has_matching_sample_type
+                          upload_fulltext upload_pdf soft_delete_fulltext has_matching_sample_type unzip
                         ]).freeze
       }.freeze
 

--- a/lib/seek/permissions/translator.rb
+++ b/lib/seek/permissions/translator.rb
@@ -29,7 +29,7 @@ module Seek
         manage: Set.new(%i[
                           manage manage_update notification read_interaction write_interaction report_problem storage_report
                           select_sample_type extraction_status persistence_status extract_samples confirm_extraction cancel_extraction
-                          upload_fulltext upload_pdf soft_delete_fulltext has_matching_sample_type unzip unzip_status confirm_unzip cancel_unzip
+                          upload_fulltext upload_pdf soft_delete_fulltext has_matching_sample_type unzip unzip_status confirm_unzip unzip_persistence_status cancel_unzip
                         ]).freeze
       }.freeze
 

--- a/lib/seek/permissions/translator.rb
+++ b/lib/seek/permissions/translator.rb
@@ -29,7 +29,7 @@ module Seek
         manage: Set.new(%i[
                           manage manage_update notification read_interaction write_interaction report_problem storage_report
                           select_sample_type extraction_status persistence_status extract_samples confirm_extraction cancel_extraction
-                          upload_fulltext upload_pdf soft_delete_fulltext has_matching_sample_type unzip unzip_status
+                          upload_fulltext upload_pdf soft_delete_fulltext has_matching_sample_type unzip unzip_status confirm_unzip cancel_unzip
                         ]).freeze
       }.freeze
 

--- a/lib/seek/permissions/translator.rb
+++ b/lib/seek/permissions/translator.rb
@@ -29,7 +29,7 @@ module Seek
         manage: Set.new(%i[
                           manage manage_update notification read_interaction write_interaction report_problem storage_report
                           select_sample_type extraction_status persistence_status extract_samples confirm_extraction cancel_extraction
-                          upload_fulltext upload_pdf soft_delete_fulltext has_matching_sample_type unzip
+                          upload_fulltext upload_pdf soft_delete_fulltext has_matching_sample_type unzip unzip_status
                         ]).freeze
       }.freeze
 

--- a/lib/seek/workers.rb
+++ b/lib/seek/workers.rb
@@ -24,6 +24,7 @@ module Seek
       queues << QueueNames::SAMPLES if Seek::Config.samples_enabled
       queues << QueueNames::INDEXING if Seek::Config.solr_enabled
       queues << QueueNames::TEMPLATES if Seek::Config.isa_json_compliance_enabled
+      queues << QueueNames::DATAFILES if Seek::Config.data_files_enabled
       queues.each do |queue_name|
         commands << command(queue_name, 1, action)
       end


### PR DESCRIPTION
Adds ability to unzip datafiles and save contents as new datafiles, which can be linked to any assay the zipped folder is linked to.

Notes:
- A way to link multiple datafiles to an assay simultaneously would be useful if users forget to link in the unzip process
- Nothing is implemented to handle new datafile versions not matching the original zip contents, this could be added in a similar manner to updating extracted samples
- Unzipped datafiles do not have a creator, similar to extracted samples
- Currently no tests have been written for this feature

