### PR TITLE
if person or project can be edited then show contact details 

### DIFF
--- a/app/helpers/people_helper.rb
+++ b/app/helpers/people_helper.rb
@@ -45,9 +45,11 @@ module PeopleHelper
   # Return whether or not to hide contact details from this user
   # Current decided by Seek::Config.hide_details_enabled or
   # is hidden if the current person doesn't share the same programme as the person being viewed
+  # User that can edit, the sys admins, can see the details unless hide_details_enabled is set
   def hide_contact_details?(displayed_person_or_project)
     return true if Seek::Config.hide_details_enabled || !logged_in?
-    !current_user.person.shares_project_or_programme?(displayed_person_or_project)
+
+    !(displayed_person_or_project.can_edit? || current_user.person.shares_project_or_programme?(displayed_person_or_project))
   end
 
   def filter_items_not_in_ISA (all_related_items)

--- a/test/unit/helpers/people_helper_test.rb
+++ b/test/unit/helpers/people_helper_test.rb
@@ -1,0 +1,75 @@
+require 'test_helper'
+
+class PeopleHelperTest < ActionView::TestCase
+
+  # mocking the methods that are added as helper methods via AuthenticatedSystem when included in ApplicationController (using helper_method :xxx)
+  PeopleHelperTest.class_eval do
+    define_method :logged_in? do
+      User.logged_in?
+    end
+    define_method :current_user do
+      User.current_user
+    end
+  end
+
+  test'hide_contact_details?' do
+    PeopleController.new
+    admin = FactoryBot.create(:admin)
+    person = FactoryBot.create(:person)
+    project = person.projects.first
+    person_same_project = FactoryBot.create(:person)
+    person_same_project.add_to_project_and_institution(project, person.institutions.first)
+    person_different_project = FactoryBot.create(:person)
+    different_project = person_different_project.projects.first
+
+    User.with_current_user(person.user) do
+      with_config_value(:hide_details_enabled, false) do
+        refute hide_contact_details?(person_same_project)
+        assert hide_contact_details?(person_different_project)
+        refute hide_contact_details?(project)
+        assert hide_contact_details?(different_project)
+      end
+
+      with_config_value(:hide_details_enabled, true) do
+        assert hide_contact_details?(person_same_project)
+        assert hide_contact_details?(person_different_project)
+        assert hide_contact_details?(project)
+        assert hide_contact_details?(different_project)
+      end
+    end
+
+    User.with_current_user(nil) do
+      with_config_value(:hide_details_enabled, false) do
+        assert hide_contact_details?(person_same_project)
+        assert hide_contact_details?(person_different_project)
+        assert hide_contact_details?(project)
+        assert hide_contact_details?(different_project)
+      end
+
+      with_config_value(:hide_details_enabled, true) do
+        assert hide_contact_details?(person_same_project)
+        assert hide_contact_details?(person_different_project)
+        assert hide_contact_details?(project)
+        assert hide_contact_details?(different_project)
+      end
+    end
+
+    User.with_current_user(admin) do
+      with_config_value(:hide_details_enabled, false) do
+        refute hide_contact_details?(person_same_project)
+        refute hide_contact_details?(person_different_project)
+        refute hide_contact_details?(project)
+        refute hide_contact_details?(different_project)
+      end
+
+      with_config_value(:hide_details_enabled, true) do
+        assert hide_contact_details?(person_same_project)
+        assert hide_contact_details?(person_different_project)
+        assert hide_contact_details?(project)
+        assert hide_contact_details?(different_project)
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
Display contact details for those that have permission to edit a profile (typically sys admins). Don't show if `hide_details_enabled` is true

* fix for #1988