### PR TITLE
remove obsolete 'version' from the docker composes

### DIFF
--- a/docker-compose-relative-root.yml
+++ b/docker-compose-relative-root.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   db: # Database implementation, in this case MySQL
     image: mysql:8.0

--- a/docker-compose-virtuoso.yml
+++ b/docker-compose-virtuoso.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   db: # Database implementation, in this case MySQL
     image: mysql:8.0

--- a/docker-compose-with-email.yml
+++ b/docker-compose-with-email.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   db: # Database implementation, in this case MySQL
     image: mysql:8.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   db: # Database implementation, in this case MySQL
     image: mysql:8.0


### PR DESCRIPTION
version is no longer needed or used. Results in the warning ...

```
docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```