### PR TITLE
Don't append slash to custom OIDC provider issuer URL

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -100,7 +100,6 @@ class AdminController < ApplicationController
     Seek::Config.omniauth_oidc_image&.destroy! if params[:clear_omniauth_oidc_image] == '1'
     Seek::Config.omniauth_oidc_image = params[:omniauth_oidc_image]
 
-    params[:omniauth_oidc_issuer] = params[:omniauth_oidc_issuer].chomp('/') + '/' if params[:omniauth_oidc_issuer].present?
     Seek::Config.omniauth_oidc_issuer = params[:omniauth_oidc_issuer]
     Seek::Config.omniauth_oidc_client_id = params[:omniauth_oidc_client_id]
     Seek::Config.omniauth_oidc_secret = params[:omniauth_oidc_secret]

--- a/config/initializers/seek_testing.rb
+++ b/config/initializers/seek_testing.rb
@@ -133,7 +133,7 @@ def load_seek_testing_defaults!
 
       Settings.defaults[:omniauth_oidc_enabled] = true
       Settings.defaults[:omniauth_oidc_name] = 'SEEK Testing OIDC'
-      Settings.defaults[:omniauth_oidc_issuer] = 'https://example.com/oidc/'
+      Settings.defaults[:omniauth_oidc_issuer] = 'https://example.com/oidc'
       Settings.defaults[:omniauth_oidc_client_id] = 'def'
       Settings.defaults[:omniauth_oidc_secret] = '789'
 


### PR DESCRIPTION
If server's issuer URL doesn't end in a slash it will cause an auth failure due to the mismatch, see https://github.com/seek4science/seek/issues/1446#issuecomment-2180292252

Not sure why it was added in the first place - possibly to make appending paths to the URL easier, but that doesn't occur anywhere in the code.