### PR TITLE
Lost temporary access code in the URL when switching between versions or clicking on the "Back to Model" button. 

### DIFF
--- a/app/views/general/_item_title.html.erb
+++ b/app/views/general/_item_title.html.erb
@@ -29,7 +29,7 @@ gatekeeper_status_bar = item.is_asset? && item.can_manage? && (item.is_waiting_a
                 <ul class="dropdown-menu" role="menu">
                   <% visible_versions.reverse.each do |v| %>
                       <li>
-                        <%= link_to({:version => v.version}, :method => request.request_method) do -%>
+                        <%= link_to({:version => v.version, :code => params[:code]}, :method => request.request_method) do -%>
                             <%= v.name %> <%= item.describe_version(v.version) -%><br/>
                         <% end %>
                       </li>

--- a/app/views/models/simulate.html.erb
+++ b/app/views/models/simulate.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:buttons) { button_link_to("Back to #{t('model')}", 'back', model_path(@model,:version=>@display_model.version)) } %>
+<% content_for(:buttons) { button_link_to("Back to #{t('model')}", 'back', model_path(@model,:version=>@display_model.version, :code=>params[:code])) } %>
 
 <%= render :partial => "general/item_title",:locals=>{:item=>@model,:title_postfix=>" - JWS Online #{t('model')} Simulation"} %>
 


### PR DESCRIPTION
https://github.com/seek4science/seek/issues/1926