### PR TITLE
362 add and edit attributes in sample types

### DIFF
--- a/app/controllers/sample_types_controller.rb
+++ b/app/controllers/sample_types_controller.rb
@@ -13,6 +13,7 @@ class SampleTypesController < ApplicationController
   before_action :auth_to_create, only: %i[new create]
   before_action :project_membership_required, only: %i[create new select filter_for_select]
 
+  after_action :update_sample_json_metadata, only: :update
 
   api_actions :index, :show, :create, :update, :destroy
 
@@ -200,5 +201,9 @@ class SampleTypesController < ApplicationController
       flash[:error] = "Cannot #{action_name} this sample type - There are #{count} samples using it."
       redirect_to @sample_type
     end
+  end
+
+  def update_sample_json_metadata
+    UpdateSampleMetadataJob.perform_later(@sample_type)
   end
 end

--- a/app/controllers/sample_types_controller.rb
+++ b/app/controllers/sample_types_controller.rb
@@ -227,6 +227,7 @@ class SampleTypesController < ApplicationController
 
   def check_if_locked
     @sample_type ||= SampleType.find(params[:id])
+    @sample_type.reload
     return unless @sample_type&.locked?
 
     error_message = 'This sample type is locked and cannot be edited right now.'

--- a/app/controllers/sample_types_controller.rb
+++ b/app/controllers/sample_types_controller.rb
@@ -204,6 +204,6 @@ class SampleTypesController < ApplicationController
   end
 
   def update_sample_json_metadata
-    UpdateSampleMetadataJob.perform_later(@sample_type)
+    UpdateSampleMetadataJob.perform_later(@sample_type) unless @sample_type.samples.blank?
   end
 end

--- a/app/controllers/sample_types_controller.rb
+++ b/app/controllers/sample_types_controller.rb
@@ -6,10 +6,10 @@ class SampleTypesController < ApplicationController
 
   before_action :samples_enabled?
   before_action :check_no_created_samples, only: [:destroy]
+  before_action :check_if_locked, only: %i[edit manage manage_update update]
   before_action :find_and_authorize_requested_item, except: %i[create batch_upload index new template_details]
   before_action :find_sample_type, only: %i[batch_upload template_details]
   before_action :check_isa_json_compliance, only: %i[edit update manage manage_update]
-  before_action :check_if_locked, only: %i[edit manage update manage_update]
   before_action :find_assets, only: [:index]
   before_action :auth_to_create, only: %i[new create]
   before_action :project_membership_required, only: %i[create new select filter_for_select]
@@ -222,12 +222,12 @@ class SampleTypesController < ApplicationController
     end.compact
     return if attribute_changes.blank?
 
-    UpdateSampleMetadataJob.perform_later(@sample_type, attribute_changes, @current_user)
+    UpdateSampleMetadataJob.perform_later(@sample_type, @current_user, attribute_changes)
   end
 
   def check_if_locked
-    return unless @sample_type.locked?
-    return if @current_user&.is_admin?
+    @sample_type ||= SampleType.find(params[:id])
+    return unless @sample_type&.locked?
 
     error_message = 'This sample type is locked and cannot be edited right now.'
     flash[:error] = error_message

--- a/app/controllers/sample_types_controller.rb
+++ b/app/controllers/sample_types_controller.rb
@@ -9,6 +9,7 @@ class SampleTypesController < ApplicationController
   before_action :find_and_authorize_requested_item, except: %i[create batch_upload index new template_details]
   before_action :find_sample_type, only: %i[batch_upload template_details]
   before_action :check_isa_json_compliance, only: %i[edit update manage manage_update]
+  before_action :check_if_locked, only: %i[edit manage update manage_update]
   before_action :find_assets, only: [:index]
   before_action :auth_to_create, only: %i[new create]
   before_action :project_membership_required, only: %i[create new select filter_for_select]
@@ -222,5 +223,15 @@ class SampleTypesController < ApplicationController
     return if attribute_changes.blank?
 
     UpdateSampleMetadataJob.perform_later(@sample_type, attribute_changes, @current_user)
+  end
+
+  def check_if_locked
+    return unless @sample_type.locked?
+    return if @current_user&.is_admin?
+
+    error_message = 'This sample type is locked and cannot be edited right now.'
+    flash[:error] = error_message
+    @sample_type.errors.add(:base, error_message)
+    redirect_to @sample_type
   end
 end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -8,6 +8,7 @@ class SamplesController < ApplicationController
   before_action :samples_enabled?
   before_action :find_index_assets, only: :index
   before_action :find_and_authorize_requested_item, except: [:index, :new, :create, :preview]
+  before_action :check_if_locked_sample_type, only: [:edit, :new]
   before_action :templates_enabled?, only: [:query, :query_form]
 
   before_action :auth_to_create, only: %i[new create batch_create]
@@ -370,5 +371,15 @@ class SamplesController < ApplicationController
       flash[:error] = 'Not available'
       redirect_to select_sample_types_path
     end
+  end
+
+  def check_if_locked_sample_type
+    return unless params[:sample_type_id]
+
+    sample_type = SampleType.find(params[:sample_type_id])
+    return unless sample_type&.locked?
+
+    flash[:error] = 'This sample type is locked. You cannot edit the sample.'
+    redirect_to sample_types_path(sample_type)
   end
 end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -8,7 +8,7 @@ class SamplesController < ApplicationController
   before_action :samples_enabled?
   before_action :find_index_assets, only: :index
   before_action :find_and_authorize_requested_item, except: [:index, :new, :create, :preview]
-  before_action :check_if_locked_sample_type, only: [:edit, :new]
+  before_action :check_if_locked_sample_type, only: %i[edit new create update]
   before_action :templates_enabled?, only: [:query, :query_form]
 
   before_action :auth_to_create, only: %i[new create batch_create]

--- a/app/jobs/update_sample_metadata_job.rb
+++ b/app/jobs/update_sample_metadata_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class UpdateSampleMetadataJob < ApplicationJob
+  queue_with_priority 1
+  queue_as :QueueNames::SAMPLES
+
+  def perform(sample_type)
+    Seek::Samples::SampleMetadataUpdater.new(sample_type).update_metadata
+  end
+end

--- a/app/jobs/update_sample_metadata_job.rb
+++ b/app/jobs/update_sample_metadata_job.rb
@@ -5,7 +5,7 @@ class UpdateSampleMetadataJob < TaskJob
   queue_as QueueNames::SAMPLES
 
   after_perform do |job|
-    SampleTypeUpdateJob.perform_later(job.arguments.first, true)
+    SampleTypeUpdateJob.perform_later(job.arguments.first, false)
   end
 
   def perform(sample_type, user, attribute_changes = [])

--- a/app/jobs/update_sample_metadata_job.rb
+++ b/app/jobs/update_sample_metadata_job.rb
@@ -4,7 +4,7 @@ class UpdateSampleMetadataJob < ApplicationJob
   queue_with_priority 1
   queue_as QueueNames::SAMPLES
 
-  def perform(sample_type)
-    Seek::Samples::SampleMetadataUpdater.new(sample_type).update_metadata
+  def perform(sample_type, attribute_changes = [])
+    Seek::Samples::SampleMetadataUpdater.new(sample_type, attribute_changes).update_metadata
   end
 end

--- a/app/jobs/update_sample_metadata_job.rb
+++ b/app/jobs/update_sample_metadata_job.rb
@@ -5,10 +5,16 @@ class UpdateSampleMetadataJob < ApplicationJob
   queue_as QueueNames::SAMPLES
 
   def perform(sample_type, user, attribute_changes = [])
+    Rails.cache.write("sample_type_lock_#{sample_type.id}", true, expires_in: 1.hour)
+
+    Seek::Samples::SampleMetadataUpdater.new(sample_type, user, attribute_changes).update_metadata
+  end
+
+  def perform_with_error(sample_type, user, attribute_changes = [])
     begin
       Rails.cache.write("sample_type_lock_#{sample_type.id}", true, expires_in: 1.hour)
       sample_type.lock.samples.in_batches(of: 1000) do |samples|
-        Seek::Samples::SampleMetadataUpdater.new(samples, user, attribute_changes).update_metadata
+        Seek::Samples::SampleMetadataUpdater.new(samples, user, attribute_changes).raise_sample_metadata_update_exception
       end
     end
   ensure

--- a/app/jobs/update_sample_metadata_job.rb
+++ b/app/jobs/update_sample_metadata_job.rb
@@ -4,7 +4,7 @@ class UpdateSampleMetadataJob < ApplicationJob
   queue_with_priority 1
   queue_as QueueNames::SAMPLES
 
-  def perform(sample_type, attribute_changes = [])
-    Seek::Samples::SampleMetadataUpdater.new(sample_type, attribute_changes).update_metadata
+  def perform(sample_type, attribute_changes = [], user)
+    Seek::Samples::SampleMetadataUpdater.new(sample_type, attribute_changes, user).update_metadata
   end
 end

--- a/app/jobs/update_sample_metadata_job.rb
+++ b/app/jobs/update_sample_metadata_job.rb
@@ -2,7 +2,7 @@
 
 class UpdateSampleMetadataJob < ApplicationJob
   queue_with_priority 1
-  queue_as :QueueNames::SAMPLES
+  queue_as QueueNames::SAMPLES
 
   def perform(sample_type)
     Seek::Samples::SampleMetadataUpdater.new(sample_type).update_metadata

--- a/app/jobs/update_sample_metadata_job.rb
+++ b/app/jobs/update_sample_metadata_job.rb
@@ -4,6 +4,10 @@ class UpdateSampleMetadataJob < TaskJob
   queue_with_priority 1
   queue_as QueueNames::SAMPLES
 
+  after_perform do |job|
+    SampleTypeUpdateJob.perform_later(job.arguments.first, true)
+  end
+
   def perform(sample_type, user, attribute_changes = [])
     @sample_type = sample_type
     @user = user

--- a/app/jobs/update_sample_metadata_job.rb
+++ b/app/jobs/update_sample_metadata_job.rb
@@ -4,7 +4,9 @@ class UpdateSampleMetadataJob < ApplicationJob
   queue_with_priority 1
   queue_as QueueNames::SAMPLES
 
-  def perform(sample_type, attribute_changes = [], user)
-    Seek::Samples::SampleMetadataUpdater.new(sample_type, attribute_changes, user).update_metadata
+  def perform(sample_type, user, attribute_changes = [])
+    sample_type.samples.in_batches(of: 1000) do |samples|
+      Seek::Samples::SampleMetadataUpdater.new(samples, user, attribute_changes).update_metadata
+    end
   end
 end

--- a/app/jobs/update_sample_metadata_job.rb
+++ b/app/jobs/update_sample_metadata_job.rb
@@ -1,18 +1,8 @@
 # frozen_string_literal: true
 
-class UpdateSampleMetadataJob < ApplicationJob
+class UpdateSampleMetadataJob < TaskJob
   queue_with_priority 1
   queue_as QueueNames::SAMPLES
-
-  attr_accessor :sample_type, :user, :attribute_changes
-
-  before_enqueue do |job|
-    SampleType.find(job.arguments[0].id).set_lock
-  end
-
-  before_perform do |job|
-    SampleType.find(job.arguments[0].id).set_lock
-  end
 
   def perform(sample_type, user, attribute_changes = [])
     @sample_type = sample_type
@@ -20,5 +10,9 @@ class UpdateSampleMetadataJob < ApplicationJob
     @attribute_changes = attribute_changes
 
     Seek::Samples::SampleMetadataUpdater.new(@sample_type, @user, @attribute_changes).update_metadata
+  end
+
+  def task
+    arguments[0].sample_metadata_update_task
   end
 end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -40,6 +40,7 @@ class Sample < ApplicationRecord
 
   validates_with SampleAttributeValidator
   validate :validate_added_linked_sample_permissions
+  validate :check_if_locked_sample_type, on: :create
 
   before_validation :set_title_to_title_attribute_value
   before_validation :update_sample_resource_links
@@ -241,12 +242,12 @@ class Sample < ApplicationRecord
     return if $authorization_checks_disabled
     return if linked_samples.empty?
     previous_linked_samples = []
-    unless new_record?
-      previous_linked_samples = Sample.find(id).referenced_samples
-    end
+    previous_linked_samples = Sample.find(id).referenced_samples unless new_record?
     additions = linked_samples - previous_linked_samples
-    if additions.detect { |sample| !sample.can_view? }
-      errors.add(:linked_samples, 'includes a new private sample')
-    end
+    errors.add(:linked_samples, 'includes a new private sample') if additions.detect { |sample| !sample.can_view? }
+  end
+
+  def check_if_locked_sample_type
+    errors.add(:sample_type, 'is locked') if sample_type&.locked?
   end
 end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -40,7 +40,7 @@ class Sample < ApplicationRecord
 
   validates_with SampleAttributeValidator
   validate :validate_added_linked_sample_permissions
-  validate :check_if_locked_sample_type, on: :create
+  validate :check_if_locked_sample_type, on: %i[create update]
 
   before_validation :set_title_to_title_attribute_value
   before_validation :update_sample_resource_links

--- a/app/models/sample_attribute.rb
+++ b/app/models/sample_attribute.rb
@@ -97,7 +97,8 @@ class SampleAttribute < ApplicationRecord
 
   def validate_against_editing_constraints
     c = sample_type.editing_constraints
-    error_message = "cannot be changed (#{title_was})" # Use pre-change title in error message.
+    attr_title = self.new_record? ? title : title_was
+    error_message = "cannot be changed (#{attr_title})" # Use pre-change title in error message.
 
     errors.add(:title, error_message) if title_changed? && !c.allow_name_change?(self)
 

--- a/app/models/sample_attribute.rb
+++ b/app/models/sample_attribute.rb
@@ -100,8 +100,6 @@ class SampleAttribute < ApplicationRecord
     attr_title = self.new_record? ? title : title_was
     error_message = "cannot be changed (#{attr_title})" # Use pre-change title in error message.
 
-    errors.add(:title, error_message) if title_changed? && !c.allow_name_change?(self)
-
     unless c.allow_required?(self)
       errors.add(:is_title, error_message) if is_title_changed?
       errors.add(:required, error_message) if required_changed?

--- a/app/models/sample_type.rb
+++ b/app/models/sample_type.rb
@@ -162,18 +162,19 @@ class SampleType < ApplicationRecord
     can && (!Seek::Config.project_admin_sample_type_restriction || User.current_user.is_admin_or_project_administrator?)
   end
 
-  def can_edit?(user = User.current_user)
+  def state_allows_edit?(*args)
     super && !locked?
   end
 
-  def can_manage?(user = User.current_user)
+  def state_allows_manage?(*args)
+    super && !locked?
+  end
+
+  def state_allows_delete?(*args)
     super && !locked?
   end
 
   def can_delete?(user = User.current_user)
-    # Should not be able to delete a sample type if it is locked
-    return false if locked?
-
     # Users should be able to delete an ISA JSON compliant sample type that has linked sample attributes,
     # as long as it's ISA JSON compliant.
     if is_isa_json_compliant?

--- a/app/models/sample_type.rb
+++ b/app/models/sample_type.rb
@@ -165,7 +165,18 @@ class SampleType < ApplicationRecord
     can && (!Seek::Config.project_admin_sample_type_restriction || User.current_user.is_admin_or_project_administrator?)
   end
 
+  def can_edit?(user = User.current_user)
+    super && !locked?
+  end
+
+  def can_manage?(user = User.current_user)
+    super && !locked?
+  end
+
   def can_delete?(user = User.current_user)
+    # Should not be able to delete a sample type if it is locked
+    return false if locked?
+
     # Users should be able to delete an ISA JSON compliant sample type that has linked sample attributes,
     # as long as it's ISA JSON compliant.
     if is_isa_json_compliant?

--- a/app/models/sample_type.rb
+++ b/app/models/sample_type.rb
@@ -115,6 +115,10 @@ class SampleType < ApplicationRecord
     Rails.cache.fetch("sample_type_lock_#{id}").present?
   end
 
+  def set_lock
+    Rails.cache.write("sample_type_lock_#{id}", true, expires_in: 1.hour)
+  end
+
   def validate_value?(attribute_name, value)
     attribute = sample_attributes.detect { |attr| attr.title == attribute_name }
     raise UnknownAttributeException, "Unknown attribute #{attribute_name}" unless attribute

--- a/app/models/sample_type.rb
+++ b/app/models/sample_type.rb
@@ -64,6 +64,7 @@ class SampleType < ApplicationRecord
 
   has_annotation_type :sample_type_tag, method_name: :tags
 
+  has_task :sample_metadata_update
   def investigations
     return [] if studies.empty? && assays.empty?
 
@@ -112,11 +113,7 @@ class SampleType < ApplicationRecord
   end
 
   def locked?
-    Rails.cache.fetch("sample_type_lock_#{id}").present?
-  end
-
-  def set_lock
-    Rails.cache.write("sample_type_lock_#{id}", true, expires_in: 1.hour)
+    sample_metadata_update_task&.in_progress?
   end
 
   def validate_value?(attribute_name, value)

--- a/app/models/sample_type.rb
+++ b/app/models/sample_type.rb
@@ -244,10 +244,6 @@ class SampleType < ApplicationRecord
       if a.marked_for_destruction? && !c.allow_attribute_removal?(a)
         errors.add(:sample_attributes, "cannot be removed, there are existing samples using this attribute (#{a.title})")
       end
-
-      if a.new_record? && !c.allow_new_attribute?
-        errors.add(:sample_attributes, "cannot be added, new attributes are not allowed (#{a.title})")
-      end
     end
   end
 

--- a/app/views/isa_studies/_sample_types_form.html.erb
+++ b/app/views/isa_studies/_sample_types_form.html.erb
@@ -52,7 +52,7 @@
                                                                                   display_isa_tag: true } %>
 					<% end %>
 
-					<% unless sample_type.uploaded_template? %>
+					<% unless sample_type.uploaded_template? || !sample_type.editing_constraints.allow_new_attribute? %>
 							<tr id=<%=add_attribute_row_id%> >
 								<td colspan="6">
 									<%= button_link_to('Add new attribute', 'add', '#', id: add_attribute_id  ) %>

--- a/app/views/isa_studies/_sample_types_form.html.erb
+++ b/app/views/isa_studies/_sample_types_form.html.erb
@@ -52,7 +52,7 @@
                                                                                   display_isa_tag: true } %>
 					<% end %>
 
-					<% unless sample_type.uploaded_template? || !sample_type.editing_constraints.allow_new_attribute? %>
+					<% unless sample_type.uploaded_template? %>
 							<tr id=<%=add_attribute_row_id%> >
 								<td colspan="6">
 									<%= button_link_to('Add new attribute', 'add', '#', id: add_attribute_id  ) %>

--- a/app/views/sample_types/_buttons.html.erb
+++ b/app/views/sample_types/_buttons.html.erb
@@ -4,7 +4,7 @@
     <%= button_link_to("View samples", 'view_samples', sample_type_samples_path(sample_type)) %>
 <% end %>
 
-<% if Sample.can_create? %>
+<% if Sample.can_create? && !sample_type.locked? %>
     <%= button_link_to("Create sample", 'new', new_sample_path(sample_type_id:sample_type.id)) %>
 <% end %>
 

--- a/app/views/sample_types/_form.html.erb
+++ b/app/views/sample_types/_form.html.erb
@@ -1,11 +1,5 @@
 <% tab ||= 'manual' %>
 
-<% if @sample_type.locked? %>
-    <div id="locked-sample-type-warning" class="alert alert-danger">
-        <strong>Warning!</strong> This sample type is locked and should not be edited.
-    </div>
-<% end %>
-
 <span id='modal-dialogues'>
     <%= sample_controlled_vocab_model_dialog('cv-modal') %>
 </span>

--- a/app/views/sample_types/_form.html.erb
+++ b/app/views/sample_types/_form.html.erb
@@ -49,7 +49,7 @@
                                                                            display_isa_tag: false } %>
           <% end %>
 
-          <% unless @sample_type.uploaded_template? || !@sample_type.editing_constraints.allow_new_attribute? %>
+          <% unless @sample_type.uploaded_template? %>
               <tr id="add-attribute-row">
                 <td colspan="6">
                   <%= button_link_to('Add new attribute', 'add', '#', id: 'add-attribute') %>

--- a/app/views/sample_types/_form.html.erb
+++ b/app/views/sample_types/_form.html.erb
@@ -1,5 +1,11 @@
 <% tab ||= 'manual' %>
 
+<% if @sample_type.locked? %>
+    <div id="locked-sample-type-warning" class="alert alert-danger">
+        <strong>Warning!</strong> This sample type is locked and should not be edited.
+    </div>
+<% end %>
+
 <span id='modal-dialogues'>
     <%= sample_controlled_vocab_model_dialog('cv-modal') %>
 </span>

--- a/app/views/sample_types/_sample_attribute_form.html.erb
+++ b/app/views/sample_types/_sample_attribute_form.html.erb
@@ -132,7 +132,7 @@
                                       unit_id),
                    include_blank: true,
                    class: 'form-control',
-                   disabled: !allow_type_change, data: { attr: "unit" } %>
+                   data: { attr: "unit" } %>
   </td>
 
 

--- a/app/views/sample_types/_sample_attribute_form.html.erb
+++ b/app/views/sample_types/_sample_attribute_form.html.erb
@@ -19,7 +19,6 @@
 <% allow_required = constraints.allow_required?(sample_attribute) %>
 <% allow_attribute_removal = constraints.allow_attribute_removal?(sample_attribute)  %>
 <% allow_type_change = constraints.allow_type_change?(sample_attribute) %>
-<% allow_name_change = constraints.allow_name_change?(sample_attribute) %>
 <% seek_sample_multi = sample_attribute&.seek_sample_multi? %>
 <% link_to_self = sample_attribute && sample_attribute.deferred_link_to_self %>
 <% display_isa_tag ||= false %>
@@ -31,7 +30,6 @@
 <% allow_isa_tag_change = constraints.allow_isa_tag_change?(sample_attribute) if display_isa_tag %>
 <% required_title_text = allow_required ? nil : "You are not allowed to make this attribute required.\nSome samples have no value for this attribute." %>
 <% is_title_title_text = allow_required ? nil : "You are not allowed to change this attribute's title field.\nSome samples have no value for this attribute." %>
-<% change_name_text = allow_name_change ? nil : "You are not allowed to change the name of this attribute.\nYou need at least editing permission to all samples in this sample type." %>
 
 <tr class="sample-attribute <%= 'success' if sample_attribute.nil? -%><%='hidden' if hide_seek_sample_multi -%>" data-index="<%= index-%>">
   <th scope="row" class="attribute-position">
@@ -43,8 +41,8 @@
   </th>
   <td>
 
-    <%= text_field_tag "#{field_name_prefix}[title]", title, class: 'form-control', title: change_name_text,
-                       placeholder: 'Attribute name', disabled: !allow_name_change, data: { attr: "title" } %>
+    <%= text_field_tag "#{field_name_prefix}[title]", title, class: 'form-control',
+                       placeholder: 'Attribute name', data: { attr: "title" } %>
   </td>
 
   <td class="text-center" title="<%= required_title_text %>">

--- a/app/views/sample_types/_sample_attribute_form.html.erb
+++ b/app/views/sample_types/_sample_attribute_form.html.erb
@@ -31,6 +31,7 @@
 <% allow_isa_tag_change = constraints.allow_isa_tag_change?(sample_attribute) if display_isa_tag %>
 <% required_title_text = allow_required ? nil : "You are not allowed to make this attribute required.\nSome samples have no value for this attribute." %>
 <% is_title_title_text = allow_required ? nil : "You are not allowed to change this attribute's title field.\nSome samples have no value for this attribute." %>
+<% change_name_text = allow_name_change ? nil : "You are not allowed to change the name of this attribute.\nYou need at least editing permission to all samples in this sample type." %>
 
 <tr class="sample-attribute <%= 'success' if sample_attribute.nil? -%><%='hidden' if hide_seek_sample_multi -%>" data-index="<%= index-%>">
   <th scope="row" class="attribute-position">
@@ -42,7 +43,7 @@
   </th>
   <td>
 
-    <%= text_field_tag "#{field_name_prefix}[title]", title, class: 'form-control',
+    <%= text_field_tag "#{field_name_prefix}[title]", title, class: 'form-control', title: change_name_text,
                        placeholder: 'Attribute name', disabled: !allow_name_change, data: { attr: "title" } %>
   </td>
 

--- a/app/views/sample_types/select/_filtered_sample_types.html.erb
+++ b/app/views/sample_types/select/_filtered_sample_types.html.erb
@@ -7,7 +7,7 @@
             <%= render :partial => "assets/resource_list_item", :object => sample_type %>
           </div>
         </div>
-        <% if Sample.can_create? %>
+        <% if Sample.can_create? && !sample_type.locked? %>
           <div class="col-sm-2">
             <%= link_to "New sample", new_sample_path(:sample_type_id => sample_type.id, project_ids: params[:project_ids]), class: "btn btn-primary" %>
           </div>

--- a/app/views/sample_types/show.html.erb
+++ b/app/views/sample_types/show.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: 'general/item_title', locals: { item: @sample_type, buttons_partial: 'buttons' } %>
 <% if @sample_type.locked? %>
   <div id="locked-sample-type-warning" class="alert alert-danger">
-    <strong>Warning!</strong> This sample type is locked and should not be edited.
+    <strong>Warning!</strong> This sample type is being edited by a background process and cannot be edited right now.
   </div>
 <% end %>
 <%= render partial: 'general/show_page_tab_definitions' %>

--- a/app/views/sample_types/show.html.erb
+++ b/app/views/sample_types/show.html.erb
@@ -1,5 +1,9 @@
 <%= render partial: 'general/item_title', locals: { item: @sample_type, buttons_partial: 'buttons' } %>
-
+<% if @sample_type.locked? %>
+  <div id="locked-sample-type-warning" class="alert alert-danger">
+    <strong>Warning!</strong> This sample type is locked and should not be edited.
+  </div>
+<% end %>
 <%= render partial: 'general/show_page_tab_definitions' %>
 
 <div class="tab-content">

--- a/lib/seek/samples/sample_metadata_updater.rb
+++ b/lib/seek/samples/sample_metadata_updater.rb
@@ -7,17 +7,17 @@ module Seek
 
     # Class to handle the updating of sample metadata after updating Sample type
     class SampleMetadataUpdater
-      def initialize(sample_type, attribute_changes, user)
-        @sample_type = sample_type
-        @attribute_change_maps = attribute_changes
+      def initialize(samples, user, attribute_changes)
+        @samples = samples
         @user = user
+        @attribute_change_maps = attribute_changes
       end
 
       def update_metadata
-        return if @attribute_change_maps.blank? || @sample_type.samples.blank? || @sample_type.nil? || @user.nil?
+        return if @attribute_change_maps.blank? || @samples.blank? || @user.nil?
 
         User.with_current_user(@user) do
-          @sample_type.samples.each do |sample|
+          @samples.each do |sample|
             metadata = JSON.parse(sample.json_metadata)
             # Update the metadata keys with the new attribute titles
             @attribute_change_maps.each do |change|

--- a/lib/seek/samples/sample_metadata_updater.rb
+++ b/lib/seek/samples/sample_metadata_updater.rb
@@ -18,16 +18,14 @@ module Seek
         return unless @sample_type.locked?
 
         User.with_current_user(@user) do
-          @sample_type.with_lock do
-            @sample_type.samples.in_batches(of: 1000).each do |batch|
-              batch.each do |sample|
-                metadata = JSON.parse(sample.json_metadata)
-                # Update the metadata keys with the new attribute titles
-                @attribute_change_maps.each do |change|
-                  metadata[change[:new_title]] = metadata.delete(change[:old_title])
-                end
-                sample.update_column(:json_metadata, metadata.to_json)
+          @sample_type.samples.in_batches(of: 1000).each do |batch|
+            batch.each do |sample|
+              metadata = JSON.parse(sample.json_metadata)
+              # Update the metadata keys with the new attribute titles
+              @attribute_change_maps.each do |change|
+                metadata[change[:new_title]] = metadata.delete(change[:old_title])
               end
+              sample.update_column(:json_metadata, metadata.to_json)
             end
           end
         end

--- a/lib/seek/samples/sample_metadata_updater.rb
+++ b/lib/seek/samples/sample_metadata_updater.rb
@@ -17,22 +17,21 @@ module Seek
         return if @attribute_change_maps.blank? || @sample_type.blank? || @user.nil? || @sample_type.samples.blank?
         return unless @sample_type.locked?
 
-        begin
-          User.with_current_user(@user) do
-            @sample_type.with_lock do
-              @sample_type.samples.in_batches(of: 1000).each do |batch|
-                batch.each do |sample|
-                  metadata = JSON.parse(sample.json_metadata)
-                  # Update the metadata keys with the new attribute titles
-                  @attribute_change_maps.each do |change|
-                    metadata[change[:new_title]] = metadata.delete(change[:old_title])
-                  end
-                  sample.update_column(:json_metadata, metadata.to_json)
+        User.with_current_user(@user) do
+          @sample_type.with_lock do
+            @sample_type.samples.in_batches(of: 1000).each do |batch|
+              batch.each do |sample|
+                metadata = JSON.parse(sample.json_metadata)
+                # Update the metadata keys with the new attribute titles
+                @attribute_change_maps.each do |change|
+                  metadata[change[:new_title]] = metadata.delete(change[:old_title])
                 end
+                sample.update_column(:json_metadata, metadata.to_json)
               end
             end
           end
         end
+        
       ensure
         Rails.cache.delete("sample_type_lock_#{@sample_type.id}")
       end

--- a/lib/seek/samples/sample_metadata_updater.rb
+++ b/lib/seek/samples/sample_metadata_updater.rb
@@ -21,14 +21,12 @@ module Seek
           @sample_type.with_lock do
             @sample_type.samples.in_batches(of: 1000).each do |batch|
               batch.each do |sample|
-                sample.with_lock do
-                  metadata = JSON.parse(sample.json_metadata)
-                  # Update the metadata keys with the new attribute titles
-                  @attribute_change_maps.each do |change|
-                    metadata[change[:new_title]] = metadata.delete(change[:old_title])
-                  end
-                  sample.update_column(:json_metadata, metadata.to_json)
+                metadata = JSON.parse(sample.json_metadata)
+                # Update the metadata keys with the new attribute titles
+                @attribute_change_maps.each do |change|
+                  metadata[change[:new_title]] = metadata.delete(change[:old_title])
                 end
+                sample.update_column(:json_metadata, metadata.to_json)
               end
             end
           end

--- a/lib/seek/samples/sample_metadata_updater.rb
+++ b/lib/seek/samples/sample_metadata_updater.rb
@@ -7,23 +7,24 @@ module Seek
 
     # Class to handle the updating of sample metadata after updating Sample type
     class SampleMetadataUpdater
-      def initialize(sample_type, attribute_changes)
+      def initialize(sample_type, attribute_changes, user)
         @sample_type = sample_type
         @attribute_change_maps = attribute_changes
+        @user = user
       end
 
       def update_metadata
-        samples = @sample_type.samples
-        # Should raise an exception if the user does not have permission to update all the samples in this sample type.
-        raise SampleMetadataUpdateException('Invalid permissions! You need editing permission to all samples in this sample type.') unless samples.all?(&:can_edit?)
+        return if @attribute_change_maps.blank? || @sample_type.samples.blank? || @sample_type.nil? || @user.nil?
 
-        samples.each do |sample|
-          metadata = JSON.parse(sample.json_metadata)
-          # Update the metadata keys with the new attribute titles
-          @attribute_change_maps.each do |change|
-            metadata[change[:new_title]] = metadata.delete(change[:old_title])
+        User.with_current_user(@user) do
+          @sample_type.samples.each do |sample|
+            metadata = JSON.parse(sample.json_metadata)
+            # Update the metadata keys with the new attribute titles
+            @attribute_change_maps.each do |change|
+              metadata[change[:new_title]] = metadata.delete(change[:old_title])
+            end
+            sample.update_column(:json_metadata, metadata.to_json)
           end
-          sample.update_column(:json_metadata, metadata.to_json)
         end
       end
     end

--- a/lib/seek/samples/sample_metadata_updater.rb
+++ b/lib/seek/samples/sample_metadata_updater.rb
@@ -21,17 +21,19 @@ module Seek
           @sample_type.with_lock do
             @sample_type.samples.in_batches(of: 1000).each do |batch|
               batch.each do |sample|
-                metadata = JSON.parse(sample.json_metadata)
-                # Update the metadata keys with the new attribute titles
-                @attribute_change_maps.each do |change|
-                  metadata[change[:new_title]] = metadata.delete(change[:old_title])
+                sample.with_lock do
+                  metadata = JSON.parse(sample.json_metadata)
+                  # Update the metadata keys with the new attribute titles
+                  @attribute_change_maps.each do |change|
+                    metadata[change[:new_title]] = metadata.delete(change[:old_title])
+                  end
+                  sample.update_column(:json_metadata, metadata.to_json)
                 end
-                sample.update_column(:json_metadata, metadata.to_json)
               end
             end
           end
         end
-        
+
       ensure
         Rails.cache.delete("sample_type_lock_#{@sample_type.id}")
       end

--- a/lib/seek/samples/sample_metadata_updater.rb
+++ b/lib/seek/samples/sample_metadata_updater.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Seek
+  module Samples
+
+    class SampleMetadataUpdateException < StandardError; end
+
+    # Class to handle the updating of sample metadata after updating Sample type
+    class SampleMetadataUpdater
+      def initialize(sample_type)
+        @sample_type = sample_type
+      end
+
+      def update_metadata
+        samples = @sample_type.samples
+        # Should raise an exception if the user does not have permission to update all the samples in this sample type.
+        raise SampleMetadataUpdateException('Invalid permissions! You need editing permission to all samples in this sample type.') unless samples.all?(&:can_edit?)
+
+        sample_attributes = @sample_type.sample_attributes.map(&:title)
+
+        samples.each do |sample|
+          metadata = JSON.parse(sample.json_metadata)
+          missing_attributes = sample_attributes - metadata.keys
+          missing_attributes.map do |attr|
+            metadata[attr] = nil
+          end
+
+          removed_attributes = metadata.keys - sample_attributes
+          removed_attributes.map do |attr|
+            metadata.delete(attr)
+          end
+          # For now permission are skipped and all samples will be updated
+          Sample.find(sample.id).update_column(json_metadata, metadata.to_json)
+        end
+      end
+    end
+  end
+end

--- a/lib/seek/samples/sample_metadata_updater.rb
+++ b/lib/seek/samples/sample_metadata_updater.rb
@@ -7,25 +7,37 @@ module Seek
 
     # Class to handle the updating of sample metadata after updating Sample type
     class SampleMetadataUpdater
-      def initialize(samples, user, attribute_changes)
-        @samples = samples
+      def initialize(sample_type, user, attribute_changes)
+        @sample_type = sample_type
         @user = user
         @attribute_change_maps = attribute_changes
       end
 
       def update_metadata
-        return if @attribute_change_maps.blank? || @samples.blank? || @user.nil?
+        return if @attribute_change_maps.blank? || @sample_type.blank? || @user.nil? || @sample_type.samples.blank?
 
-        User.with_current_user(@user) do
-          @samples.each do |sample|
-            metadata = JSON.parse(sample.json_metadata)
-            # Update the metadata keys with the new attribute titles
-            @attribute_change_maps.each do |change|
-              metadata[change[:new_title]] = metadata.delete(change[:old_title])
+        begin
+          User.with_current_user(@user) do
+            @sample_type.with_lock do
+              @sample_type.samples.in_batches(of: 1000).each do |batch|
+                batch.each do |sample|
+                  metadata = JSON.parse(sample.json_metadata)
+                  # Update the metadata keys with the new attribute titles
+                  @attribute_change_maps.each do |change|
+                    metadata[change[:new_title]] = metadata.delete(change[:old_title])
+                  end
+                  sample.update_column(:json_metadata, metadata.to_json)
+                end
+              end
             end
-            sample.update_column(:json_metadata, metadata.to_json)
           end
         end
+      ensure
+        Rails.cache.delete("sample_type_lock_#{@sample_type.id}")
+      end
+
+      def raise_sample_metadata_update_exception
+        raise SampleMetadataUpdateException.new('An unexpected error occurred while updating the sample metadata')
       end
     end
   end

--- a/lib/seek/samples/sample_metadata_updater.rb
+++ b/lib/seek/samples/sample_metadata_updater.rb
@@ -15,6 +15,7 @@ module Seek
 
       def update_metadata
         return if @attribute_change_maps.blank? || @sample_type.blank? || @user.nil? || @sample_type.samples.blank?
+        return unless @sample_type.locked?
 
         begin
           User.with_current_user(@user) do

--- a/lib/seek/samples/sample_metadata_updater.rb
+++ b/lib/seek/samples/sample_metadata_updater.rb
@@ -29,9 +29,6 @@ module Seek
             end
           end
         end
-
-      ensure
-        Rails.cache.delete("sample_type_lock_#{@sample_type.id}")
       end
 
       def raise_sample_metadata_update_exception

--- a/lib/seek/samples/sample_metadata_updater.rb
+++ b/lib/seek/samples/sample_metadata_updater.rb
@@ -7,8 +7,9 @@ module Seek
 
     # Class to handle the updating of sample metadata after updating Sample type
     class SampleMetadataUpdater
-      def initialize(sample_type)
+      def initialize(sample_type, attribute_changes)
         @sample_type = sample_type
+        @attribute_change_maps = attribute_changes
       end
 
       def update_metadata
@@ -16,23 +17,12 @@ module Seek
         # Should raise an exception if the user does not have permission to update all the samples in this sample type.
         raise SampleMetadataUpdateException('Invalid permissions! You need editing permission to all samples in this sample type.') unless samples.all?(&:can_edit?)
 
-        sample_attributes = @sample_type.sample_attributes.map(&:title)
-
         samples.each do |sample|
           metadata = JSON.parse(sample.json_metadata)
-          # Skip this sample if the sample attributes are the same as the JSON metadata keys
-          next if metadata.keys == sample_attributes
-
-          missing_attributes = sample_attributes - metadata.keys
-          missing_attributes.map do |attr|
-            metadata[attr] = nil
+          # Update the metadata keys with the new attribute titles
+          @attribute_change_maps.each do |change|
+            metadata[change[:new_title]] = metadata.delete(change[:old_title])
           end
-
-          removed_attributes = metadata.keys - sample_attributes
-          removed_attributes.map do |attr|
-            metadata.delete(attr)
-          end
-          # For now permission are skipped and all samples will be updated
           sample.update_column(:json_metadata, metadata.to_json)
         end
       end

--- a/lib/seek/samples/sample_metadata_updater.rb
+++ b/lib/seek/samples/sample_metadata_updater.rb
@@ -20,6 +20,9 @@ module Seek
 
         samples.each do |sample|
           metadata = JSON.parse(sample.json_metadata)
+          # Skip this sample if the sample attributes are the same as the JSON metadata keys
+          next if metadata.keys == sample_attributes
+
           missing_attributes = sample_attributes - metadata.keys
           missing_attributes.map do |attr|
             metadata[attr] = nil
@@ -30,7 +33,7 @@ module Seek
             metadata.delete(attr)
           end
           # For now permission are skipped and all samples will be updated
-          Sample.find(sample.id).update_column(json_metadata, metadata.to_json)
+          sample.update_column(:json_metadata, metadata.to_json)
         end
       end
     end

--- a/lib/seek/samples/sample_type_editing_constraints.rb
+++ b/lib/seek/samples/sample_type_editing_constraints.rb
@@ -49,6 +49,12 @@ module Seek
         end
       end
 
+      # This method was left in so it can be changed in the future
+      # Currently, it always returns true
+      # see https://github.com/seek4science/seek/pull/2032#discussion_r1813137258
+      def allow_new_attribute?
+        true
+      end
       # whether the type for the attribute can be changed
       def allow_type_change?(attr)
         if attr.is_a?(SampleAttribute)

--- a/lib/seek/samples/sample_type_editing_constraints.rb
+++ b/lib/seek/samples/sample_type_editing_constraints.rb
@@ -53,12 +53,11 @@ module Seek
       def allow_name_change?(attr)
         if attr.is_a?(SampleAttribute)
           return true if attr.new_record?
-          return false if inherited?(attr)
 
           attr = attr.accessor_name
         end
         if attr
-          !samples?
+          samples.all?(&:can_edit?)
         else
           true
         end

--- a/lib/seek/samples/sample_type_editing_constraints.rb
+++ b/lib/seek/samples/sample_type_editing_constraints.rb
@@ -49,19 +49,6 @@ module Seek
         end
       end
 
-      # whether the name of the attribute can be changed
-      def allow_name_change?(attr)
-        if attr.is_a?(SampleAttribute)
-          return true if attr.new_record?
-
-          attr = attr.accessor_name
-        end
-        return !samples? unless attr
-        return samples.all?(&:can_edit?) if samples?
-
-        true
-      end
-
       # whether the type for the attribute can be changed
       def allow_type_change?(attr)
         if attr.is_a?(SampleAttribute)

--- a/lib/seek/samples/sample_type_editing_constraints.rb
+++ b/lib/seek/samples/sample_type_editing_constraints.rb
@@ -21,7 +21,7 @@ module Seek
       # if attr is nil, indicates a new attribute. required is not allowed if there are already samples
       def allow_required?(attr)
         if attr.is_a?(SampleAttribute)
-          return true if attr.new_record?
+          return true if attr.new_record? && @sample_type.new_record?
           return false if inherited?(attr)
 
           attr = attr.accessor_name

--- a/lib/seek/samples/sample_type_editing_constraints.rb
+++ b/lib/seek/samples/sample_type_editing_constraints.rb
@@ -49,11 +49,6 @@ module Seek
         end
       end
 
-      # whether a new attribtue can be created
-      def allow_new_attribute?
-        !samples?
-      end
-
       # whether the name of the attribute can be changed
       def allow_name_change?(attr)
         if attr.is_a?(SampleAttribute)

--- a/lib/seek/samples/sample_type_editing_constraints.rb
+++ b/lib/seek/samples/sample_type_editing_constraints.rb
@@ -26,11 +26,11 @@ module Seek
 
           attr = attr.accessor_name
         end
-        if attr
-          !blanks?(attr)
-        else
-          !samples?
-        end
+
+        return false unless attr
+        return !blanks?(attr) if samples?
+
+        true
       end
 
       # an attribute could be removed if all are currently blank
@@ -56,11 +56,10 @@ module Seek
 
           attr = attr.accessor_name
         end
-        if attr
-          samples.all?(&:can_edit?)
-        else
-          true
-        end
+        return false unless attr
+        return samples.all?(&:can_edit?) if samples?
+
+        true
       end
 
       # whether the type for the attribute can be changed

--- a/lib/seek/samples/sample_type_editing_constraints.rb
+++ b/lib/seek/samples/sample_type_editing_constraints.rb
@@ -27,7 +27,7 @@ module Seek
           attr = attr.accessor_name
         end
 
-        return false unless attr
+        return !samples? unless attr
         return !blanks?(attr) if samples?
 
         true
@@ -56,7 +56,7 @@ module Seek
 
           attr = attr.accessor_name
         end
-        return false unless attr
+        return !samples? unless attr
         return samples.all?(&:can_edit?) if samples?
 
         true

--- a/test/functional/sample_types_controller_test.rb
+++ b/test/functional/sample_types_controller_test.rb
@@ -775,16 +775,28 @@ class SampleTypesControllerTest < ActionController::TestCase
     get :edit, params: { id: sample_type.id }
     assert_response :success
     assert_select 'a#add-attribute', count: 1
-    assert_difference('SampleAttribute.count') do
-      put :update, params: { id: sample_type.id, sample_type: {
+
+    # Should be able to add an optional new attribute to a sample type with samples
+    assert_difference('SampleAttribute.count', 1) do
+      patch :update, params: { id: sample_type.id, sample_type: {
         sample_attributes_attributes: {
-          '1': { title: 'new attribute', sample_attribute_type_id: @string_type.id }
+          '1': { title: 'new optional attribute', sample_attribute_type_id: @string_type.id, required: '0' }
         }
       } }
     end
     assert_redirected_to sample_type_path(sample_type)
     sample_type.reload
-    assert_equal 'new attribute', sample_type.sample_attributes.last.title
+    assert_equal 'new optional attribute', sample_type.sample_attributes.last.title
+
+    # Should not be able to add a mandatory new attribute to a sample type with samples
+    assert_no_difference('SampleAttribute.count') do
+      patch :update, params: { id: sample_type.id, sample_type: {
+        sample_attributes_attributes: {
+          '2': { title: 'new mandatory attribute', sample_attribute_type_id: @string_type.id, required: '1' }
+        }
+      } }
+    end
+
   end
 
   test 'change attribute name' do

--- a/test/functional/sample_types_controller_test.rb
+++ b/test/functional/sample_types_controller_test.rb
@@ -816,7 +816,9 @@ class SampleTypesControllerTest < ActionController::TestCase
         '0': { id: sample_type.sample_attributes.detect(&:is_title), title: 'new title' }
       }
     } }
+    assert_nil flash[:error]
     assert_redirected_to sample_type_path(sample_type)
+    sample_type.reload
     assert sample_type.locked?
 
     login_as(other_person)
@@ -826,6 +828,7 @@ class SampleTypesControllerTest < ActionController::TestCase
         '0': { id: sample_type.sample_attributes.detect(&:is_title), title: 'new title' }
       }
     } }
+    sample_type.reload
     sample_type.errors.added?(:base, 'This sample type is locked and cannot be edited right now.')
 
     assert_redirected_to sample_type_path(sample_type)

--- a/test/functional/sample_types_controller_test.rb
+++ b/test/functional/sample_types_controller_test.rb
@@ -755,8 +755,8 @@ class SampleTypesControllerTest < ActionController::TestCase
 
   test 'add new attribute to an existing sample type populated with samples' do
     sample_type = FactoryBot.create(:simple_sample_type, project_ids: @project_ids, contributor: @person)
-    samples = (1..10).map do |i|
-      FactoryBot.create(:sample, contributor: @person, project_ids: @project_ids, sample_type:)
+    (1..10).map do |_i|
+      FactoryBot.create(:sample, contributor: @person, project_ids: @project_ids, sample_type: sample_type)
     end
     refute_empty sample_type.samples
     login_as(@person)

--- a/test/functional/sample_types_controller_test.rb
+++ b/test/functional/sample_types_controller_test.rb
@@ -439,16 +439,6 @@ class SampleTypesControllerTest < ActionController::TestCase
     get :edit, params: { id: type.id }
     assert_response :success
     assert_select 'a#add-attribute', count: 1
-
-    sample = FactoryBot.create(:patient_sample, contributor: @person,
-                                                sample_type: FactoryBot.create(:patient_sample_type, project_ids: @project_ids, contributor: @person))
-    type = sample.sample_type
-    refute_empty type.samples
-    assert type.can_edit?
-
-    get :edit, params: { id: type.id }
-    assert_response :success
-    assert_select 'a#add-attribute', count: 0
   end
 
   test 'cannot access when disabled' do

--- a/test/functional/sample_types_controller_test.rb
+++ b/test/functional/sample_types_controller_test.rb
@@ -41,7 +41,7 @@ class SampleTypesControllerTest < ActionController::TestCase
       assert_enqueued_with(job: SampleTypeUpdateJob) do
         assert_difference('ActivityLog.count') do
           assert_difference('SampleType.count') do
-            assert_difference('Task.count') do
+            assert_difference('Task.where(key: "template_generation").count') do
               post :create, params: { sample_type: { title: 'Hello!',
                                                      project_ids: @project_ids,
                                                      description: 'The description!!',
@@ -787,8 +787,8 @@ class SampleTypesControllerTest < ActionController::TestCase
       assert_response :success
     end
 
-    # Locking the sample type
-    @sample_type.set_lock
+    # lock the sample type by adding a fake update task
+    UpdateSampleMetadataJob.perform_later(@sample_type, @person.user, [])
     assert @sample_type.locked?
 
     %i[edit manage].each do |action|

--- a/test/functional/sample_types_controller_test.rb
+++ b/test/functional/sample_types_controller_test.rb
@@ -792,7 +792,7 @@ class SampleTypesControllerTest < ActionController::TestCase
     end
 
     # Locking the sample type
-    Rails.cache.write("sample_type_lock_#{@sample_type.id}", true)
+    @sample_type.set_lock
     assert @sample_type.locked?
 
     %i[edit manage].each do |action|

--- a/test/functional/sample_types_controller_test.rb
+++ b/test/functional/sample_types_controller_test.rb
@@ -5,7 +5,6 @@ class SampleTypesControllerTest < ActionController::TestCase
   include AuthenticatedTestHelper
 
   setup do
-    Rails.cache.clear
     FactoryBot.create(:person) # to prevent person being first person and therefore admin
     @person = FactoryBot.create(:project_administrator)
     @project = @person.projects.first

--- a/test/functional/sample_types_controller_test.rb
+++ b/test/functional/sample_types_controller_test.rb
@@ -677,6 +677,7 @@ class SampleTypesControllerTest < ActionController::TestCase
     end
   end
 
+  # TODO: This test fails now because the sample type is not immutable anymore.
   test 'validates changes against editing constraints' do
     @sample_type.samples.create!(data: { the_title: 'yes' }, sample_type: @sample_type, project_ids: @project_ids)
 

--- a/test/functional/samples_controller_test.rb
+++ b/test/functional/samples_controller_test.rb
@@ -1584,6 +1584,19 @@ class SamplesControllerTest < ActionController::TestCase
 
   end
 
+  test 'should not add a sample to a locked sample type' do
+    person = FactoryBot.create(:person)
+    project = person.projects.first
+    login_as(person)
+
+    sample_type = FactoryBot.create(:simple_sample_type, contributor: person, project_ids: [project.id])
+
+    get :new, params: { sample_type_id: sample_type.id }
+    assert_response :success
+
+    assert_select 'input[type=submit][disabled=disabled]', count: 1
+  end
+
   def rdf_test_object
     FactoryBot.create(:max_sample, policy: FactoryBot.create(:public_policy))
   end

--- a/test/functional/samples_controller_test.rb
+++ b/test/functional/samples_controller_test.rb
@@ -1594,7 +1594,10 @@ class SamplesControllerTest < ActionController::TestCase
     get :new, params: { sample_type_id: sample_type.id }
     assert_response :success
 
-    assert_select 'input[type=submit][disabled=disabled]', count: 1
+    sample_type.set_lock
+    get :new, params: { sample_type_id: sample_type.id }
+    assert_redirected_to sample_types_path(sample_type)
+    assert_equal flash[:error], 'This sample type is locked. You cannot edit the sample.'
   end
 
   def rdf_test_object

--- a/test/functional/samples_controller_test.rb
+++ b/test/functional/samples_controller_test.rb
@@ -1591,10 +1591,9 @@ class SamplesControllerTest < ActionController::TestCase
 
     sample_type = FactoryBot.create(:simple_sample_type, contributor: person, project_ids: [project.id])
 
-    get :new, params: { sample_type_id: sample_type.id }
-    assert_response :success
+    # lock the sample type by adding a fake update task
+    UpdateSampleMetadataJob.perform_later(sample_type, person.user, [])
 
-    sample_type.set_lock
     get :new, params: { sample_type_id: sample_type.id }
     assert_redirected_to sample_types_path(sample_type)
     assert_equal flash[:error], 'This sample type is locked. You cannot edit the sample.'

--- a/test/unit/jobs/update_sample_metadata_job_test.rb
+++ b/test/unit/jobs/update_sample_metadata_job_test.rb
@@ -18,23 +18,21 @@ class UpdateSampleMetadataJobTest < ActiveSupport::TestCase
 
   test 'perform' do
     User.with_current_user(@person.user) do
-      UpdateSampleMetadataJob.new.perform(@sample_type)
+      UpdateSampleMetadataJob.new.perform(@sample_type, [], @person.user)
     end
   end
 
   test 'Check sample metadata after updating the attribute title' do
-    User.with_current_user(@person.user) do
-      assert_equal @sample_type.sample_attributes.first.title, 'the_title'
-      @sample_type.sample_attributes.first.update!(title: 'new title')
-      attribute_change_maps = [{id: @sample_type.sample_attributes.first.id, old_title: 'the_title', new_title: 'new title' }]
-      assert_equal @sample_type.sample_attributes.first.title, 'new title'
-      refute_equal @sample_type.sample_attributes.first.title, 'the_title'
-      UpdateSampleMetadataJob.new.perform(@sample_type, attribute_change_maps)
-      @sample_type.samples.each do |sample|
-        json_metadata = JSON.parse sample.json_metadata
-        assert json_metadata.keys.include?('new title')
-        refute json_metadata.keys.include?('the_title')
-      end
+    assert_equal @sample_type.sample_attributes.first.title, 'the_title'
+    @sample_type.sample_attributes.first.update!(title: 'new title')
+    attribute_change_maps = [{id: @sample_type.sample_attributes.first.id, old_title: 'the_title', new_title: 'new title' }]
+    assert_equal @sample_type.sample_attributes.first.title, 'new title'
+    refute_equal @sample_type.sample_attributes.first.title, 'the_title'
+    UpdateSampleMetadataJob.new.perform(@sample_type, attribute_change_maps, @person.user)
+    @sample_type.samples.each do |sample|
+      json_metadata = JSON.parse sample.json_metadata
+      assert json_metadata.keys.include?('new title')
+      refute json_metadata.keys.include?('the_title')
     end
   end
 end

--- a/test/unit/jobs/update_sample_metadata_job_test.rb
+++ b/test/unit/jobs/update_sample_metadata_job_test.rb
@@ -18,7 +18,7 @@ class UpdateSampleMetadataJobTest < ActiveSupport::TestCase
 
   test 'perform' do
     User.with_current_user(@person.user) do
-      UpdateSampleMetadataJob.new.perform(@sample_type, [], @person.user)
+      UpdateSampleMetadataJob.new.perform(@sample_type, @person.user, [])
     end
   end
 
@@ -28,7 +28,8 @@ class UpdateSampleMetadataJobTest < ActiveSupport::TestCase
       attribute_change_maps = [{id: @sample_type.sample_attributes.first.id, old_title: 'the_title', new_title: 'new title' }]
       assert_equal @sample_type.sample_attributes.first.title, 'new title'
       refute_equal @sample_type.sample_attributes.first.title, 'the_title'
-      UpdateSampleMetadataJob.new.perform(@sample_type, attribute_change_maps, @person.user)
+      UpdateSampleMetadataJob.perform_now(@sample_type, @person.user, attribute_change_maps)
+      @sample_type.reload
       @sample_type.samples.each do |sample|
         json_metadata = JSON.parse sample.json_metadata
         assert json_metadata.keys.include?('new title')

--- a/test/unit/jobs/update_sample_metadata_job_test.rb
+++ b/test/unit/jobs/update_sample_metadata_job_test.rb
@@ -22,13 +22,14 @@ class UpdateSampleMetadataJobTest < ActiveSupport::TestCase
     end
   end
 
-  test 'Check sample metadata after performing the job' do
+  test 'Check sample metadata after updating the attribute title' do
     User.with_current_user(@person.user) do
       assert_equal @sample_type.sample_attributes.first.title, 'the_title'
       @sample_type.sample_attributes.first.update!(title: 'new title')
+      attribute_change_maps = [{id: @sample_type.sample_attributes.first.id, old_title: 'the_title', new_title: 'new title' }]
       assert_equal @sample_type.sample_attributes.first.title, 'new title'
       refute_equal @sample_type.sample_attributes.first.title, 'the_title'
-      UpdateSampleMetadataJob.new.perform(@sample_type)
+      UpdateSampleMetadataJob.new.perform(@sample_type, attribute_change_maps)
       @sample_type.samples.each do |sample|
         json_metadata = JSON.parse sample.json_metadata
         assert json_metadata.keys.include?('new title')

--- a/test/unit/jobs/update_sample_metadata_job_test.rb
+++ b/test/unit/jobs/update_sample_metadata_job_test.rb
@@ -23,16 +23,17 @@ class UpdateSampleMetadataJobTest < ActiveSupport::TestCase
   end
 
   test 'Check sample metadata after updating the attribute title' do
-    assert_equal @sample_type.sample_attributes.first.title, 'the_title'
-    @sample_type.sample_attributes.first.update!(title: 'new title')
-    attribute_change_maps = [{id: @sample_type.sample_attributes.first.id, old_title: 'the_title', new_title: 'new title' }]
-    assert_equal @sample_type.sample_attributes.first.title, 'new title'
-    refute_equal @sample_type.sample_attributes.first.title, 'the_title'
-    UpdateSampleMetadataJob.new.perform(@sample_type, attribute_change_maps, @person.user)
-    @sample_type.samples.each do |sample|
-      json_metadata = JSON.parse sample.json_metadata
-      assert json_metadata.keys.include?('new title')
-      refute json_metadata.keys.include?('the_title')
+    User.with_current_user(@person.user) do
+      @sample_type.sample_attributes.first.update!(title: 'new title')
+      attribute_change_maps = [{id: @sample_type.sample_attributes.first.id, old_title: 'the_title', new_title: 'new title' }]
+      assert_equal @sample_type.sample_attributes.first.title, 'new title'
+      refute_equal @sample_type.sample_attributes.first.title, 'the_title'
+      UpdateSampleMetadataJob.new.perform(@sample_type, attribute_change_maps, @person.user)
+      @sample_type.samples.each do |sample|
+        json_metadata = JSON.parse sample.json_metadata
+        assert json_metadata.keys.include?('new title')
+        refute json_metadata.keys.include?('the_title')
+      end
     end
   end
 end

--- a/test/unit/jobs/update_sample_metadata_job_test.rb
+++ b/test/unit/jobs/update_sample_metadata_job_test.rb
@@ -29,6 +29,7 @@ class UpdateSampleMetadataJobTest < ActiveSupport::TestCase
       assert_equal @sample_type.sample_attributes.first.title, 'new title'
       refute_equal @sample_type.sample_attributes.first.title, 'the_title'
       UpdateSampleMetadataJob.perform_now(@sample_type, @person.user, attribute_change_maps)
+      refute Rails.cache.fetch("sample_type_lock_#{@sample_type.id}")
       @sample_type.reload
       @sample_type.samples.each do |sample|
         json_metadata = JSON.parse sample.json_metadata

--- a/test/unit/jobs/update_sample_metadata_job_test.rb
+++ b/test/unit/jobs/update_sample_metadata_job_test.rb
@@ -10,15 +10,33 @@ class UpdateSampleMetadataJobTest < ActiveSupport::TestCase
     (1..10).each do |_i|
       FactoryBot.create(:sample, sample_type: @sample_type, contributor: @person)
     end
+    Rails.cache.clear
   end
 
   def teardown
-    # Do nothing
+    Rails.cache.clear
   end
 
   test 'perform' do
     User.with_current_user(@person.user) do
-      UpdateSampleMetadataJob.new.perform(@sample_type, @person.user, [])
+      UpdateSampleMetadataJob.perform_now(@sample_type, @person.user, [])
+    end
+  end
+
+  test 'enqueue' do
+    # Simulate the lock in the cache from the controller
+    job = UpdateSampleMetadataJob.new(@sample_type, @person.user, [])
+    User.with_current_user(@person.user) do
+      assert_enqueued_with(job: UpdateSampleMetadataJob, args: [@sample_type, @person.user, []]) do
+        job.enqueue
+      end
+      assert @sample_type.locked?
+
+      perform_enqueued_jobs do
+        job.perform_now
+      end
+
+      refute @sample_type.locked?
     end
   end
 
@@ -29,13 +47,28 @@ class UpdateSampleMetadataJobTest < ActiveSupport::TestCase
       assert_equal @sample_type.sample_attributes.first.title, 'new title'
       refute_equal @sample_type.sample_attributes.first.title, 'the_title'
       UpdateSampleMetadataJob.perform_now(@sample_type, @person.user, attribute_change_maps)
-      refute Rails.cache.fetch("sample_type_lock_#{@sample_type.id}")
+      refute @sample_type.locked?
       @sample_type.reload
       @sample_type.samples.each do |sample|
         json_metadata = JSON.parse sample.json_metadata
         assert json_metadata.keys.include?('new title')
         refute json_metadata.keys.include?('the_title')
       end
+    end
+  end
+
+  test 'perform with unexpected error' do
+    job = UpdateSampleMetadataJob.new(@sample_type, @person.user, 'bad_attribute_change_map')
+    assert_enqueued_with(job: UpdateSampleMetadataJob, args: [@sample_type, @person.user, 'bad_attribute_change_map']) do
+      job.enqueue
+    end
+    assert @sample_type.locked?
+
+    perform_enqueued_jobs do
+      job.perform_now
+    rescue StandardError
+      # The sample type should be unlocked even if an error occurs
+      refute @sample_type.locked?
     end
   end
 end

--- a/test/unit/jobs/update_sample_metadata_job_test.rb
+++ b/test/unit/jobs/update_sample_metadata_job_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class UpdateSampleMetadataJobTest < ActiveSupport::TestCase
+  def setup
+    @person = FactoryBot.create(:person)
+    @project = @person.projects.first
+    @sample_type = FactoryBot.create(:simple_sample_type, project_ids: [@project.id], contributor: @person, policy: FactoryBot.create(:public_policy))
+    (1..10).each do |_i|
+      FactoryBot.create(:sample, sample_type: @sample_type, contributor: @person)
+    end
+  end
+
+  def teardown
+    # Do nothing
+  end
+
+  test 'perform' do
+    User.with_current_user(@person.user) do
+      UpdateSampleMetadataJob.new.perform(@sample_type)
+    end
+  end
+end

--- a/test/unit/sample_test.rb
+++ b/test/unit/sample_test.rb
@@ -1456,8 +1456,11 @@ class SampleTest < ActiveSupport::TestCase
   end
 
   test 'add sample to a locked sample type' do
-    sample_type = FactoryBot.create(:simple_sample_type, project_ids: [FactoryBot.create(:project).id], contributor: FactoryBot.create(:person))
-    sample_type.set_lock
+    person = FactoryBot.create(:person)
+    sample_type = FactoryBot.create(:simple_sample_type, project_ids: [FactoryBot.create(:project).id], contributor: person)
+
+    # lock the sample type by adding a fake update task
+    UpdateSampleMetadataJob.perform_later(sample_type, person.user, [])
     assert sample_type.locked?
 
     assert_no_difference('Sample.count') do

--- a/test/unit/sample_test.rb
+++ b/test/unit/sample_test.rb
@@ -1455,4 +1455,14 @@ class SampleTest < ActiveSupport::TestCase
     end
   end
 
+  test 'add sample to a locked sample type' do
+    sample_type = FactoryBot.create(:simple_sample_type, project_ids: [FactoryBot.create(:project).id], contributor: FactoryBot.create(:person))
+    sample_type.set_lock
+    assert sample_type.locked?
+
+    assert_no_difference('Sample.count') do
+      sample = Sample.create(sample_type: sample_type, project_ids: [sample_type.projects.first.id])
+      sample.errors.added?(:sample_type, 'is locked')
+    end
+  end
 end

--- a/test/unit/sample_type_test.rb
+++ b/test/unit/sample_type_test.rb
@@ -1069,6 +1069,19 @@ class SampleTypeTest < ActiveSupport::TestCase
     assert sample_type.errors.added?(:base, 'This sample type is locked and cannot be edited right now.')
   end
 
+  test 'update locked sample type' do
+    sample_type = FactoryBot.create(:simple_sample_type, project_ids: @project_ids, contributor: @person)
+    (1..10).each do |i|
+      FactoryBot.create(:sample, sample_type: sample_type, project_ids: @project_ids, title: "Sample #{i}")
+    end
+    sample_type.with_lock do
+      # sample_type.samples << FactoryBot.create(:sample, sample_type: sample_type, project_ids: @project_ids, title: 'Sample 11')
+      # sample_type.title = 'Updated title'
+      sample_type.sample_attributes.first.title = 'Updated title'
+      sample_type.save!
+    end
+  end
+
   private
 
   # sample type with 3 samples

--- a/test/unit/sample_type_test.rb
+++ b/test/unit/sample_type_test.rb
@@ -925,14 +925,6 @@ class SampleTypeTest < ActiveSupport::TestCase
     sample_type.reload
     assert sample_type.valid?
 
-    # Changing attribute title
-    sample_type.sample_attributes.last.title = 'banana'
-    refute sample_type.valid?
-    assert sample_type.errors.added?(:'sample_attributes.title', 'cannot be changed (patient)')
-
-    sample_type.reload
-    assert sample_type.valid?
-
     # Changing "required" attribute
     User.with_current_user(@person.user) do
       sample_type.samples.create!(data: { title: 'Lib-5', patient: nil }, sample_type: sample_type,

--- a/test/unit/sample_type_test.rb
+++ b/test/unit/sample_type_test.rb
@@ -1063,7 +1063,7 @@ class SampleTypeTest < ActiveSupport::TestCase
   test 'sample type is locked?' do
     sample_type = FactoryBot.create(:simple_sample_type, project_ids: @project_ids, contributor: @person)
     refute sample_type.locked?
-    Rails.cache.write("sample_type_lock_#{sample_type.id}", true)
+    sample_type.set_lock
     assert sample_type.locked?
     refute sample_type.valid?
     assert sample_type.errors.added?(:base, 'This sample type is locked and cannot be edited right now.')

--- a/test/unit/sample_type_test.rb
+++ b/test/unit/sample_type_test.rb
@@ -901,10 +901,18 @@ class SampleTypeTest < ActiveSupport::TestCase
 
     assert sample_type.valid?
 
-    # Adding attribute
-    sample_type.sample_attributes.build(title: 'test 123')
+    # Adding optional attribute
+    sample_type.sample_attributes.build(title: 'optional test 123', sample_attribute_type: FactoryBot.create(:string_sample_attribute_type), required: false, is_title: false, linked_sample_type: nil)
+    assert sample_type.valid?
+    assert sample_type.errors.none?
+
+    sample_type.reload
+    assert sample_type.valid?
+
+    # Adding mandatory attribute
+    sample_type.sample_attributes.build(title: 'mandatory test 123', sample_attribute_type: FactoryBot.create(:string_sample_attribute_type), required: true, is_title: false, linked_sample_type: nil)
     refute sample_type.valid?
-    assert sample_type.errors.added?(:sample_attributes, 'cannot be added, new attributes are not allowed (test 123)')
+    assert sample_type.errors.added?(:'sample_attributes.required', 'cannot be changed (mandatory test 123)')
 
     sample_type.reload
     assert sample_type.valid?

--- a/test/unit/samples/sample_type_editing_constraints_test.rb
+++ b/test/unit/samples/sample_type_editing_constraints_test.rb
@@ -159,14 +159,6 @@ class SampleTypeEditingConstraintsTest < ActiveSupport::TestCase
     refute c.send(:all_blank?, 'full name')
   end
 
-  test 'allow_new_attribute' do
-    # currently only allowed if there are not samples
-    c = Seek::Samples::SampleTypeEditingConstraints.new(sample_type_with_samples)
-    refute c.allow_new_attribute?
-    c = Seek::Samples::SampleTypeEditingConstraints.new(FactoryBot.create(:simple_sample_type))
-    assert c.allow_new_attribute?
-  end
-
   test 'allow editing isa tag' do
     person = FactoryBot.create(:person)
     project = person.projects.first

--- a/test/unit/samples/sample_type_editing_constraints_test.rb
+++ b/test/unit/samples/sample_type_editing_constraints_test.rb
@@ -20,44 +20,6 @@ class SampleTypeEditingConstraintsTest < ActiveSupport::TestCase
     refute c.samples?
   end
 
-  test 'allow title change?' do
-    person = FactoryBot.create(:person)
-
-    User.with_current_user(person.user) do
-      # Not OK if te user doesn't have editing permission over all samples
-      st1 = sample_type_with_samples
-      refute st1.samples.all?(&:can_edit?)
-      c = Seek::Samples::SampleTypeEditingConstraints.new(st1)
-      refute c.allow_name_change?(:address)
-      attr = c.sample_type.sample_attributes.detect { |t| t.accessor_name == 'address' }
-      refute_nil attr
-      refute c.allow_name_change?(attr)
-      # Not OK if attribute = nil and the sample type has samples
-      refute c.allow_name_change?(nil)
-
-      # OK if there are no samples
-      st2 = FactoryBot.create(:simple_sample_type)
-      c = Seek::Samples::SampleTypeEditingConstraints.new(st2)
-      assert c.allow_name_change?(:the_title)
-      attr = c.sample_type.sample_attributes.detect { |t| t.accessor_name == 'the_title' }
-      refute_nil attr
-      assert c.allow_name_change?(attr)
-      # OK if attribute = nil and the sample type has no samples
-      assert c.allow_name_change?(nil)
-
-      # OK if user has editing permission over all samples
-      st3 = sample_type_with_samples(person)
-      assert st3.samples.all?(&:can_edit?)
-      c = Seek::Samples::SampleTypeEditingConstraints.new(st3)
-      assert c.allow_name_change?(:address)
-      attr = c.sample_type.sample_attributes.detect { |t| t.accessor_name == 'address' }
-      refute_nil attr
-      assert c.allow_name_change?(attr)
-      # Not OK if attribute = nil and the sample type has samples
-      refute c.allow_name_change?(nil)
-    end
-  end
-
   test 'allow type change?' do
     c = Seek::Samples::SampleTypeEditingConstraints.new(sample_type_with_samples)
     refute c.allow_type_change?(:address)

--- a/test/unit/samples/sample_type_editing_constraints_test.rb
+++ b/test/unit/samples/sample_type_editing_constraints_test.rb
@@ -32,7 +32,8 @@ class SampleTypeEditingConstraintsTest < ActiveSupport::TestCase
       attr = c.sample_type.sample_attributes.detect { |t| t.accessor_name == 'address' }
       refute_nil attr
       refute c.allow_name_change?(attr)
-      assert c.allow_name_change?(nil)
+      # Not OK if attribute = nil and the sample type has samples
+      refute c.allow_name_change?(nil)
 
       # OK if there are no samples
       st2 = FactoryBot.create(:simple_sample_type)
@@ -41,6 +42,7 @@ class SampleTypeEditingConstraintsTest < ActiveSupport::TestCase
       attr = c.sample_type.sample_attributes.detect { |t| t.accessor_name == 'the_title' }
       refute_nil attr
       assert c.allow_name_change?(attr)
+      # OK if attribute = nil and the sample type has no samples
       assert c.allow_name_change?(nil)
 
       # OK if user has editing permission over all samples
@@ -51,7 +53,8 @@ class SampleTypeEditingConstraintsTest < ActiveSupport::TestCase
       attr = c.sample_type.sample_attributes.detect { |t| t.accessor_name == 'address' }
       refute_nil attr
       assert c.allow_name_change?(attr)
-      assert c.allow_name_change?(nil)
+      # Not OK if attribute = nil and the sample type has samples
+      refute c.allow_name_change?(nil)
     end
   end
 


### PR DESCRIPTION
- Adds possibility to add new optional attribute to an existing sample type
- Makes the title of a sample attribute editable.
- If the title of an attribute is updated, the JSON metadata values of all samples that are linked to the sample type are also updated as a background job.

Closes #1257 
Closes #1258 
Closes #362 