### PR TITLE
Direct user to sandbox if they try to create project/programme with "test" in the name

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -351,6 +351,8 @@ class AdminController < ApplicationController
     Seek::Config.metadata_license = params[:metadata_license]
     Seek::Config.recommended_data_licenses = params[:recommended_data_licenses]&.compact_blank
     Seek::Config.recommended_software_licenses = params[:recommended_software_licenses]&.compact_blank
+    Seek::Config.sandbox_instance_url = params[:sandbox_instance_url]
+    Seek::Config.sandbox_instance_name = params[:sandbox_instance_name]
     update_flag = (pubmed_email == '' || pubmed_email_valid) && (crossref_email == '' || crossref_email_valid)
     update_redirect_to update_flag, 'settings'
   end

--- a/app/views/admin/settings.html.erb
+++ b/app/views/admin/settings.html.erb
@@ -40,7 +40,7 @@
 
     <%= admin_text_setting(:sandbox_instance_url, Seek::Config.sandbox_instance_url,
                            'Sandbox instance URL', "A URL of an instance of SEEK to be used for testing/development. Users will be directed here if they attempt to create a #{t('project')} or #{t('programme')} with a name including \"test\".") %>
-    <%= admin_text_setting(:sandbox_instance_name, Seek::Config.sandbox_instance_url,
+    <%= admin_text_setting(:sandbox_instance_name, Seek::Config.sandbox_instance_name,
                            'Sandbox instance name', "The name of the testing/sandbox instance.") %>
     <h2>Policy and license settings</h2>
     <%= access_type_options = [Policy::PRIVATE, Policy::VISIBLE, Policy::ACCESSIBLE]

--- a/app/views/admin/settings.html.erb
+++ b/app/views/admin/settings.html.erb
@@ -38,6 +38,10 @@
                              :onkeypress => "javascript: return onlyNumbers(event);") %>
     </div>
 
+    <%= admin_text_setting(:sandbox_instance_url, Seek::Config.sandbox_instance_url,
+                           'Sandbox instance URL', "A URL of an instance of SEEK to be used for testing/development. Users will be directed here if they attempt to create a #{t('project')} or #{t('programme')} with a name including \"test\".") %>
+    <%= admin_text_setting(:sandbox_instance_name, Seek::Config.sandbox_instance_url,
+                           'Sandbox instance name', "The name of the testing/sandbox instance.") %>
     <h2>Policy and license settings</h2>
     <%= access_type_options = [Policy::PRIVATE, Policy::VISIBLE, Policy::ACCESSIBLE]
         # Passing in a data file so that is_downloadable is true, and the ACCESSIBLE option will be kept.

--- a/app/views/projects/guided_create.html.erb
+++ b/app/views/projects/guided_create.html.erb
@@ -1,7 +1,7 @@
 <%= index_and_new_help_icon controller_name %>
 
-<% if Seek::Config.sandbox_instance_url %>
-  <% sandbox_name = Seek::Config.sandbox_instance_name || Seek::Config.sandbox_instance_url %>
+<% if Seek::Config.sandbox_instance_url.present? %>
+  <% sandbox_name = Seek::Config.sandbox_instance_name.presence || Seek::Config.sandbox_instance_url %>
   <template id="sandbox-notice">
     <span class="help-block">
       If you would like to test out <%= Seek::Config.instance_name %>, please use

--- a/app/views/projects/guided_create.html.erb
+++ b/app/views/projects/guided_create.html.erb
@@ -1,5 +1,15 @@
 <%= index_and_new_help_icon controller_name %>
 
+<% if Seek::Config.sandbox_instance_url %>
+  <% sandbox_name = Seek::Config.sandbox_instance_name || Seek::Config.sandbox_instance_url %>
+  <template id="sandbox-notice">
+    <span class="help-block">
+      If you would like to test out <%= Seek::Config.instance_name %>, please use
+      <%= link_to(sandbox_name, Seek::Config.sandbox_instance_url, target: :_blank) %> instead.
+    </span>
+  </template>
+<% end %>
+
 <%= form_tag request_create_projects_path do %>
   <div class="row">
     <div  style="margin:auto;width:70%;">
@@ -15,8 +25,10 @@
           information once it has been created. You may also <a href="./guided_import">import</a> a project from a Data Management Plan (DMP) file.
         </div>
 
-        <%= label_tag :project_title, "Title" %><span class="required">*</span>
-        <%= text_field_tag 'project[title]', @project.title, class: 'form-control' %>
+        <div class="form-group" id="project-title-group">
+          <%= label_tag :project_title, "Title" %><span class="required">*</span>
+          <%= text_field_tag 'project[title]', @project.title, class: 'form-control' %>
+        </div>
         <%= label_tag :project_description, "Description" %>
         <%= text_area_tag 'project[description]', @project.description, rows:2, class: 'form-control' %>
         <%= label_tag :project_web_page, "Web page" %>
@@ -92,8 +104,30 @@
           checkSubmitButtonEnabled();
        });
 
-        $j('input#project_title').on('input',function() {
+       $j('input#project_title').on('input',function() {
             checkSubmitButtonEnabled();
-        });
+       });
+
+       var sandboxNotice = $j('#sandbox-notice');
+       var testingRegex = /^test| test/i;
+       if (sandboxNotice.length) {
+           ['#project-title-group', '#programme-title-group'].forEach(function (selector) {
+               var group = $j(selector);
+               if (group.length) {
+                   var textField = $j('input[type=text]', group);
+                   textField.blur(function () {
+                       var isTest = testingRegex.test(textField.val());
+                       group.toggleClass('has-warning', isTest);
+                       if (isTest) {
+                           if (!$j('.help-block', group).length) {
+                               group.append(sandboxNotice.html());
+                           }
+                       } else {
+                           $j('.help-block', group).remove();
+                       }
+                   });
+               }
+           });
+       }
     });
 </script>

--- a/app/views/projects/guided_create/_programme_details.html.erb
+++ b/app/views/projects/guided_create/_programme_details.html.erb
@@ -3,6 +3,8 @@
   <div class="help-block">
     Specify a title for a new <%= t('programme') %>, which your new <%= t('project') %> will be associated with.
   </div>
-  <%= label_tag :programme_title, "Title" %><span class="required">*</span>
-  <%= text_field_tag 'programme[title]', @programme&.title, class: 'form-control' %>
+  <div class="form-group" id="programme-title-group">
+    <%= label_tag :programme_title, "Title" %><span class="required">*</span>
+    <%= text_field_tag 'programme[title]', @programme&.title, class: 'form-control' %>
+  </div>
 </div>

--- a/lib/seek/config_setting_attributes.yml
+++ b/lib/seek/config_setting_attributes.yml
@@ -271,3 +271,5 @@ regular_job_offset:
 auto_activate_programmes:
 auto_activate_site_managed_projects:
 fair_data_station_enabled:
+sandbox_instance_url:
+sandbox_instance_name:


### PR DESCRIPTION
- Adds `sandbox_instance_url` and `sandbox_instance_name` settings to admin page (under Settings).
- Adds JS on guided project creation form that, if a sandbox URL is set, checks for "test", "testing" etc. in the project/programme name (but not "greatest" etc.) and displays a warning message.

![image](https://github.com/user-attachments/assets/4a8e9f5f-6cc7-44a9-b6db-f6b53005b219)
