### PR TITLE
Log workflow and model executions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -390,7 +390,8 @@ class ApplicationController < ActionController::Base
         action = 'update' if action == 'create_version'
         action = 'inline_view' if action == 'explore'
         action = 'download' if action == 'ro_crate'
-        if %w(show create update destroy download inline_view).include?(action)
+        action = 'run' if action == 'simulate'
+        if %w(show create update destroy download inline_view run).include?(action)
           check_log_exists(action, controller_name, object)
           ActivityLog.create(action: action,
                              culprit: current_user,

--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -7,12 +7,13 @@ class WorkflowsController < ApplicationController
   before_action :workflows_enabled?
   before_action :find_assets, only: [:index]
   before_action :find_and_authorize_requested_item, except: [:index, :new, :create, :preview, :update_annotations_ajax]
-  before_action :find_display_asset, only: [:show, :download, :diagram, :ro_crate, :ro_crate_metadata, :edit_paths, :update_paths]
+  before_action :find_display_asset, only: [:show, :download, :diagram, :ro_crate, :ro_crate_metadata, :edit_paths, :update_paths, :run]
   before_action :login_required, only: [:create, :create_version, :new_version,
                                         :create_from_files, :create_from_ro_crate,
                                         :create_metadata, :provide_metadata, :create_from_git, :create_version_from_git,
                                         :submit]
   before_action :find_or_initialize_workflow, only: [:create_from_files, :create_from_ro_crate]
+  before_action :check_can_run, only: :run
 
   include Seek::Publishing::PublishingCommon
   include Seek::Doi::Minting
@@ -323,6 +324,13 @@ class WorkflowsController < ApplicationController
     end
   end
 
+  def run
+    # Support other execution methods in the future
+    respond_to do |format|
+      format.html { redirect_to @display_workflow.run_url }
+    end
+  end
+
   private
 
   def handle_ro_crate_post(new_version = false)
@@ -394,5 +402,10 @@ class WorkflowsController < ApplicationController
 
   def git_version_path_params
     params.require(:git_version).permit(:main_workflow_path, :abstract_cwl_path, :diagram_path)
+  end
+
+  def check_can_run
+    return if @workflow.can_run?
+    error('Execution is not supported for this workflow', '')
   end
 end

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -111,6 +111,10 @@ class Model < ApplicationRecord
     end
   end
 
+  def can_run?
+    Seek::Config.jws_enabled && can_download? && is_jws_supported?
+  end
+
   private
 
   def check_for_sbml_format

--- a/app/views/assets/_asset_buttons.html.erb
+++ b/app/views/assets/_asset_buttons.html.erb
@@ -36,7 +36,8 @@
         <%= button_link_to('Download RO-Crate', 'ro_crate_file', ro_crate_workflow_path(asset, version: version, code: params[:code]),
                            'data-tooltip' => tooltip("The Workflow RO-Crate is a package containing the workflow definition, its metadata and supporting resources like test data")) %>
         <% if asset.can_run? %>
-          <%= button_link_to("Run on Galaxy", 'run_galaxy', display_asset.run_url) %>
+          <%# TODO: Change this to be more generic when other types can be run %>
+          <%= button_link_to("Run on Galaxy", 'run_galaxy', run_workflow_path(asset, version: version), method: :post) %>
         <% end %>
       <% else %>
         <%= button_link_to('Download RO-Crate', 'ro_crate_file', nil,

--- a/app/views/assets/_usage_info_box.html.erb
+++ b/app/views/assets/_usage_info_box.html.erb
@@ -1,6 +1,7 @@
 <%
   logging_start_date ||= nil
   show_downloads = resource.respond_to?(:contains_downloadable_items?) && resource.contains_downloadable_items?
+  show_runs = resource.respond_to?(:can_run?) && resource.can_run?
 %>
 
 <%= panel("Activity") do %>
@@ -10,6 +11,10 @@
     <% if show_downloads -%>
       <span style="width: 2em">&nbsp;</span>
       <strong>Downloads:</strong> <%= resource.download_count -%>
+    <% end -%>
+    <% if show_runs -%>
+      <span style="width: 2em">&nbsp;</span>
+      <strong>Runs:</strong> <%= resource.run_count -%>
     <% end -%>
   </p>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -546,6 +546,7 @@ SEEK::Application.routes.draw do
       post :create_version_from_git
       get :edit_paths
       patch :update_paths
+      post :run
     end
     resources :people, :programmes, :projects, :investigations, :assays, :samples, :studies, :publications, :events, :sops, :collections, :presentations, :documents, :data_files, only: [:index]
   end

--- a/lib/seek/jws/simulator.rb
+++ b/lib/seek/jws/simulator.rb
@@ -8,6 +8,7 @@ module Seek
         include Seek::ExternalServiceWrapper
         before_action :find_display_asset_for_jws, only: [:simulate]
         before_action :jws_enabled, only: [:simulate]
+        skip_after_action :log_event, if: -> (c) { c.action_name == 'simulate' && @constraint_based.nil? }
       end
 
       def simulate

--- a/lib/seek/jws/simulator.rb
+++ b/lib/seek/jws/simulator.rb
@@ -13,25 +13,20 @@ module Seek
       def simulate
         if @constraint_based = params[:constraint_based]
           wrap_service('JWS online', model_path(@model, version: @display_model.version)) do
-            slug = upload_model_blob(select_jws_content_blob, @constraint_based == '1')
+            slug = upload_model_blob(@blob, @constraint_based == '1')
             if slug
               @simulate_url = model_simulate_url_from_slug(slug)
             else
               @jws_error = "JWS Online was unable to parse the SBML during upload"
             end
-
           end
         end
       end
 
-      def select_jws_content_blob
-        blob = @display_model.jws_supported_content_blobs.first
-        raise 'Unable to find file to support JWS Online' unless blob
-        blob
-      end
-
       def find_display_asset_for_jws
         find_display_asset
+        @blob = @display_model.jws_supported_content_blobs.first
+        error('Unable to find JWS Online-compatible file', '') if @blob.nil?
       end
     end
   end

--- a/lib/seek/permissions/translator.rb
+++ b/lib/seek/permissions/translator.rb
@@ -12,7 +12,7 @@ module Seek
         download: Set.new(%i[
                             download named_download launch submit_job data execute plot explore
                             download_log download_results input output download_output download_input
-                            view_result compare_versions simulate diagram ro_crate ro_crate_metadata
+                            view_result compare_versions simulate diagram ro_crate ro_crate_metadata run
                           ]).freeze,
 
         edit: Set.new(%i[

--- a/lib/seek/stats/activity_counts.rb
+++ b/lib/seek/stats/activity_counts.rb
@@ -20,6 +20,10 @@ module Seek
         count_actions('show')
       end
 
+      def run_count
+        count_actions('run')
+      end
+
       private
 
       def count_actions(actions = nil)

--- a/test/functional/data_files_controller_test.rb
+++ b/test/functional/data_files_controller_test.rb
@@ -614,6 +614,7 @@ class DataFilesControllerTest < ActionController::TestCase
 
     assert_select '#usage_count' do
       assert_select 'strong', text: /Downloads/, count: 1
+      assert_select 'strong', text: /Runs/, count: 0
     end
   end
 

--- a/test/functional/jws_online_test.rb
+++ b/test/functional/jws_online_test.rb
@@ -56,4 +56,15 @@ class JwsOnlineTest < ActionController::TestCase
     assert_redirected_to root_url
     assert flash[:error].include?('JWS Online-compatible')
   end
+
+  test 'do not log event before simulation is run' do
+    model = FactoryBot.create(:teusink_model, policy: FactoryBot.create(:public_policy))
+
+    assert_no_difference('model.run_count') do
+      get :simulate, params: { id: model.id, version: model.version } # `constraint_based` param is missing
+    end
+
+    assert_response :success
+    assert_select 'div', text: /JWS Online needs information.+/
+  end
 end

--- a/test/functional/models_controller_test.rb
+++ b/test/functional/models_controller_test.rb
@@ -1410,6 +1410,28 @@ class ModelsControllerTest < ActionController::TestCase
     end
   end
 
+  test 'show run count for simulatable model' do
+    model = FactoryBot.create(:teusink_model, policy: FactoryBot.create(:public_policy))
+
+    get :show, params: { id: model }
+
+    assert_select '#usage_count' do
+      assert_select 'strong', text: /Downloads/, count: 1
+      assert_select 'strong', text: /Runs/, count: 1
+    end
+  end
+
+  test 'do not show run count for non-simulatable model' do
+    model = FactoryBot.create(:non_sbml_xml_model, policy: FactoryBot.create(:public_policy))
+
+    get :show, params: { id: model }
+
+    assert_select '#usage_count' do
+      assert_select 'strong', text: /Downloads/, count: 1
+      assert_select 'strong', text: /Runs/, count: 0
+    end
+  end
+
   private
 
   def valid_model


### PR DESCRIPTION
Records an `ActivityLog` when a workflow or JWS-compatible model is run and displays a count along with view and downloads on the right-hand side of the show page