### PR TITLE
upgrade task to repair xlsx blobs changed to zip 

### DIFF
--- a/lib/tasks/seek_upgrades.rake
+++ b/lib/tasks/seek_upgrades.rake
@@ -18,6 +18,7 @@ namespace :seek do
     implement_assay_streams_for_isa_assays
     set_ls_login_legacy_mode
     rename_custom_metadata_legacy_supported_type
+    fix_xlsx_marked_as_zip
   ]
 
   # these are the tasks that are executes for each upgrade as standard, and rarely change
@@ -202,6 +203,15 @@ namespace :seek do
     if ExtendedMetadataType.where(supported_type: 'CustomMetadata').any?
       puts "... Renaming ExtendedMetadata supported_type from Custom to ExtendedMetadata"
       ExtendedMetadataType.where(supported_type: 'CustomMetadata').update_all(supported_type: 'ExtendedMetadata')
+    end
+  end
+
+  task(fix_xlsx_marked_as_zip: [:environment]) do
+    blobs = ContentBlob.where('original_filename LIKE ?','%.xlsx').where(content_type: 'application/zip')
+    if blobs.any?
+      n = blobs.count
+      blobs.update_all(content_type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+      puts "... fixed #{n} XLSX blobs with zip content type"
     end
   end
 


### PR DESCRIPTION
will fix content blobs damaged by #1820

based on teh assumption an .xlsx filename with a zip mime type is far more likely to be due to this issue than otherwise.