### PR TITLE
Issue 1587 correct redirection isa json compliant items

### DIFF
--- a/app/controllers/assays_controller.rb
+++ b/app/controllers/assays_controller.rb
@@ -84,7 +84,11 @@ class AssaysController < ApplicationController
   end
 
   def edit
-    respond_to(&:html)
+    if @assay.is_isa_json_compliant?
+      redirect_to edit_isa_assay_path(@assay)
+    else
+      respond_to(&:html)
+    end
   end
 
   def create

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -40,8 +40,12 @@ class StudiesController < ApplicationController
 
   def edit
     @study = Study.find(params[:id])
-    respond_to do |format|
-      format.html
+    if @study.is_isa_json_compliant?
+      redirect_to edit_isa_study_path(@study)
+    else
+      respond_to do |format|
+        format.html
+      end
     end
   end
 

--- a/test/functional/assays_controller_test.rb
+++ b/test/functional/assays_controller_test.rb
@@ -2159,4 +2159,20 @@ class AssaysControllerTest < ActionController::TestCase
       assert_equal end_assay.position, 1
     end
   end
+
+  test 'should redirect isa json compliant assay to isa assay edit page' do
+    with_config_value(:isa_json_compliance_enabled, true) do
+      person = FactoryBot.create(:person)
+      project = person.projects.first
+      login_as(person)
+      investigation = FactoryBot.create(:investigation, is_isa_json_compliant: true, contributor: person)
+      study = FactoryBot.create(:isa_json_compliant_study, investigation: investigation )
+      assay_stream = FactoryBot.create(:assay_stream, study: study, contributor: person)
+      assay_sample_type = FactoryBot.create(:isa_assay_material_sample_type, linked_sample_type: study.sample_types.second, projects: [project], contributor: person)
+      assay = FactoryBot.create(:assay, contributor: person, study: study, assay_stream:, sample_type: assay_sample_type)
+
+      get :edit, params: { id: assay  }
+      assert_redirected_to edit_isa_assay_path(assay)
+    end
+  end
 end

--- a/test/functional/studies_controller_test.rb
+++ b/test/functional/studies_controller_test.rb
@@ -2099,4 +2099,16 @@ class StudiesControllerTest < ActionController::TestCase
       assert_select 'a', text: /Add new #{I18n.t('assay')}/i, count: 0
     end
   end
+
+  test 'should redirect isa json compliant study to isa study edit page' do
+    with_config_value(:isa_json_compliance_enabled, true) do
+      person = FactoryBot.create(:person)
+      login_as(person)
+      investigation = FactoryBot.create(:investigation, contributor: person, is_isa_json_compliant: true)
+      study = FactoryBot.create(:isa_json_compliant_study, contributor: person, investigation: investigation)
+
+      get :edit, params: { id: study }
+      assert_redirected_to edit_isa_study_path(study)
+    end
+  end
 end


### PR DESCRIPTION
When loading `/studies/:id/edit` or `/assays/:id/edit`,  ISA-JSON compliant items are redirected to `/isa_assays/:id/edit` and `/isa_studies/:id/edit`.

Closes #1587 