### PR TITLE
Issue 1977 query by est fix reg samples

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -332,6 +332,16 @@ class SamplesController < ApplicationController
     end
   end
 
+  # Filters linked samples based on the provided options and template attribute title.
+  #
+  # @param samples [Array<Sample>] the list of samples to filter
+  # @param link [Symbol] the method to call on each sample to get the linked samples (:linked_samples or :linking_samples)
+  # @param options [Hash] the options for filtering
+  # @option options [Integer] :template_id the ID of the template to filter by
+  # @option options [String] :attribute_value the value of the attribute to filter by
+  # @option options [Integer] :attribute_id the ID of the attribute to filter by
+  # @param template_attribute_title [String] the title of the template attribute to filter by
+  # @return [Array<Sample>] the filtered list of samples
   def filter_linked_samples(samples, link, options, template_attribute_title)
     samples.select do |s|
       s.send(link).any? do |x|

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -346,7 +346,7 @@ class SamplesController < ApplicationController
     samples.select do |s|
       s.send(link).any? do |x|
         selected = x.sample_type.template_id == options[:template_id].to_i
-        selected = x.get_attribute_value(template_attribute_title)&.include?(options[:attribute_value]) if template_attribute_title.present? && selected
+        selected = x.get_attribute_value(template_attribute_title)&.downcase&.include?(options[:attribute_value]&.downcase) if template_attribute_title.present? && selected
         selected || filter_linked_samples([x], link, options, template_attribute_title).present?
       end
     end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -225,8 +225,16 @@ class SamplesController < ApplicationController
       Template.find(params[:template_id]).sample_types.map(&:samples).flatten : []
 
     if params[:template_attribute_id].present? && params[:template_attribute_value].present?
-      attribute_title = TemplateAttribute.find(params[:template_attribute_id]).title
-      @result = @result.select { |s| s.get_attribute_value(attribute_title)&.include?(params[:template_attribute_value]) }
+      attribute = TemplateAttribute.find(params[:template_attribute_id])
+      attribute_title = attribute.title
+      @result = @result.select do |s|
+        if attribute.sample_attribute_type.seek_sample_multi?
+          attr_value = s.get_attribute_value(attribute_title)
+          attr_value&.any? { |v| v[:title].include?(params[:template_attribute_value]) }
+        else
+          s.get_attribute_value(attribute_title)&.include?(params[:template_attribute_value])
+        end
+      end
     end
 
     if params[:input_template_id].present? # linked

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -238,7 +238,7 @@ class SamplesController < ApplicationController
           attr_value = s.get_attribute_value(sample_attribute_title)
           attr_value&.any? { |v| v.downcase.include?(attribute_filter_value) }
         else
-          s.get_attribute_value(sample_attribute_title)&.include?(attribute_filter_value)
+          s.get_attribute_value(sample_attribute_title)&.downcase&.include?(attribute_filter_value)
         end
       end
     end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -343,6 +343,8 @@ class SamplesController < ApplicationController
   # @param template_attribute_title [String] the title of the template attribute to filter by
   # @return [Array<Sample>] the filtered list of samples
   def filter_linked_samples(samples, link, options, template_attribute)
+    raise ArgumentError, "Invalid linking method provided. '#{link.to_s}' is not allowed!" unless %i[linked_samples linking_samples].include? link
+
     template_attribute_title = template_attribute&.title
     samples.select do |s|
       s.send(link).any? do |x|

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -220,7 +220,7 @@ class SamplesController < ApplicationController
 
   def query
     project_ids = params[:project_ids]&.map(&:to_i)
-    attribute_filter_value = params[:template_attribute_value].downcase
+    attribute_filter_value = params[:template_attribute_value]&.downcase
     @result = params[:template_id].present? ?
       Template.find(params[:template_id]).sample_types.map(&:samples).flatten : []
 
@@ -229,12 +229,12 @@ class SamplesController < ApplicationController
       @result = @result.select do |s|
         sample_attribute = s.sample_type.sample_attributes.detect { |sa| template_attribute.sample_attributes.include? sa }
         sample_attribute_title = sample_attribute&.title
-        if sample_attribute.sample_attribute_type.seek_sample_multi?
+        if sample_attribute&.sample_attribute_type&.seek_sample_multi?
           attr_value = s.get_attribute_value(sample_attribute_title)
           attr_value&.any? { |v| v[:title].downcase.include?(attribute_filter_value) }
-        elsif sample_attribute.sample_attribute_type.seek_sample?
+        elsif sample_attribute&.sample_attribute_type&.seek_sample?
           s.get_attribute_value(sample_attribute_title)[:title]&.downcase&.include?(attribute_filter_value)
-        elsif sample_attribute.sample_attribute_type.seek_cv_list?
+        elsif sample_attribute&.sample_attribute_type&.seek_cv_list?
           attr_value = s.get_attribute_value(sample_attribute_title)
           attr_value&.any? { |v| v.downcase.include?(attribute_filter_value) }
         else

--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -116,7 +116,7 @@ class TemplatesController < ApplicationController
   # post
   def template_attributes
     template = Template.find(params[:id])
-    items = template.template_attributes.map { |a| { id: a.id, title: a.title } }
+    items = template.template_attributes.map { |a| { id: a.id, title: a.title.sanitize } }
     respond_to do |format|
       format.json { render json: items.to_json }
     end

--- a/app/helpers/templates_helper.rb
+++ b/app/helpers/templates_helper.rb
@@ -17,12 +17,12 @@ module TemplatesHelper
   def load_templates
     privilege = Seek::Permissions::Translator.translate('view')
     Template.order(:group, :group_order).select { |t| t.can_perform?(privilege) }.map do |item|
-      { title: item.title,
-        group: item.group,
-        level: item.level,
-        organism: item.organism,
+      { title: item.title&.sanitize,
+        group: item.group&.sanitize,
+        level: item.level&.sanitize,
+        organism: item.organism&.sanitize,
         template_id: item.id,
-        description: item.description,
+        description: item.description&.sanitize,
         group_order: item.group_order,
         attributes: item.template_attributes.order(:pos).map { |a| map_template_attributes(a) } }
     end
@@ -77,19 +77,19 @@ module TemplatesHelper
   def map_template_attributes(attribute)
     {
       attribute_type_id: attribute.sample_attribute_type_id,
-      data_type: SampleAttributeType.find(attribute.sample_attribute_type_id)&.title,
+      data_type: SampleAttributeType.find(attribute.sample_attribute_type_id)&.title&.sanitize,
       cv_id: attribute.sample_controlled_vocab_id,
       allow_cv_free_text: attribute.allow_cv_free_text,
-      title: attribute.title,
+      title: attribute.title&.sanitize,
       is_title: attribute.is_title,
-      short_name: attribute.short_name,
-      description: attribute.description,
-      pid: attribute.pid,
+      short_name: attribute.short_name&.sanitize,
+      description: attribute.description&.sanitize,
+      pid: attribute.pid&.sanitize,
       required: attribute.required,
       unit_id: attribute.unit_id,
       pos: attribute.pos,
       isa_tag_id: attribute.isa_tag_id,
-      isa_tag_title: attribute.isa_tag&.title,
+      isa_tag_title: attribute.isa_tag&.title&.sanitize,
       linked_sample_type_id: attribute.linked_sample_type_id,
       template_attribute_id: attribute.id
     }

--- a/app/models/sample_type.rb
+++ b/app/models/sample_type.rb
@@ -60,6 +60,30 @@ class SampleType < ApplicationRecord
 
   has_annotation_type :sample_type_tag, method_name: :tags
 
+  # Creates sample attributes from an ISA template.
+  # @param template [Template] The ISA template to create sample attributes from.
+  # @param linked_sample_type [SampleType, nil] The linked sample type, if any.
+  def create_sample_attributes_from_isa_template(template, linked_sample_type = nil)
+    self.sample_attributes = template.template_attributes.map do |temp_attr|
+      has_seek_samples = temp_attr.sample_attribute_type.seek_sample? || temp_attr.sample_attribute_type.seek_sample_multi?
+      has_linked_st = linked_sample_type && has_seek_samples
+
+      SampleAttribute.new(
+        title: temp_attr.title,
+        description: temp_attr.description,
+        sample_attribute_type_id: temp_attr.sample_attribute_type_id,
+        required: temp_attr.required,
+        unit_id: temp_attr.unit_id,
+        is_title: temp_attr.is_title,
+        sample_controlled_vocab_id: temp_attr.sample_controlled_vocab_id,
+        linked_sample_type_id: has_linked_st ? linked_sample_type&.id : nil,
+        isa_tag_id: temp_attr.isa_tag_id,
+        allow_cv_free_text: temp_attr.allow_cv_free_text,
+        template_attribute_id: temp_attr.id
+      )
+    end
+  end
+
   def level
     isa_template&.level
   end

--- a/app/views/samples/query_form.html.erb
+++ b/app/views/samples/query_form.html.erb
@@ -17,7 +17,7 @@
 			<label>Select Project(s)</label>
 			<select id="projects" class="form-control select2" multiple="multiple">
 				<% projects.each do |p| %>
-					<option value='<%= p[:id] %>'><%= p[:title] %></option>
+					<option value='<%= p[:id] %>'><%= p[:title].sanitize %></option>
 				<% end %>
 			</select>
 		</div>
@@ -31,7 +31,7 @@
 				<% templates.pluck(:group).uniq.each do |group_name| %>
 					<optgroup label='<%= group_name %>'>
 						<% templates.select{|t| t[:group]==group_name}.each do |t| %>
-							<option value='<%= t[:template_id] %>'><%=t[:title]%></option>
+							<option value='<%= t[:template_id] %>'><%=t[:title].sanitize%></option>
 						<% end %>
 					</optgroup>
 				<% end %>
@@ -66,7 +66,7 @@
 					<% templates.pluck(:group).uniq.each do |group_name| %>
 						<optgroup label='<%= group_name %>'>
 							<% templates.select{|t| t[:group]==group_name}.each do |t| %>
-								<option value='<%= t[:template_id] %>'><%= t[:title] %></option>
+								<option value='<%= t[:template_id] %>'><%= t[:title].sanitize %></option>
 							<% end %>
 						</optgroup>
 					<% end %>
@@ -99,7 +99,7 @@
 					<% templates.pluck(:group).uniq.each do |group_name| %>
 						<optgroup label='<%= group_name %>'>
 							<% templates.select{|t| t[:group]==group_name}.each do |t| %>
-								<option value='<%= t[:template_id] %>'><%= t[:title] %></option>
+								<option value='<%= t[:template_id] %>'><%= t[:title].sanitize %></option>
 							<% end %>
 						</optgroup>
 					<% end %>

--- a/test/functional/samples_controller_test.rb
+++ b/test/functional/samples_controller_test.rb
@@ -1313,6 +1313,24 @@ class SamplesControllerTest < ActionController::TestCase
       assert result = assigns(:result)
       assert_equal 1, result.length
 
+      # Do the same query but with random casing to check if case-insensitive
+      post :query, xhr: true, params: {
+        project_ids: [project.id],
+        template_id: template2.id,
+        template_attribute_id: template2.template_attributes.second.id,
+        template_attribute_value: 'ColLecTion',
+        input_template_id: template1.id,
+        input_attribute_id: template1.template_attributes.third.id,
+        input_attribute_value: "x's",
+        output_template_id: template3.id,
+        output_attribute_id: template3.template_attributes.second.id,
+        output_attribute_value: '1'
+      }
+
+      assert_response :success
+      assert result = assigns(:result)
+      assert_equal 1, result.length
+
       # Query for sample's grandparents
       post :query, xhr: true, params: {
         project_ids: [project.id],

--- a/test/functional/samples_controller_test.rb
+++ b/test/functional/samples_controller_test.rb
@@ -1360,6 +1360,48 @@ class SamplesControllerTest < ActionController::TestCase
       assert_response :success
       assert result = assigns(:result)
       assert_equal 1, result.length
+
+      # Simple query on 'Input' attribute (SEEK_SAMPLE_MULTI type)
+      post :query, xhr: true, params: {
+        project_ids: [project.id],
+        template_id: template2.id,
+        template_attribute_id: template2.template_attributes.detect(&:input_attribute?)&.id,
+        template_attribute_value: 'source'
+      }
+
+      assert_response :success
+      result = assigns(:result)
+      assert_equal result.length, 1
+
+      # parent query on 'Input' attribute (SEEK_SAMPLE_MULTI type)
+      post :query, xhr: true, params: {
+        project_ids: [project.id],
+        template_id: template3.id,
+        template_attribute_id: template3.template_attributes.second.id,
+        template_attribute_value: 'Protocol',
+        input_template_id: template2.id,
+        input_attribute_id: template2.template_attributes.detect(&:input_attribute?)&.id,
+        input_attribute_value: "source"
+      }
+
+      assert_response :success
+      result = assigns(:result)
+      assert_equal result.length, 1
+
+      # Grandchild query on 'Input' attribute (SEEK_SAMPLE_MULTI type)
+      post :query, xhr: true, params: {
+        project_ids: [project.id],
+        template_id: template1.id,
+        template_attribute_id: template1.template_attributes.third.id,
+        template_attribute_value: "x's",
+        output_template_id: template3.id,
+        output_attribute_id: template3.template_attributes.detect(&:input_attribute?)&.id,
+        output_attribute_value: 'sample'
+      }
+
+      assert_response :success
+      result = assigns(:result)
+      assert_equal result.length, 1
     end
   end
 

--- a/test/functional/samples_controller_test.rb
+++ b/test/functional/samples_controller_test.rb
@@ -1275,11 +1275,14 @@ class SamplesControllerTest < ActionController::TestCase
       template2 = FactoryBot.create(:isa_sample_collection_template)
       template3 = FactoryBot.create(:isa_assay_material_template)
 
-      type1 = FactoryBot.create(:isa_source_sample_type, contributor: person, project_ids: [project.id], isa_template: template1)
-      type2 = FactoryBot.create(:isa_sample_collection_sample_type, contributor: person, project_ids: [project.id],
-                                                          isa_template: template2, linked_sample_type: type1)
-      type3 = FactoryBot.create(:isa_assay_material_sample_type, contributor: person, project_ids: [project.id], isa_template: template3,
-                                              linked_sample_type: type2)
+      type1 = FactoryBot.create(:simple_sample_type, contributor: person, project_ids: [project.id], title: 'Source sample type', template_id: template1.id)
+      type1.create_sample_attributes_from_isa_template(template1)
+
+      type2 = FactoryBot.create(:simple_sample_type, contributor: person, project_ids: [project.id], title: 'Sample collection sample type', template_id: template2.id)
+      type2.create_sample_attributes_from_isa_template(template2, type1)
+
+      type3 = FactoryBot.create(:simple_sample_type, contributor: person, project_ids: [project.id], title: 'Assay material sample type', template_id: template3.id)
+      type3.create_sample_attributes_from_isa_template(template3, type2)
 
       sample1 = FactoryBot.create :sample, title: 'sample1', sample_type: type1, project_ids: [project.id], contributor: person,
                                  data: { 'Source Name': 'Source Name', 'Source Characteristic 1': 'Source Characteristic 1', 'Source Characteristic 2': "Cox's Orange Pippin" }
@@ -1487,6 +1490,5 @@ class SamplesControllerTest < ActionController::TestCase
     sample.save!
     sample
   end
-
 
 end

--- a/test/functional/samples_controller_test.rb
+++ b/test/functional/samples_controller_test.rb
@@ -1290,7 +1290,8 @@ class SamplesControllerTest < ActionController::TestCase
       sample2 = FactoryBot.create :sample, title: 'sample2', sample_type: type2, project_ids: [project.id], contributor: person,
                                  data: { Input: [sample1.id], 'sample collection': 'sample collection', 'sample collection parameter value 1': 'sample collection parameter value 1', 'Sample Name': 'sample name', 'sample characteristic 1': 'sample characteristic 1' }
 
-      sample3 = FactoryBot.create :sample, title: 'sample3', sample_type: type3, project_ids: [project.id], contributor: person,
+      # sample3
+      FactoryBot.create :sample, title: 'sample3', sample_type: type3, project_ids: [project.id], contributor: person,
                                  data: { Input: [sample2.id], 'Protocol Assay 1': 'Protocol Assay 1', 'Assay 1 parameter value 1': 'Assay 1 parameter value 1', 'Extract Name': 'Extract Name', 'other material characteristic 1': 'other material characteristic 1' }
 
 

--- a/test/unit/sample_type_test.rb
+++ b/test/unit/sample_type_test.rb
@@ -1138,6 +1138,25 @@ class SampleTypeTest < ActiveSupport::TestCase
     assert third_sample_type.next_linked_sample_types.blank?
   end
 
+  test 'create sample attributes from isa template' do
+    template1 = FactoryBot.create(:isa_source_template)
+    template2 = FactoryBot.create(:isa_sample_collection_template)
+
+    sample_type1 = FactoryBot.create(:simple_sample_type, title: 'Sample Type 1', project_ids: @project_ids, contributor: @person, template_id: template1.id)
+    sample_type1.create_sample_attributes_from_isa_template(template1)
+    assert sample_type1.valid?
+    sample_type1.sample_attributes.map do |sa|
+      assert template1.template_attributes.map(&:id).include? sa.template_attribute_id
+    end
+
+    sample_type2 = FactoryBot.create(:simple_sample_type, title: 'Sample Type 2', project_ids: @project_ids, contributor: @person, template_id: template2.id)
+    sample_type2.create_sample_attributes_from_isa_template(template2, sample_type1)
+    assert sample_type2.valid?
+    sample_type2.sample_attributes.map do |sa|
+      assert template2.template_attributes.map(&:id).include? sa.template_attribute_id
+    end
+  end
+
   private
 
   # sample type with 3 samples


### PR DESCRIPTION
Fixes #1977 

- Querying samples by attributes that are not of type string, like SEEK samples and CV lists, is now possible.
- The query matches are now not case-sensitive anymore