### PR TITLE
added Sop.related_samples 

### DIFF
--- a/app/models/data_file.rb
+++ b/app/models/data_file.rb
@@ -20,7 +20,7 @@ class DataFile < ApplicationRecord
 
   belongs_to :file_template
   has_many :extracted_samples, class_name: 'Sample', foreign_key: :originating_data_file_id
-  has_many :sample_resource_links, -> { where(resource_type: 'DataFile') }, class_name: 'SampleResourceLink', foreign_key: :resource_id
+  has_many :sample_resource_links, -> { where(resource_type: 'DataFile') }, foreign_key: :resource_id
   has_many :linked_samples, through: :sample_resource_links, source: :sample
   
   has_many :unzipped_files, class_name: 'DataFile', foreign_key: :zip_origin_id

--- a/app/models/sop.rb
+++ b/app/models/sop.rb
@@ -12,8 +12,9 @@ class Sop < ApplicationRecord
 
   #don't add a dependent=>:destroy, as the content_blob needs to remain to detect future duplicates
   has_one :content_blob, -> (r) { where('content_blobs.asset_version =? AND deleted=?', r.version, false) }, :as => :asset, :foreign_key => :asset_id
-
   has_and_belongs_to_many :workflows
+  has_many :sample_resource_links, -> { where(resource_type: 'Sop') }, foreign_key: :resource_id
+  has_many :linked_samples, through: :sample_resource_links, source: :sample
 
   has_filter assay_type: Seek::Filtering::Filter.new(
       value_field: 'assays.assay_type_uri',
@@ -48,6 +49,10 @@ class Sop < ApplicationRecord
 
   def use_mime_type_for_avatar?
     true
+  end
+
+  def related_samples
+    linked_samples
   end
 
 end


### PR DESCRIPTION
added related_samples to Sop to include samples where they are linked through the Sop sample attributes.

* fix for #2053 