### PR TITLE
Import and Update from FAIR data station to support nested extended metadata

### DIFF
--- a/lib/seek/fair_data_station/base.rb
+++ b/lib/seek/fair_data_station/base.rb
@@ -115,8 +115,13 @@ module Seek
         else
           linked_attributes = extended_metadata_type.attributes_with_linked_extended_metadata_type
           linked_attributes.each do |linked_attribute|
-            nested_data = data[linked_attribute.accessor_name] || {}
-            data[linked_attribute.accessor_name] = populate_seek_extended_metadata_for_property(linked_attribute.linked_extended_metadata_type, property_id, value, nested_data)
+
+            result = populate_seek_extended_metadata_for_property(linked_attribute.linked_extended_metadata_type, { }, property_id, value)
+            unless result.empty?
+              data[linked_attribute.accessor_name] ||= {}
+              data[linked_attribute.accessor_name].merge!(result)
+              break
+            end
           end
         end
 

--- a/lib/seek/fair_data_station/base.rb
+++ b/lib/seek/fair_data_station/base.rb
@@ -99,15 +99,29 @@ module Seek
         extended_metadata_type = seek_resource.extended_metadata.extended_metadata_type
         data = {}
         additional_metadata_annotations.each do |annotation|
-          property = annotation[0]
+          property_id = annotation[0]
           value = annotation[1]
-          attribute = extended_metadata_type.extended_metadata_attributes.where(pid: property).first
-          data[attribute.title] = value if attribute
+          data = populate_seek_extended_metadata_for_property(extended_metadata_type, data, property_id, value)
         end
         seek_resource.extended_metadata.data = data
       end
 
       private
+
+      def populate_seek_extended_metadata_for_property(extended_metadata_type, data, property_id, value)
+        attribute = extended_metadata_type.extended_metadata_attributes.where(pid: property_id).first
+        if attribute
+          data[attribute.accessor_name] = value
+        else
+          linked_attributes = extended_metadata_type.attributes_with_linked_extended_metadata_type
+          linked_attributes.each do |linked_attribute|
+            nested_data = data[linked_attribute.accessor_name] || {}
+            data[linked_attribute.accessor_name] = populate_seek_extended_metadata_for_property(linked_attribute.linked_extended_metadata_type, property_id, value, nested_data)
+          end
+        end
+
+        return data
+      end
 
       def query_annotations
         sparql = SPARQL::Client.new(graph)

--- a/lib/seek/fair_data_station/writer.rb
+++ b/lib/seek/fair_data_station/writer.rb
@@ -182,7 +182,7 @@ module Seek
       end
 
       def populate_extended_metadata(seek_entity, datastation_entity)
-        if emt = detect_extended_metadata(seek_entity, datastation_entity)
+        if emt = detect_extended_metadata_type(seek_entity, datastation_entity)
           seek_entity.extended_metadata = ExtendedMetadata.new(extended_metadata_type: emt)
           update_extended_metadata(seek_entity, datastation_entity)
         end
@@ -192,14 +192,14 @@ module Seek
         datastation_entity.populate_extended_metadata(seek_entity)
       end
 
-      def detect_extended_metadata(seek_entity, datastation_entity)
+      def detect_extended_metadata_type(seek_entity, datastation_entity)
         property_ids = datastation_entity.additional_metadata_annotations.collect { |annotation| annotation[0] }
 
         # collect and sort those with the most properties that match, eliminating any where no properties match
         candidates = ::ExtendedMetadataType.where(supported_type: seek_entity.class.name).includes(:extended_metadata_attributes).collect do |emt|
-          ids = emt.extended_metadata_attributes.collect(&:pid)
-          score = (property_ids - ids).length
-          emt = nil if (property_ids & ids).empty?
+          pids = collect_extended_metadata_type_attibute_pids(emt)
+          score = (property_ids - pids).length
+          emt = nil if (property_ids & pids).empty?
           [score, emt]
         end.sort_by do |x|
           x[0]
@@ -208,6 +208,16 @@ module Seek
         candidates.first&.last
       end
 
+      def collect_extended_metadata_type_attibute_pids(extended_metadata_type)
+        pids = extended_metadata_type.extended_metadata_attributes.collect do |attr|
+          if attr.linked_extended_metadata_type
+            collect_extended_metadata_type_attibute_pids(attr.linked_extended_metadata_type)
+          else
+            attr.pid
+          end
+        end
+        pids.flatten
+      end
       def populate_sample(seek_sample, datastation_sample)
         if sample_type = detect_sample_type(datastation_sample)
           seek_sample.sample_type = sample_type

--- a/test/factories/extended_metadata_types.rb
+++ b/test/factories/extended_metadata_types.rb
@@ -525,6 +525,42 @@ FactoryBot.define do
     end
   end
 
+  factory(:nested_study_date_details_extended_metadata_type,class:ExtendedMetadataType) do
+    title { 'study date details' }
+    supported_type { 'ExtendedMetadata' }
+    after(:build) do |a|
+      a.extended_metadata_attributes << FactoryBot.create(:study_title_extended_metadata_attribute, title: 'End date of Study', pid:'http://fairbydesign.nl/ontology/end_date_of_study')
+      a.extended_metadata_attributes << FactoryBot.create(:study_title_extended_metadata_attribute, title: 'Start date of Study', pid:'http://fairbydesign.nl/ontology/start_date_of_study')
+    end
+  end
 
+  factory(:fairdata_test_case_nested_study_extended_metadata, class: ExtendedMetadataType) do
+    title {'Fair Data Station Nested Study Test Case'}
+    supported_type { 'Study' }
+    after(:build) do |a|
+      a.extended_metadata_attributes << FactoryBot.create(:study_title_extended_metadata_attribute, title: 'Experimental site name', pid:'http://fairbydesign.nl/ontology/experimental_site_name')
+      a.extended_metadata_attributes << FactoryBot.create(:extended_metadata_attribute, title:'study date details', sample_attribute_type: FactoryBot.create(:extended_metadata_sample_attribute_type),
+      linked_extended_metadata_type: FactoryBot.create(:nested_study_date_details_extended_metadata_type))
+    end
+  end
+
+  factory(:nested_obs_unit_birth_details_extended_metadata_type,class:ExtendedMetadataType) do
+    title { 'obs unit birth details' }
+    supported_type { 'ExtendedMetadata' }
+    after(:build) do |a|
+      a.extended_metadata_attributes << FactoryBot.create(:study_title_extended_metadata_attribute, title: 'Birth weight', pid:'http://fairbydesign.nl/ontology/birth_weight')
+      a.extended_metadata_attributes << FactoryBot.create(:study_title_extended_metadata_attribute, title: 'Date of birth', pid:'http://fairbydesign.nl/ontology/date_of_birth')
+    end
+  end
+
+  factory(:fairdata_test_case_nested_obsv_unit_extended_metadata, class: ExtendedMetadataType) do
+    title {'Fair Data Station Nested Obs Unit Test Case'}
+    supported_type { 'ObservationUnit' }
+    after(:build) do |a|
+      a.extended_metadata_attributes << FactoryBot.create(:study_title_extended_metadata_attribute, title: 'Gender', pid:'https://w3id.org/mixs/0000811')
+      a.extended_metadata_attributes << FactoryBot.create(:extended_metadata_attribute, title:'obs_unit_birth_details', sample_attribute_type: FactoryBot.create(:extended_metadata_sample_attribute_type),
+                                                          linked_extended_metadata_type: FactoryBot.create(:nested_obs_unit_birth_details_extended_metadata_type))
+    end
+  end
 end
 

--- a/test/factories/extended_metadata_types.rb
+++ b/test/factories/extended_metadata_types.rb
@@ -562,5 +562,33 @@ FactoryBot.define do
                                                           linked_extended_metadata_type: FactoryBot.create(:nested_obs_unit_birth_details_extended_metadata_type))
     end
   end
+
+  factory(:deep_nested_study_grandchild_extended_metadata_type,class:ExtendedMetadataType) do
+    title { 'deep nested study grandchild' }
+    supported_type { 'ExtendedMetadata' }
+    after(:build) do |a|
+      a.extended_metadata_attributes << a.extended_metadata_attributes << FactoryBot.create(:study_title_extended_metadata_attribute, title: 'Start date of Study', pid:'http://fairbydesign.nl/ontology/start_date_of_study')
+    end
+  end
+
+  factory(:deep_nested_study_child_extended_metadata_type,class:ExtendedMetadataType) do
+    title { 'deep nested study child' }
+    supported_type { 'ExtendedMetadata' }
+    after(:build) do |a|
+      a.extended_metadata_attributes << FactoryBot.create(:study_title_extended_metadata_attribute, title: 'End date of Study', pid:'http://fairbydesign.nl/ontology/end_date_of_study')
+      a.extended_metadata_attributes << FactoryBot.create(:extended_metadata_attribute, title:'grandchild', sample_attribute_type: FactoryBot.create(:extended_metadata_sample_attribute_type),
+                                                          linked_extended_metadata_type: FactoryBot.create(:deep_nested_study_grandchild_extended_metadata_type))
+    end
+  end
+
+  factory(:fairdata_test_case_deep_nested_study_extended_metadata, class: ExtendedMetadataType) do
+    title {'Fair Data Station Deep Nested Study Test Case'}
+    supported_type { 'Study' }
+    after(:build) do |a|
+      a.extended_metadata_attributes << FactoryBot.create(:study_title_extended_metadata_attribute, title: 'Experimental site name', pid:'http://fairbydesign.nl/ontology/experimental_site_name')
+      a.extended_metadata_attributes << FactoryBot.create(:extended_metadata_attribute, title:'child', sample_attribute_type: FactoryBot.create(:extended_metadata_sample_attribute_type),
+                                                          linked_extended_metadata_type: FactoryBot.create(:deep_nested_study_child_extended_metadata_type))
+    end
+  end
 end
 

--- a/test/unit/fair_data_station/fair_data_station_writer_test.rb
+++ b/test/unit/fair_data_station/fair_data_station_writer_test.rb
@@ -432,6 +432,70 @@ class FairDataStationWriterTest < ActiveSupport::TestCase
 
   end
 
+  test 'construct with nested extended metadata' do
+    FactoryBot.create(:fairdata_test_case_investigation_extended_metadata)
+    study_emt = FactoryBot.create(:fairdata_test_case_nested_study_extended_metadata)
+    obs_unit_emt = FactoryBot.create(:fairdata_test_case_nested_obsv_unit_extended_metadata)
+    FactoryBot.create(:fairdata_test_case_assay_extended_metadata)
+    FactoryBot.create(:fairdatastation_test_case_sample_type)
+    FactoryBot.create(:experimental_assay_class)
+    path = "#{Rails.root}/test/fixtures/files/fair_data_station/seek-fair-data-station-test-case.ttl"
+    inv = Seek::FairDataStation::Reader.new.parse_graph(path).first
+    contributor = FactoryBot.create(:person)
+
+    investigation = Seek::FairDataStation::Writer.new.construct_isa(inv, contributor, contributor.projects, Policy.default)
+    assert investigation.valid?
+
+    assert_difference('ExtendedMetadata.count', 12) do
+      User.with_current_user(contributor.user) do
+        investigation.save!
+      end
+    end
+
+    assert_equal 2, investigation.studies.count
+    study = investigation.studies.first
+    assert_equal study_emt, study.extended_metadata.extended_metadata_type
+    assert_equal 'test study 1', study.title
+
+    expected = HashWithIndifferentAccess.new({
+      'Experimental site name':'manchester test site',
+      'study date details': {
+        'End date of Study': '8/8/2024',
+        'Start date of Study': '8/1/2024'
+      }
+    })
+
+    assert_equal expected, study.extended_metadata.data
+
+    study = investigation.studies.last
+    assert_equal study_emt, study.extended_metadata.extended_metadata_type
+    assert_equal 'test study 2', study.title
+
+    expected = HashWithIndifferentAccess.new({
+                                               'Experimental site name':'manchester test site',
+                                               'study date details': {
+                                                 'End date of Study': '8/18/2024',
+                                                 'Start date of Study': '8/10/2024'
+                                               }
+                                             })
+
+    assert_equal expected, study.extended_metadata.data
+
+    assert_equal 2, study.observation_units.count
+    obs_unit = study.observation_units.first
+    assert_equal obs_unit_emt, obs_unit.extended_metadata.extended_metadata_type
+    assert_equal 'test obs unit 2', obs_unit.title
+
+    expected = HashWithIndifferentAccess.new({
+                                               'Gender':'female',
+                                               'obs_unit_birth_details': {
+                                                 'Birth weight': '1235g',
+                                                 'Date of birth': '1/11/2020'
+                                               }
+                                             })
+    assert_equal expected, obs_unit.extended_metadata.data
+  end
+
   private
 
   def setup_test_case_investigation

--- a/test/unit/fair_data_station/fair_data_station_writer_test.rb
+++ b/test/unit/fair_data_station/fair_data_station_writer_test.rb
@@ -460,8 +460,8 @@ class FairDataStationWriterTest < ActiveSupport::TestCase
     expected = HashWithIndifferentAccess.new({
       'Experimental site name':'manchester test site',
       'study date details': {
-        'End date of Study': '8/8/2024',
-        'Start date of Study': '8/1/2024'
+        'End date of Study': '2024-08-08',
+        'Start date of Study': '2024-08-01'
       }
     })
 
@@ -474,8 +474,8 @@ class FairDataStationWriterTest < ActiveSupport::TestCase
     expected = HashWithIndifferentAccess.new({
                                                'Experimental site name':'manchester test site',
                                                'study date details': {
-                                                 'End date of Study': '8/18/2024',
-                                                 'Start date of Study': '8/10/2024'
+                                                 'End date of Study': '2024-08-18',
+                                                 'Start date of Study': '2024-08-10'
                                                }
                                              })
 
@@ -490,7 +490,7 @@ class FairDataStationWriterTest < ActiveSupport::TestCase
                                                'Gender':'female',
                                                'obs_unit_birth_details': {
                                                  'Birth weight': '1235g',
-                                                 'Date of birth': '1/11/2020'
+                                                 'Date of birth': '2020-01-11'
                                                }
                                              })
     assert_equal expected, obs_unit.extended_metadata.data


### PR DESCRIPTION
follows links to nested extended metadata to both check for the matching type, and also for assigning the values.

* fix for #1986 