### PR TITLE
Fix treeview builder for sampletypes

### DIFF
--- a/lib/treeview_builder.rb
+++ b/lib/treeview_builder.rb
@@ -52,11 +52,7 @@ class TreeviewBuilder
   end
 
   def create_node(obj)
-    can_view = if obj[:resource].is_a?(SampleType)
-                 obj[:resource].can_view?(User.current_user, nil, true)
-               else
-                 obj[:resource].can_view?
-               end
+    can_view = obj[:resource].can_view?
     unless can_view
       obj[:text] = 'hidden item'
       obj[:a_attr] = { 'style': 'font-style:italic;font-weight:bold;color:#ccc' }


### PR DESCRIPTION
Fixes the `treeview_builder` which is called from here:
https://github.com/seek4science/seek/blob/76082619c3b0d40914afa1b708b12f19ce122fb0/app/views/single_pages/show.html.erb#L61