### PR TITLE
Typo in upgrade task

### DIFF
--- a/lib/tasks/seek_upgrades.rake
+++ b/lib/tasks/seek_upgrades.rake
@@ -261,7 +261,7 @@ namespace :seek do
           # Project admins can manage
           project_admins = st.projects.map(&:project_administrators).flatten
           project_admins.map do |admin|
-            policy.permissions << Permission.new(contributor_type: Permission::PERSON, contributor_id: admin.id, access_type: Policy::MANAGE)
+            policy.permissions << Permission.new(contributor_type: Permission::PERSON, contributor_id: admin.id, access_type: Policy::MANAGING)
           end
 
           policy.save


### PR DESCRIPTION
Fix for failing Upgrade task because of typo.