### PR TITLE
1941 make the isa json compliance default

### DIFF
--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -72,11 +72,6 @@ class InvestigationsController < ApplicationController
     headers["Content-Length"]=ro_file.size.to_s
   end
 
-  def new
-    @investigation = Investigation.new
-    @investigation.is_isa_json_compliant = Seek::Config.isa_json_compliance_enabled ? true : false
-    respond_to(&:html)
-  end
   def create
     @investigation = Investigation.new(investigation_params)
     update_sharing_policies @investigation

--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -72,6 +72,11 @@ class InvestigationsController < ApplicationController
     headers["Content-Length"]=ro_file.size.to_s
   end
 
+  def new
+    @investigation = Investigation.new
+    @investigation.is_isa_json_compliant = Seek::Config.isa_json_compliance_enabled ? true : false
+    respond_to(&:html)
+  end
   def create
     @investigation = Investigation.new(investigation_params)
     update_sharing_policies @investigation

--- a/app/views/investigations/_form.html.erb
+++ b/app/views/investigations/_form.html.erb
@@ -1,4 +1,5 @@
 <% object ||= nil %>
+<% isa_json_compliance_default = @investigation.new_record? ? Seek::Config.isa_json_compliance_enabled : @investigation.is_isa_json_compliant %>
 
 <%= f.error_messages -%>
 
@@ -26,7 +27,7 @@
       <% if @investigation.studies.any? %>
         <%= f.check_box :is_isa_json_compliant, disabled: "disabled"%>
       <% else %>
-        <%= f.check_box :is_isa_json_compliant%>
+        <%= f.check_box :is_isa_json_compliant, checked: isa_json_compliance_default %>
       <% end %>
       <%= "Make #{t('investigation')} compliant to ISA-JSON schemas?" %>
     </label>

--- a/test/functional/investigations_controller_test.rb
+++ b/test/functional/investigations_controller_test.rb
@@ -1231,4 +1231,23 @@ class InvestigationsControllerTest < ActionController::TestCase
       assert_select 'input[type="checkbox"][checked="checked"]#investigation_is_isa_json_compliant', count: 1
     end
   end
+
+  test 'isa json compliance on edit page' do
+    current_user = FactoryBot.create(:user)
+
+    inv = FactoryBot.create(:investigation, contributor: current_user.person)
+    isa_json_inv = FactoryBot.create(:investigation, contributor: current_user.person, is_isa_json_compliant: true)
+
+    login_as(current_user)
+    with_config_values({isa_json_compliance_enabled: false, project_single_page_enabled: false}) do
+      get :edit, params: { id: inv }
+      assert_response :success
+      assert_select 'input[type="checkbox"][checked="checked"]#investigation_is_isa_json_compliant', count: 0
+
+      get :edit, params: { id: isa_json_inv }
+      assert_response :success
+      assert_select 'input[type="checkbox"][checked="checked"]#investigation_is_isa_json_compliant', count: 1
+
+    end
+  end
 end

--- a/test/functional/investigations_controller_test.rb
+++ b/test/functional/investigations_controller_test.rb
@@ -1212,4 +1212,23 @@ class InvestigationsControllerTest < ActionController::TestCase
       assert_select 'a', text: /Add a #{I18n.t('study')}/i, count: 0
     end
   end
+
+  test 'compliance to isa json checked if ISA-JSON compliance enabled' do
+    current_user = FactoryBot.create(:user)
+    login_as(current_user)
+
+    with_config_values({isa_json_compliance_enabled: false, project_single_page_enabled: false}) do
+      get :new
+      assert_response :success
+
+      assert_select 'input[type="checkbox"][checked="checked"]#investigation_is_isa_json_compliant', count: 0
+    end
+
+    with_config_values({isa_json_compliance_enabled: true, project_single_page_enabled: true}) do
+      get :new
+      assert_response :success
+
+      assert_select 'input[type="checkbox"][checked="checked"]#investigation_is_isa_json_compliant', count: 1
+    end
+  end
 end


### PR DESCRIPTION
Small PR that simplifies making ISA-JSON compliant investigations. The `ISA-JSON compliance` checkbox is now checked when the Config value `isa_json_compliance` is enabled.
![image](https://github.com/user-attachments/assets/b0f93296-b2cb-4bed-b033-d47150ec86b4)
