### PR TITLE
Fair data station setting in admin UI

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -122,6 +122,7 @@ class AdminController < ApplicationController
     Seek::Config.events_enabled = string_to_boolean params[:events_enabled]
     Seek::Config.isa_enabled = string_to_boolean params[:isa_enabled]
     Seek::Config.observation_units_enabled = string_to_boolean params[:observation_units_enabled]
+    Seek::Config.fair_data_station_enabled = string_to_boolean params[:fair_data_station_enabled]
     Seek::Config.models_enabled = string_to_boolean params[:models_enabled]
     Seek::Config.organisms_enabled = string_to_boolean params[:organisms_enabled]
     Seek::Config.programmes_enabled = string_to_boolean params[:programmes_enabled]

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -11,6 +11,8 @@ class ProjectsController < ApplicationController
   include Seek::AnnotationCommon
 
   before_action :fair_data_station_enabled?, only:[:import_from_fairdata_station, :submit_fairdata_station]
+  before_action :observation_units_enabled?, only:[:import_from_fairdata_station, :submit_fairdata_station]
+  before_action :investigations_enabled?, only:[:import_from_fairdata_station, :submit_fairdata_station]
 
   before_action :login_required, only: [:guided_join, :guided_create, :guided_import, :request_join, :request_create, :request_import,
                                         :administer_join_request, :respond_join_request,

--- a/app/views/admin/features_enabled.html.erb
+++ b/app/views/admin/features_enabled.html.erb
@@ -57,11 +57,14 @@
                              "#{t('event').pluralize} enabled","Whether the #{t('event').pluralize} are displayed and can be added.") %>
 
   <%= admin_checkbox_setting(:isa_enabled, 1, Seek::Config.isa_enabled,
-                             "ISA enabled", "Whether the ISA framework is enabled. The ISA framework allows users to create Investigations, Studies and Assays to organize their work.") %>
-  <%= admin_checkbox_setting(:observation_units_enabled, 1, Seek::Config.observation_units_enabled,
-                             "Observation Units enabled", "Whether the users can register Observation Units to organize their work. Requires ISA enabled to function correctly.") %>
-  <%= admin_checkbox_setting(:fair_data_station_enabled, 1, Seek::Config.fair_data_station_enabled,
-                             "FAIR Data Station enabled", "Whether the users can import or update using metadata from FAIR Data Station. Requires ISA and Observation Units to be enabled to function correctly") %>
+                             "ISA enabled", "Whether the ISA framework is enabled. The ISA framework allows users to create Investigations, Studies and Assays to organize their work.",
+                             onchange: toggle_appear_javascript('isa_details')) %>
+  <div id="isa_details" class="additional_settings" style="<%= show_or_hide_block Seek::Config.isa_enabled -%>">
+    <%= admin_checkbox_setting(:observation_units_enabled, 1, Seek::Config.observation_units_enabled,
+                               "Observation Units enabled", "Whether the users can register Observation Units to organize their work. Requires ISA enabled to function correctly.") %>
+    <%= admin_checkbox_setting(:fair_data_station_enabled, 1, Seek::Config.fair_data_station_enabled,
+                               "FAIR Data Station enabled", "Whether the users can import or update using metadata from FAIR Data Station. Requires ISA and Observation Units to be enabled to function correctly") %>
+  </div>
   <%= admin_checkbox_setting(:models_enabled, 1, Seek::Config.models_enabled,
                              "Models enabled", "Whether the users can register computational models in SEEK.") %>
 

--- a/app/views/admin/features_enabled.html.erb
+++ b/app/views/admin/features_enabled.html.erb
@@ -59,7 +59,9 @@
   <%= admin_checkbox_setting(:isa_enabled, 1, Seek::Config.isa_enabled,
                              "ISA enabled", "Whether the ISA framework is enabled. The ISA framework allows users to create Investigations, Studies and Assays to organize their work.") %>
   <%= admin_checkbox_setting(:observation_units_enabled, 1, Seek::Config.observation_units_enabled,
-                             "Observation Units enabled", "Whether the users can register Observation Units to organize their work.") %>
+                             "Observation Units enabled", "Whether the users can register Observation Units to organize their work. Requires ISA enabled to function correctly.") %>
+  <%= admin_checkbox_setting(:fair_data_station_enabled, 1, Seek::Config.fair_data_station_enabled,
+                             "FAIR Data Station enabled", "Whether the users can import or update using metadata from FAIR Data Station. Requires ISA and Observation Units to be enabled to function correctly") %>
   <%= admin_checkbox_setting(:models_enabled, 1, Seek::Config.models_enabled,
                              "Models enabled", "Whether the users can register computational models in SEEK.") %>
 

--- a/config/initializers/seek_configuration.rb
+++ b/config/initializers/seek_configuration.rb
@@ -82,7 +82,7 @@ def load_seek_config_defaults!
   Seek::Config.default :data_files_enabled,true
   Seek::Config.default :events_enabled,true
   Seek::Config.default :isa_enabled, true
-  Seek::Config.default :observation_units_enabled,true
+  Seek::Config.default :observation_units_enabled, false
   Seek::Config.default :models_enabled,true
   Seek::Config.default :organisms_enabled,true
   Seek::Config.default :programmes_enabled, false

--- a/test/functional/projects_controller_test.rb
+++ b/test/functional/projects_controller_test.rb
@@ -5079,6 +5079,38 @@ class ProjectsControllerTest < ActionController::TestCase
     end
   end
 
+  test 'dont show import from fair data station if obs units disabled' do
+    person = FactoryBot.create(:person)
+    refute person.is_admin?
+    project = person.projects.first
+    with_config_value(:observation_units_enabled, false) do
+      get :show, params: { id: project.id }
+      assert_response :success
+      # menu item still shown but will be an error message when clicking it
+      assert_select '#item-admin-menu' do
+        assert_select 'li a[href=?]', import_from_fairdata_station_project_path(project), text:/Import from FAIRData Station/, count: 1
+      end
+
+      get :import_from_fairdata_station, params: { id: project.id }
+      assert_redirected_to :root
+      refute_nil flash[:error]
+      assert_equal 'Observation units are disabled', flash[:error]
+    end
+    with_config_value(:isa_enabled, false) do
+      get :show, params: { id: project.id }
+      assert_response :success
+      # menu item still shown but will be an error message when clicking it
+      assert_select '#item-admin-menu' do
+        assert_select 'li a[href=?]', import_from_fairdata_station_project_path(project), text:/Import from FAIRData Station/, count: 1
+      end
+
+      get :import_from_fairdata_station, params: { id: project.id }
+      assert_redirected_to :root
+      refute_nil flash[:error]
+      assert_equal 'Investigations are disabled', flash[:error]
+    end
+  end
+
   test 'populate from fairdata station ttl' do
 
     person = FactoryBot.create(:person)

--- a/test/functional/projects_controller_test.rb
+++ b/test/functional/projects_controller_test.rb
@@ -5079,7 +5079,7 @@ class ProjectsControllerTest < ActionController::TestCase
     end
   end
 
-  test 'dont show import from fair data station if obs units disabled' do
+  test 'dont show import from fair data station if obs units or isa disabled' do
     person = FactoryBot.create(:person)
     refute person.is_admin?
     project = person.projects.first


### PR DESCRIPTION
option to enable / disable added to the admin UI.

Now grouped together with Observation Unit, beneath ISA_enabled.

if enabled but without enabling observation units or isa, then the menu option is shown but results in an error that it needs those enabling.

* fix for #2021