### PR TITLE
Make subtext easier to read when highlighting select2 option

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -347,6 +347,10 @@ div.renderer {
   color: if(lightness($text-color) > 50, darken($text-color, 20%), lighten($text-color, 30%));
 }
 
+.select2-results__option--highlighted .subtle {
+  color: unset;
+}
+
 span.truncated-name {
   display: inline-block;
   overflow: hidden;


### PR DESCRIPTION
Fixes #1873

![image](https://github.com/user-attachments/assets/65471077-d832-478d-b109-4dba4f1ba931)
