### PR TITLE
Automatically apply project default policy to new resources

### DIFF
--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -63,7 +63,10 @@ class PoliciesController < ApplicationController
     resource_class = safe_class_lookup(params[:resource_name].camelize)
     resource = nil
     resource = resource_class.find_by_id(params[:resource_id]) if params[:resource_id]
-    resource ||= resource_class.new
+    if resource.nil?
+      resource = resource_class.new
+      resource.policy_or_default_if_new
+    end
     projects = Project.where(id: (params[:project_ids] || '').split(','))
     ucpi = updated_can_publish_immediately(resource, projects)
     policy = resource.policy.set_attributes_with_sharing(policy_params)

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -124,8 +124,9 @@ class Policy < ApplicationRecord
         end
 
         # Set attributes on the policy's permissions
+        current_permissions = policy.permissions
+        new_permissions = []
         if policy_params[:permissions_attributes]
-          current_permissions = policy.permissions
           new_permissions = policy_params[:permissions_attributes].values.map do |perm_params|
             # See if a permission already exists with that contributor
             permission = current_permissions.detect do |p|
@@ -136,10 +137,9 @@ class Policy < ApplicationRecord
 
             permission.tap { |p| p.assign_attributes(perm_params) }
           end
-
-          # Get the unused permissions and mark them for destruction (after policy is saved)
-          (current_permissions - new_permissions).each(&:mark_for_destruction)
         end
+        # Get the unused permissions and mark them for destruction (after policy is saved)
+        (current_permissions - new_permissions).each(&:mark_for_destruction)
       end
     end
   end

--- a/lib/scrapers/github_scraper.rb
+++ b/lib/scrapers/github_scraper.rb
@@ -102,8 +102,6 @@ module Scrapers
       workflow = wiz.run
       workflow.contributor = @contributor
       workflow.projects = Array(@project)
-      workflow.policy = Policy.projects_policy(workflow.projects)
-      workflow.policy.access_type = Policy::ACCESSIBLE
       workflow.source_link_url = repo.remote.chomp('.git')
       workflow.tags = topics(repo)
       if wiz.next_step == :provide_metadata

--- a/lib/seek/assets_standard_controller_actions.rb
+++ b/lib/seek/assets_standard_controller_actions.rb
@@ -152,6 +152,7 @@ module Seek
     end
 
     def update_sharing_policies(item, parameters = params)
+      item.policy ||= item.default_policy
       item.policy.set_attributes_with_sharing(policy_params(parameters)) if policy_params(parameters).present?
     end
 

--- a/lib/seek/permissions/policy_based_authorization.rb
+++ b/lib/seek/permissions/policy_based_authorization.rb
@@ -12,7 +12,7 @@ module Seek
           after_initialize :contributor_or_default_if_new
 
           # checks a policy exists, and if missing resorts to using a private policy
-          after_initialize :policy_or_default_if_new
+          before_validation :policy_or_default_if_new
 
           include Seek::ProjectAssociation unless method_defined? :projects
 
@@ -271,7 +271,11 @@ module Seek
       delegate :public?, to: :policy
 
       def default_policy
-        Policy.default
+        if projects.one? && projects.first.use_default_policy
+          projects.first.default_policy.deep_copy
+        else
+          Policy.default
+        end
       end
 
       def policy_or_default_if_new

--- a/lib/seek/permissions/policy_based_authorization.rb
+++ b/lib/seek/permissions/policy_based_authorization.rb
@@ -271,7 +271,7 @@ module Seek
       delegate :public?, to: :policy
 
       def default_policy
-        if projects.one? && projects.first.use_default_policy
+        if projects.one? && projects.first.use_default_policy && projects.first.default_policy
           projects.first.default_policy.deep_copy
         else
           Policy.default

--- a/lib/seek/publishing/publishing_common.rb
+++ b/lib/seek/publishing/publishing_common.rb
@@ -42,11 +42,10 @@ module Seek
         end
       end
 
-      def update_sharing_policies(*args)
-        param_access_type = params['policy_attributes'] ? params['policy_attributes']['access_type'] : nil
-        current_access_type = args.first.policy.access_type.to_s
-        @policy_updated = true if param_access_type != current_access_type
-        super
+      def update_sharing_policies(item, parameters = params)
+        value = super
+        @policy_updated = true if item.policy&.access_type_changed?
+        value
       end
 
       def publish

--- a/test/fixtures/json/responses/get_max_publication.json.erb
+++ b/test/fixtures/json/responses/get_max_publication.json.erb
@@ -6,6 +6,20 @@
       "policy": {
         "access": "download",
         "permissions": [
+          {
+            "resource": {
+              "id": "<%= res.seek_authors.first.person_id %>",
+              "type": "people"
+            },
+            "access": "manage"
+          },
+          {
+            "resource": {
+              "id": "<%= current_person.id %>",
+              "type": "people"
+            },
+            "access": "manage"
+          }
         ]
       },
       "discussion_links": [

--- a/test/fixtures/json/responses/get_min_publication.json.erb
+++ b/test/fixtures/json/responses/get_min_publication.json.erb
@@ -6,6 +6,13 @@
       "policy": {
         "access": "download",
         "permissions": [
+          {
+            "resource": {
+              "id": "<%= current_person.id %>",
+              "type": "people"
+            },
+            "access": "manage"
+          }
         ]
       },
       "discussion_links": [

--- a/test/functional/policies_controller_test.rb
+++ b/test/functional/policies_controller_test.rb
@@ -140,7 +140,7 @@ end
   test 'when creating an item, can not publish the item if associate to it the project which has gatekeeper' do
     gatekeeper = FactoryBot.create(:asset_gatekeeper)
     a_person = FactoryBot.create(:person)
-    sop = Sop.new
+    sop = FactoryBot.create(:sop, contributor: a_person)
 
     login_as(a_person.user)
     assert sop.can_manage?
@@ -151,7 +151,7 @@ end
 
   test 'when creating an item, can publish the item if associate to it the project which has no gatekeeper' do
     a_person = FactoryBot.create(:person)
-    sop = Sop.new
+    sop = FactoryBot.create(:sop, contributor: a_person)
 
     login_as(a_person.user)
     assert sop.can_manage?
@@ -189,7 +189,7 @@ end
 
   test 'can publish assay without study' do
     a_person = FactoryBot.create(:person)
-    assay = Assay.new
+    assay = FactoryBot.create(:assay, study: nil, contributor: a_person)
 
     login_as(a_person.user)
     assert assay.can_manage?
@@ -204,8 +204,7 @@ end
     a_person = FactoryBot.create(:person, project: gatekeeper.projects.first)
     inv = FactoryBot.create(:investigation, contributor: gatekeeper)
     study = FactoryBot.create(:study, investigation: inv, contributor: gatekeeper)
-    assay = Assay.new
-    assay.study = study
+    assay = FactoryBot.create(:assay, study: study, contributor: a_person)
 
     assert_equal assay.projects, gatekeeper.projects
     login_as(a_person.user)

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -328,8 +328,10 @@ class PublicationsControllerTest < ActionController::TestCase
 
   test 'should show old unspecified publication type' do
     publication = FactoryBot.create(:publication, title: 'Publication without type')
-    publication.publication_type = nil
-    publication.save(validate: false)
+    disable_authorization_checks do
+      publication.publication_type = nil
+      publication.save!(validate: false)
+    end
     get :index
     assert_response :success
     assert_select '.list_item_attribute' do
@@ -549,15 +551,15 @@ class PublicationsControllerTest < ActionController::TestCase
 
   test 'should get edit' do
     pub = FactoryBot.create(:publication)
+    login_as(pub.contributor)
     get :edit, params: { id: pub.id }
     assert_response :success
   end
 
-
   test 'associates assay' do
-    login_as(User.current_user)  # can edit assay
-
     publ = FactoryBot.create(:publication)
+    login_as(publ.contributor)
+
     original_assay = FactoryBot.create :assay, contributor: User.current_user.person, publications: [publ]
     publ.assays = [original_assay]
     refute_nil publ.contributor
@@ -840,6 +842,7 @@ class PublicationsControllerTest < ActionController::TestCase
 
   test 'should update project' do
     publ = FactoryBot.create(:publication)
+    login_as(publ.contributor)
     project = FactoryBot.create(:min_project)
     assert_not_equal project, publ.projects.first
     put :update, params: { id: publ.id, publication: { project_ids: [project.id] } }

--- a/test/unit/event_test.rb
+++ b/test/unit/event_test.rb
@@ -20,9 +20,11 @@ class EventTest < ActiveSupport::TestCase
   test 'publication association' do
     assert @event.publications.empty?
     publication = FactoryBot.create(:publication)
-    @event.publications << publication
-    assert @event.valid?
-    assert @event.save
+    disable_authorization_checks do
+      @event.publications << publication
+      assert @event.valid?
+      assert @event.save
+    end
     assert_equal 1, @event.publications.count
   end
 

--- a/test/unit/extended_metadata_test.rb
+++ b/test/unit/extended_metadata_test.rb
@@ -61,7 +61,7 @@ class ExtendedMetadataTest < ActiveSupport::TestCase
 
   test 'mass assign attribute with linked extended metadata' do
     cm = ExtendedMetadata.new(extended_metadata_type: FactoryBot.build(:role_extended_metadata_type), item: FactoryBot.create(:study))
-    pp   cm.update( data: {
+    cm.update( data: {
       "role_email":"alice@email.com",
       "role_phone":"0012345",
       "role_name": {
@@ -79,7 +79,7 @@ class ExtendedMetadataTest < ActiveSupport::TestCase
 
   test 'mass assign attribute with multi linked extended metadatas' do
     cm = ExtendedMetadata.new(extended_metadata_type: FactoryBot.build(:family_extended_metadata_type), item: FactoryBot.create(:study))
-    pp   cm.update( data: {
+    cm.update( data: {
       "dad":{"first_name":"tom", "last_name":"liddell"},
       "mom": { "first_name": "lily", "last_name": "liddell" },
       "child":{
@@ -197,7 +197,7 @@ class ExtendedMetadataTest < ActiveSupport::TestCase
 
   test 'mass assign attributes with the linked extended metadata' do
     cm = ExtendedMetadata.new(extended_metadata_type: FactoryBot.build(:family_extended_metadata_type), item: FactoryBot.create(:study))
-    pp   cm.update( data: {
+    cm.update( data: {
       "dad":{"first_name":"tom", "last_name":"liddell"},
       "mom": { "first_name": "lily", "last_name": "liddell" },
       "child":{

--- a/test/unit/workflow_test.rb
+++ b/test/unit/workflow_test.rb
@@ -920,7 +920,7 @@ class WorkflowTest < ActiveSupport::TestCase
       assert_equal Policy::NO_ACCESS, policy.access_type
       assert_equal 1, policy.permissions.count
       assert_equal admin, policy.permissions.first.contributor
-      assert_equal Policy::MANAGING, policy.permissions.first.contributor
+      assert_equal Policy::MANAGING, policy.permissions.first.access_type
     end
   end
 end

--- a/test/unit/workflow_test.rb
+++ b/test/unit/workflow_test.rb
@@ -923,4 +923,21 @@ class WorkflowTest < ActiveSupport::TestCase
       assert_equal Policy::MANAGING, policy.permissions.first.access_type
     end
   end
+
+  test 'does not apply project default policy if it does not exist' do
+    admin = FactoryBot.create(:project_administrator)
+    project = admin.projects.first
+    disable_authorization_checks do
+      project.use_default_policy = true
+      project.save!
+    end
+    assert_nil project.default_policy
+
+    with_config_value(:default_all_visitors_access_type, Policy::ACCESSIBLE) do
+      workflow = FactoryBot.create(:workflow, projects: [project])
+      policy = workflow.policy
+      assert_equal Policy::ACCESSIBLE, policy.access_type
+      assert_equal 0, policy.permissions.count
+    end
+  end
 end


### PR DESCRIPTION
...if no explicit policy was provided, and the resource is only associated with a single project.

Fixes #1929