### PR TITLE
Fix error for deleted contributor when displaying an Assay 

### DIFF
--- a/app/views/assays/show.html.erb
+++ b/app/views/assays/show.html.erb
@@ -25,14 +25,6 @@
                 <%= @assay.assay_class.title -%>
               </p>
             <% end %>
-            <% if @assay.contributor&.can_view? %>
-              <p class="id">
-                <label>
-                  <%= t('contributor').capitalize -%>:
-                </label>
-                <%= link_to @assay.contributor.name, @assay.contributor -%>
-              </p>
-            <% end %>
 
             <%= render :partial => 'projects/show_project_relationship', :locals => { :resource => @assay } %>
             <p id="investigation">

--- a/app/views/assays/show.html.erb
+++ b/app/views/assays/show.html.erb
@@ -25,7 +25,7 @@
                 <%= @assay.assay_class.title -%>
               </p>
             <% end %>
-            <% if @assay.contributor.can_view? %>
+            <% if @assay.contributor&.can_view? %>
               <p class="id">
                 <label>
                   <%= t('contributor').capitalize -%>:

--- a/test/functional/assays_controller_test.rb
+++ b/test/functional/assays_controller_test.rb
@@ -2277,4 +2277,16 @@ class AssaysControllerTest < ActionController::TestCase
     end
   end
 
+  test 'can show and edit with deleted contributor' do
+    assay = FactoryBot.create(:assay, deleted_contributor:'Person:99', policy: FactoryBot.create(:public_policy))
+    assay.update_column(:contributor_id, nil)
+    assert assay.can_view?
+    assert assay.can_edit?
+    assert_nil assay.contributor
+    get :show, params: { id: assay.id }
+    assert_response :success
+    get :edit, params: { id: assay.id }
+    assert_response :success
+  end
+
 end

--- a/test/functional/investigations_controller_test.rb
+++ b/test/functional/investigations_controller_test.rb
@@ -1414,6 +1414,18 @@ class InvestigationsControllerTest < ActionController::TestCase
     assert_equal 'test obs unit 1', ObservationUnit.by_external_identifier('seek-test-obs-unit-1', investigation.projects).title
   end
 
+  test 'can show and edit with deleted contributor' do
+    investigation = FactoryBot.create(:investigation, deleted_contributor:'Person:99', policy: FactoryBot.create(:public_policy))
+    investigation.update_column(:contributor_id, nil)
+    assert investigation.can_view?
+    assert investigation.can_edit?
+    assert_nil investigation.contributor
+    get :show, params: { id: investigation.id }
+    assert_response :success
+    get :edit, params: { id: investigation.id }
+    assert_response :success
+  end
+
   private
 
   def setup_test_case_investigation

--- a/test/functional/studies_controller_test.rb
+++ b/test/functional/studies_controller_test.rb
@@ -2111,4 +2111,16 @@ class StudiesControllerTest < ActionController::TestCase
       assert_redirected_to edit_isa_study_path(study)
     end
   end
+
+  test 'can show and edit with deleted contributor' do
+    study = FactoryBot.create(:study, deleted_contributor:'Person:99', policy: FactoryBot.create(:public_policy))
+    study.update_column(:contributor_id, nil)
+    assert study.can_view?
+    assert study.can_edit?
+    assert_nil study.contributor
+    get :show, params: { id: study.id }
+    assert_response :success
+    get :edit, params: { id: study.id }
+    assert_response :success
+  end
 end


### PR DESCRIPTION
Just removed the block, as it duplicates the normal place on the right that displays the submitter correctly. Also searched the code for cases of `contributor.can_view?` 

* fix for #2043