### PR TITLE
UI to create Observation Units

### DIFF
--- a/app/helpers/assays_helper.rb
+++ b/app/helpers/assays_helper.rb
@@ -57,16 +57,6 @@ module AssaysHelper
     result.html_safe
   end
 
-  # the selection dropdown box for selecting the study for an assay
-  def assay_study_selection(element_name, current_study)
-    grouped_options = grouped_options_for_study_selection(current_study)
-    blank = current_study.blank? ? 'Not specified' : nil
-    disabled = current_study && !current_study.can_edit?
-    options = grouped_options_for_select(grouped_options, current_study.try(:id))
-    select_tag(element_name, options,
-               class: 'form-control', include_blank: blank, disabled: disabled).html_safe
-  end
-
   # a lightway way to select a SOP - specifically for the assay creation during data file creation
   def assay_sop_selection(element_name, current_sop)
     sops = authorised_sops(User.current_user.person.projects)

--- a/app/helpers/studies_helper.rb
+++ b/app/helpers/studies_helper.rb
@@ -26,4 +26,14 @@ module StudiesHelper
   def show_batch_miappe_button?
     ExtendedMetadataType.where(supported_type: 'Study', title: ExtendedMetadataType::MIAPPE_TITLE, enabled: true).any?
   end
+
+  # the selection dropdown box for selecting the study for a resource, such as assay or observation unit
+  def resource_study_selection(element_name, current_study)
+    grouped_options = grouped_options_for_study_selection(current_study)
+    blank = current_study.blank? ? 'Not specified' : nil
+    disabled = current_study && !current_study.can_edit?
+    options = grouped_options_for_select(grouped_options, current_study.try(:id))
+    select_tag(element_name, options,
+               class: 'form-control', include_blank: blank, disabled: disabled).html_safe
+  end
 end

--- a/app/models/observation_unit.rb
+++ b/app/models/observation_unit.rb
@@ -10,6 +10,8 @@ class ObservationUnit < ApplicationRecord
   has_many :observation_unit_assets, inverse_of: :observation_unit, dependent: :delete_all, autosave: true
   has_many :data_files, through: :observation_unit_assets, source: :asset, source_type: 'DataFile', inverse_of: :observation_units
 
+  validates :study,  presence: true
+
   accepts_nested_attributes_for :data_files, allow_destroy: true
 
   has_extended_metadata

--- a/app/views/assays/_form.html.erb
+++ b/app/views/assays/_form.html.erb
@@ -22,7 +22,7 @@
 <div class="form-group">
   <label class="required"><%= t('study') -%></label>
 
-  <%= assay_study_selection('assay[study_id]',@assay.study) %>
+  <%= resource_study_selection('assay[study_id]', @assay.study) %>
 </div>
 
 <div class="form-group">

--- a/app/views/data_files/multi-steps/_assays.html.erb
+++ b/app/views/data_files/multi-steps/_assays.html.erb
@@ -39,7 +39,7 @@
         </div>
         <div class='form-group'>
           <label>Study <span class='required'>*</span></label>
-          <%= assay_study_selection('assay[study_id]', @assay.study) %>
+          <%= resource_study_selection('assay[study_id]', @assay.study) %>
         </div>
         <div class='form-group'>
           <label>SOP</label>

--- a/app/views/layouts/navbar/_browse_menu.html.erb
+++ b/app/views/layouts/navbar/_browse_menu.html.erb
@@ -17,6 +17,7 @@
         [t('investigation').pluralize, investigations_path, Seek::Config.investigations_enabled],
         [t('study').pluralize, studies_path, Seek::Config.studies_enabled],
         [t('assay').pluralize, assays_path, Seek::Config.assays_enabled],
+        [t('observation_unit').pluralize, observation_units_path, Seek::Config.observation_units_enabled],
         [t('template').pluralize, templates_path, Seek::Config.isa_json_compliance_enabled],
     ]) %>
 

--- a/app/views/layouts/navbar/_create_menu.html.erb
+++ b/app/views/layouts/navbar/_create_menu.html.erb
@@ -19,6 +19,7 @@
           [t('investigation'), new_investigation_path, Seek::Config.investigations_enabled],
           [t('study'), new_study_path, Seek::Config.studies_enabled],
           [t('assay'), new_assay_path, Seek::Config.assays_enabled],
+          [t('observation_unit'), new_observation_unit_path, Seek::Config.observation_units_enabled],
           [t('template'), new_template_path, Seek::Config.isa_json_compliance_enabled],
       ]) %>
 

--- a/app/views/observation_units/edit.html.erb
+++ b/app/views/observation_units/edit.html.erb
@@ -19,7 +19,7 @@
     <%= render partial: 'extended_metadata/extended_metadata_attribute_input', locals: { f: f, resource: @observation_unit } %>
 
 
-    <%= render partial: "assets/asset_form_bottom", locals: {show_publications:false, f: f}-%>
+    <%= render partial: "assets/asset_form_bottom", locals: {show_publications:false, attribution_enable: false, f: f}-%>
 
 
     <%= form_submit_buttons(@observation_unit) %>

--- a/app/views/observation_units/new.html.erb
+++ b/app/views/observation_units/new.html.erb
@@ -18,7 +18,7 @@
     <%= render partial: 'extended_metadata/extended_metadata_type_selection', locals: { f: f, resource: @observation_unit } %>
     <%= render partial: 'extended_metadata/extended_metadata_attribute_input', locals: { f: f, resource: @observation_unit } %>
 
-    <%= render :partial => "projects/project_selector", :locals => { :resource => @observation_unit } %>
+    <%= render partial: "projects/project_selector", locals: { resource: @observation_unit } %>
 
     <div class="form-group">
       <label class="required"><%= t('study') -%></label>

--- a/app/views/observation_units/new.html.erb
+++ b/app/views/observation_units/new.html.erb
@@ -1,0 +1,35 @@
+
+<h1>New <%= t('observation_unit') %></h1>
+
+<%= form_for(@observation_unit) do |f| %>
+  <div class="asset_form">
+    <%= f.error_messages %>
+
+    <div class="form-group">
+      <label class="required">Title</label>
+      <%= f.text_field :title, class: "form-control" -%>
+    </div>
+
+    <div class="form-group">
+      <label>Description</label>
+      <%= f.text_area :description, class: "form-control rich-text-edit", rows: 5 -%>
+    </div>
+
+    <%= render partial: 'extended_metadata/extended_metadata_type_selection', locals: { f: f, resource: @observation_unit } %>
+    <%= render partial: 'extended_metadata/extended_metadata_attribute_input', locals: { f: f, resource: @observation_unit } %>
+
+    <%= render :partial => "projects/project_selector", :locals => { :resource => @observation_unit } %>
+
+    <div class="form-group">
+      <label class="required"><%= t('study') -%></label>
+
+      <%= resource_study_selection('observation_unit[study_id]', @observation_unit.study) %>
+    </div>
+
+    <%= render partial: "assets/asset_form_bottom", locals: {show_publications:false, f: f}-%>
+
+
+    <%= form_submit_buttons(@observation_unit) %>
+
+  </div>
+<% end %>

--- a/app/views/observation_units/new.html.erb
+++ b/app/views/observation_units/new.html.erb
@@ -26,7 +26,7 @@
       <%= resource_study_selection('observation_unit[study_id]', @observation_unit.study) %>
     </div>
 
-    <%= render partial: "assets/asset_form_bottom", locals: {show_publications:false, f: f}-%>
+    <%= render partial: "assets/asset_form_bottom", locals: {show_publications:false, attribution_enable: false, f: f}-%>
 
 
     <%= form_submit_buttons(@observation_unit) %>

--- a/app/views/openbis_zamples/_batch_parent_form_modal.html.erb
+++ b/app/views/openbis_zamples/_batch_parent_form_modal.html.erb
@@ -13,7 +13,7 @@
         <%= form_for(Assay.new) do |f| %>
             <div class="form-group">
               <label>Register under Study </label><span class="required">*</span>
-              <%= assay_study_selection('assay[study_id]', nil) %>
+              <%= resource_study_selection('assay[study_id]', nil) %>
             </div>
             <div class="form-group">
               <%= check_box_tag('link_dependent', 1, true) %>

--- a/app/views/openbis_zamples/edit.html.erb
+++ b/app/views/openbis_zamples/edit.html.erb
@@ -18,7 +18,7 @@
         <% if not_registered %>
             <div class="form-group">
               <label>Register under Study </label><span class="required">*</span>
-              <%= assay_study_selection('assay[study_id]', @assay.study) %>
+              <%= resource_study_selection('assay[study_id]', @assay.study) %>
             </div>
         <% else %>
             <div class="form-group">

--- a/test/factories/observation_units.rb
+++ b/test/factories/observation_units.rb
@@ -4,10 +4,12 @@ FactoryBot.define do
     description { 'very simple obs unit'}
     with_project_contributor
     policy { FactoryBot.create(:public_policy) }
+    association :study, factory: :study, strategy: :create
   end
 
   factory(:min_observation_unit, parent: :observation_unit) do
     title { 'A Minimal Observation Unit' }
+    association :study, factory: :study, strategy: :create
     description { nil }
   end
 

--- a/test/fixtures/json/requests/post_min_observation_unit.json.erb
+++ b/test/fixtures/json/requests/post_min_observation_unit.json.erb
@@ -20,6 +20,12 @@
             "type": "projects"
           }
         ]
+      },
+      "study": {
+        "data": {
+          "id": "<%= @study.id %>",
+          "type": "studies"
+        }
       }
     }
   }

--- a/test/fixtures/json/responses/get_min_observation_unit.json.erb
+++ b/test/fixtures/json/responses/get_min_observation_unit.json.erb
@@ -45,7 +45,10 @@
         ]
       },
       "study": {
-        "data": null
+        "data": {
+          "id": "<%= res.study.id %>",
+          "type": "studies"
+        }
       },
       "samples": {
         "data": []

--- a/test/functional/observation_units_controller_test.rb
+++ b/test/functional/observation_units_controller_test.rb
@@ -96,7 +96,9 @@ class ObservationUnitsControllerTest < ActionController::TestCase
                                    strain: 'updated strain'
                                  }
                                }
-                             }}
+                             },
+                             tag_list:'fish, soup',
+    }
 
     assert_redirected_to obs_unit
 
@@ -106,6 +108,7 @@ class ObservationUnitsControllerTest < ActionController::TestCase
     assert_equal emt, obs_unit.extended_metadata.extended_metadata_type
     assert_equal 'updated name', obs_unit.extended_metadata.get_attribute_value('name')
     assert_equal 'updated strain', obs_unit.extended_metadata.get_attribute_value('strain')
+    assert_equal %w[fish soup], obs_unit.tags.sort
   end
 
   test 'new' do
@@ -139,6 +142,7 @@ class ObservationUnitsControllerTest < ActionController::TestCase
                                  }
                                }
                              },
+                             tag_list:'fish, soup',
                              policy_attributes: {
                                access_type: Policy::VISIBLE,
                                permissions_attributes: {'1' => {contributor_type: 'Person', contributor_id: other_person.id, access_type: Policy::MANAGING}
@@ -152,6 +156,7 @@ class ObservationUnitsControllerTest < ActionController::TestCase
     assert_equal emt, obs_unit.extended_metadata.extended_metadata_type
     assert_equal 'new name', obs_unit.extended_metadata.get_attribute_value('name')
     assert_equal 'new strain', obs_unit.extended_metadata.get_attribute_value('strain')
+    assert_equal %w[fish soup], obs_unit.tags.sort
     assert_equal contributor, obs_unit.contributor
     assert_equal [project],obs_unit.projects.sort_by(&:id)
     assert_equal [creator],obs_unit.creators

--- a/test/functional/observation_units_controller_test.rb
+++ b/test/functional/observation_units_controller_test.rb
@@ -108,6 +108,14 @@ class ObservationUnitsControllerTest < ActionController::TestCase
     assert_equal 'updated strain', obs_unit.extended_metadata.get_attribute_value('strain')
   end
 
+  test 'new' do
+    person = FactoryBot.create(:person)
+    login_as(person)
+    get :new
+    assert_response :success
+    assert_select 'form.new_observation_unit'
+  end
+
   test 'create' do
     emt = FactoryBot.create(:simple_observation_unit_extended_metadata_type)
     contributor = FactoryBot.create(:person)
@@ -160,6 +168,10 @@ class ObservationUnitsControllerTest < ActionController::TestCase
       refute_nil flash[:error]
 
       get :index
+      assert_redirected_to :root
+      refute_nil flash[:error]
+
+      get :new
       assert_redirected_to :root
       refute_nil flash[:error]
 

--- a/test/functional/observation_units_controller_test.rb
+++ b/test/functional/observation_units_controller_test.rb
@@ -119,6 +119,7 @@ class ObservationUnitsControllerTest < ActionController::TestCase
   test 'create' do
     emt = FactoryBot.create(:simple_observation_unit_extended_metadata_type)
     contributor = FactoryBot.create(:person)
+    study = FactoryBot.create(:study, contributor: contributor)
     project = contributor.projects.first
     other_person = FactoryBot.create(:person)
     creator = FactoryBot.create(:person)
@@ -129,6 +130,7 @@ class ObservationUnitsControllerTest < ActionController::TestCase
                                description: 'new description',
                                creator_ids: [creator.id],
                                project_ids: [project],
+                               study_id: study,
                                extended_metadata_attributes: {
                                  extended_metadata_type_id: emt.id,
                                  data: {

--- a/test/unit/observation_unit_test.rb
+++ b/test/unit/observation_unit_test.rb
@@ -67,5 +67,22 @@ class ObservationUnitTest < ActiveSupport::TestCase
     end
   end
 
+  test 'validation' do
+    obs_unit = FactoryBot.build(:observation_unit)
+    assert obs_unit.valid?
+
+    obs_unit.title = ''
+    refute obs_unit.valid?
+
+    obs_unit = FactoryBot.build(:observation_unit)
+    obs_unit.study = nil
+    refute obs_unit.valid?
+
+    obs_unit = FactoryBot.build(:observation_unit)
+    obs_unit.projects = []
+    refute obs_unit.valid?
+
+  end
+
 
 end


### PR DESCRIPTION
the form for the new action, and tests to cover the create action.

Also added to the Browse and Create menus, and added a validation to Obs Unit to say that Study is required (can be changed in the future if necessary)

* fix for #1961 

**Please merge and delete branch if Approved**