### PR TITLE
switch to using a dedicated filestore cache for settings, instead of memory

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -74,7 +74,5 @@ module SEEK
     config.active_record.belongs_to_required_by_default = false
     config.action_mailer.delivery_job = 'ActionMailer::MailDeliveryJob' # Can remove after updating defaults
     config.action_mailer.preview_path = "#{Rails.root}/test/mailers/previews" # For some reason it is looking in spec/ by default
-
-    config.settings_cache_store = ActiveSupport::Cache::MemoryStore.new
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,6 +30,7 @@ Rails.application.configure do
   #   config.cache_store = :null_store
   # end
   config.cache_store = :file_store, "#{Rails.root}/tmp/cache/dev-cache"
+  config.settings_cache_store = ActiveSupport::Cache::FileStore.new("#{Rails.root}/tmp/cache/dev-cache/settings-dev-cache")
 
   config.public_file_server.enabled = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,6 +57,7 @@ Rails.application.configure do
 
   # Use a different cache store in production.
   config.cache_store = :file_store, "#{Rails.root}/tmp/cache"
+  config.settings_cache_store = ActiveSupport::Cache::FileStore.new("#{Rails.root}/tmp/cache/settings-dev-cache")
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -25,6 +25,7 @@ Rails.application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
   config.cache_store = :memory_store
+  config.settings_cache_store = ActiveSupport::Cache::MemoryStore.new
 
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false


### PR DESCRIPTION
Using in memory cache causes problems since the cache isn't shared between instances.

* reverts the changes for #1971

