### PR TITLE
Sub-URI bug fixes

### DIFF
--- a/app/assets/javascripts/samples.js
+++ b/app/assets/javascripts/samples.js
@@ -81,10 +81,12 @@ Samples.initTable = function (selector, enableRowSelection, opts) {
                 "targets": strainColumns,
                 "render": function (data, type, row) {
                     if(data && data.id) {
-                        if (data.title)
-                            return '<a href="/strains/' + data.id + '">' + data.title + '</a>';
-                        else
+                        if (data.title) {
+                            var href = URL_ROOT + '/strains/' + data.id;
+                            return '<a href="' + href + '">' + data.title + '</a>';
+                        } else {
                             return '<span class="none_text">' + data.id + '</span>';
+                        }
                     } else {
                         return '<span class="none_text">Not specified</span>';
                     }
@@ -105,10 +107,12 @@ Samples.initTable = function (selector, enableRowSelection, opts) {
                     var values = Array.isArray(data) ? data : [data];
                     var result = $j.map(values, function(value, i) {
                         if(value && value.id) {
-                            if (value.title)
-                                return '<a href="/samples/' + value.id + '">' + value.title + '</a>';
-                            else
+                            if (value.title) {
+                                var href = URL_ROOT + '/samples/' + value.id;
+                                return '<a href="' + href + '">' + value.title + '</a>';
+                            } else {
                                 return '<span class="none_text">' + (value.id || value.title) + '</span>';
+                            }
                         } else {
                             return '<span class="none_text">Not specified</span>';
                         }
@@ -124,7 +128,8 @@ Samples.initTable = function (selector, enableRowSelection, opts) {
                 options["columnDefs"].push({
                     "targets": [index],
                     "render": function (data, type, row) {
-                        return '<a href="/samples/' + row.id + '">' + row.title + '</a>';
+                        var href = URL_ROOT + '/samples/' + row.id;
+                        return '<a href="' + href + '">' + row.title + '</a>';
                     }
                 });
             }

--- a/app/controllers/snapshots_controller.rb
+++ b/app/controllers/snapshots_controller.rb
@@ -2,7 +2,7 @@ require 'zenodo/oauth2/client'
 require 'zenodo-client'
 
 class SnapshotsController < ApplicationController
-  before_action :find_resource
+  before_action :get_parent_resource
   before_action :auth_resource, only: [:mint_doi_confirm, :mint_doi, :new, :create, :export_preview, :export_submit, :destroy]
   before_action :check_resource_permitted_for_ro, only: [:new, :create]
   before_action :find_snapshot, only: [:show, :mint_doi_confirm, :mint_doi, :download, :export_preview, :export_submit, :destroy]
@@ -14,13 +14,13 @@ class SnapshotsController < ApplicationController
   include Seek::ExternalServiceWrapper
 
   def create
-    @snapshot = @resource.create_snapshot
+    @snapshot = @parent_resource.create_snapshot
     if @snapshot
       flash[:notice] = "Snapshot created"
-      redirect_to polymorphic_path([@resource, @snapshot])
+      redirect_to polymorphic_path([@parent_resource, @snapshot])
     else
-      flash[:error] = @resource.errors.full_messages.join(', ')
-      redirect_to polymorphic_path(@resource)
+      flash[:error] = @parent_resource.errors.full_messages.join(', ')
+      redirect_to polymorphic_path(@parent_resource)
     end
   end
 
@@ -50,13 +50,13 @@ class SnapshotsController < ApplicationController
   end
 
   def mint_doi
-    wrap_service('DataCite', polymorphic_path([@resource, @snapshot])) do
+    wrap_service('DataCite', polymorphic_path([@parent_resource, @snapshot])) do
       if @snapshot.mint_doi
         flash[:notice] = "DOI successfully minted"
-        redirect_to polymorphic_path([@resource, @snapshot])
+        redirect_to polymorphic_path([@parent_resource, @snapshot])
       else
         flash[:error] = @snapshot.errors.full_messages
-        redirect_to polymorphic_path([@resource, @snapshot])
+        redirect_to polymorphic_path([@parent_resource, @snapshot])
       end
     end
   end
@@ -67,13 +67,13 @@ class SnapshotsController < ApplicationController
   def export_submit # Export AND publish
     access_token = @oauth_session.access_token
 
-    wrap_service('Zenodo', polymorphic_path([@resource, @snapshot]), rescue_all: !Rails.env.test?) do
+    wrap_service('Zenodo', polymorphic_path([@parent_resource, @snapshot]), rescue_all: !Rails.env.test?) do
       if @snapshot.export_to_zenodo(access_token, metadata_params) && @snapshot.publish_in_zenodo(access_token)
         flash[:notice] = "Snapshot successfully exported to Zenodo"
-        redirect_to polymorphic_path([@resource, @snapshot])
+        redirect_to polymorphic_path([@parent_resource, @snapshot])
       else
         flash[:error] = @snapshot.errors.full_messages
-        redirect_to polymorphic_path([@resource, @snapshot])
+        redirect_to polymorphic_path([@parent_resource, @snapshot])
       end
     end
   end
@@ -81,47 +81,42 @@ class SnapshotsController < ApplicationController
   def destroy
     if @snapshot.has_doi?
       flash[:error] = "You cannot delete a snapshot that has a DOI."
-      redirect_to polymorphic_path([@resource, @snapshot])
+      redirect_to polymorphic_path([@parent_resource, @snapshot])
     else
       @snapshot.destroy
       flash[:notice] = "Snapshot successfully deleted"
-      redirect_to polymorphic_path(@resource)
+      redirect_to polymorphic_path(@parent_resource)
     end
   end
 
   private
 
-  def find_resource # This is hacky :(
-    resource, id = request.path.split('/')[1, 2]
-    @resource = safe_class_lookup(resource.singularize.classify).find(id)
-  end
-
   def auth_resource
-    unless is_auth?(@resource, :manage)
+    unless is_auth?(@parent_resource, :manage)
       flash[:error] = "You are not authorized to manage snapshots of this resource."
-      redirect_to polymorphic_path(@resource)
+      redirect_to polymorphic_path(@parent_resource)
     end
   end
 
   def check_resource_permitted_for_ro
-    unless @resource.permitted_for_research_object?
+    unless @parent_resource.permitted_for_research_object?
       flash[:error] = "You may only create snapshots of publicly accessible resources."
-      redirect_to polymorphic_path(@resource)
+      redirect_to polymorphic_path(@parent_resource)
     end
   end
 
   def find_snapshot
-    @snapshot = @resource.snapshots.where(snapshot_number: params[:id]).first
+    @snapshot = @parent_resource.snapshots.where(snapshot_number: params[:id]).first
     if @snapshot.nil?
       flash[:error] = "Snapshot #{params[:id]} doesn't exist."
-      redirect_to polymorphic_path(@resource)
+      redirect_to polymorphic_path(@parent_resource)
     end
   end
 
   def doi_minting_enabled?
     unless Seek::Config.doi_minting_enabled
       flash[:error] = "DOI minting is not enabled."
-      redirect_to polymorphic_path([@resource, @snapshot])
+      redirect_to polymorphic_path([@parent_resource, @snapshot])
     end
   end
 

--- a/app/views/assets/_usage_info_box.html.erb
+++ b/app/views/assets/_usage_info_box.html.erb
@@ -37,7 +37,7 @@
   </div>
 
   <%# for items created before we started collecting logs %>
-  <% if logging_start_date && @resource.created_at <= logging_start_date %>
+  <% if logging_start_date && @parent_resource.created_at <= logging_start_date %>
     <p id="logging_started">
       (Since <%= logging_start_date.strftime('%B %Y') %>)
     </p>

--- a/app/views/snapshots/_buttons.html.erb
+++ b/app/views/snapshots/_buttons.html.erb
@@ -1,15 +1,15 @@
-<% if @resource.can_manage? %>
+<% if @parent_resource.can_manage? %>
     <% if @snapshot.can_export_to_zenodo? %>
-        <%= button_link_to("Export to Zenodo", 'snapshot_export', @zenodo_oauth_client.authorize_url(polymorphic_path([@resource, @snapshot], :action => 'export'))) %>
+        <%= button_link_to("Export to Zenodo", 'snapshot_export', @zenodo_oauth_client.authorize_url(polymorphic_path([@parent_resource, @snapshot], :action => 'export'))) %>
     <% end %>
     <% unless @snapshot.has_doi? %>
         <% if @snapshot.can_mint_doi? %>
-            <%= button_link_to("Generate a DOI", 'doi',  polymorphic_path([@resource, @snapshot], action: 'mint_doi_confirm')) %>
+            <%= button_link_to("Generate a DOI", 'doi',  polymorphic_path([@parent_resource, @snapshot], action: 'mint_doi_confirm')) %>
         <% end %>
-        <%= button_link_to("Delete", 'destroy',  polymorphic_path([@resource, @snapshot]),
+        <%= button_link_to("Delete", 'destroy',  polymorphic_path([@parent_resource, @snapshot]),
                            { confirm: "Are you sure you wish to delete this snapshot?", method: :delete }) %>
     <% end %>
 <% end %>
-<% if @resource.can_view? %>
-    <%= button_link_to("Download", 'download', polymorphic_path([@resource, @snapshot], :action => 'download')) %>
+<% if @parent_resource.can_view? %>
+    <%= button_link_to("Download", 'download', polymorphic_path([@parent_resource, @snapshot], :action => 'download')) %>
 <% end %>

--- a/app/views/snapshots/export_preview.html.erb
+++ b/app/views/snapshots/export_preview.html.erb
@@ -1,11 +1,11 @@
 <div class="row">
   <div class="col-md-8 col-md-push-2">
     <%= panel("Confirmation") do %>
-        <%= form_tag(polymorphic_path([@resource, @snapshot], :action => 'export'), method: :post) do %>
+        <%= form_tag(polymorphic_path([@parent_resource, @snapshot], :action => 'export'), method: :post) do %>
             <%= image_tag('logos/zenodo.png', :class => 'zenodo-publish') %>
             <p>
               You are about to publish:
-              <strong><%= @resource.title %></strong> to Zenodo. <br/>
+              <strong><%= @parent_resource.title %></strong> to Zenodo. <br/>
               Please fill out some additional metadata required by Zenodo before submitting.
             </p>
 
@@ -77,7 +77,7 @@
 
             <p class="text-center">
               <%= submit_tag 'Publish', :class => 'btn btn-primary' %>
-              <%= cancel_button(polymorphic_path(@resource)) %>
+              <%= cancel_button(polymorphic_path(@parent_resource)) %>
             </p>
         <% end %>
     <% end %>

--- a/app/views/snapshots/mint_doi_confirm.html.erb
+++ b/app/views/snapshots/mint_doi_confirm.html.erb
@@ -1,9 +1,9 @@
-<% type_text = "#{text_for_resource(@resource)} snapshot" %>
+<% type_text = "#{text_for_resource(@parent_resource)} snapshot" %>
 
 <div class="row">
   <div class="col-md-8 col-md-push-2">
     <%= panel("Confirmation") do %>
-        <%= form_tag(polymorphic_path([@resource, @snapshot], action: 'mint_doi'), method: :post) do %>
+        <%= form_tag(polymorphic_path([@parent_resource, @snapshot], action: 'mint_doi'), method: :post) do %>
             <%= image_tag('logos/doi_logo.svg', class: 'mint-doi') %>
 
             <p>
@@ -28,7 +28,7 @@
 
             <p class="text-center">
               <%= submit_tag 'Mint DOI', class: 'btn btn-primary' %>
-              <%= cancel_button(polymorphic_path(@resource)) %>
+              <%= cancel_button(polymorphic_path(@parent_resource)) %>
             </p>
         <% end %>
     <% end %>

--- a/app/views/snapshots/new.html.erb
+++ b/app/views/snapshots/new.html.erb
@@ -1,5 +1,5 @@
 <%= render :partial => "general/page_title", :locals => { :title => 'Snapshot Preview' } %>
-<% items = Seek::ResearchObjects::Generator.new(@resource).gather_entries(true).group_by(&:permitted_for_research_object?) %>
+<% items = Seek::ResearchObjects::Generator.new(@parent_resource).gather_entries(true).group_by(&:permitted_for_research_object?) %>
 <% included_items = items[true] || [] %>
 <% excluded_items = items[false] || [] %>
 
@@ -11,7 +11,7 @@
     These resources will be excluded from the snapshot due to not having public access privileges.
     To include an excluded resource in the snapshot, please make it publicly accessible.
     <% if excluded_items.any? %>
-    <br/>To quickly publish these items you can select the <strong>Publish full <%=t(@resource.class.name.downcase)%></strong> button below.
+    <br/>To quickly publish these items you can select the <strong>Publish full <%=t(@parent_resource.class.name.downcase)%></strong> button below.
     <% end %>
 <% end %>
 
@@ -39,9 +39,9 @@
   <% end %>
 </div>
 
-<%= link_to('Create Snapshot', polymorphic_path([@resource, :snapshots]),
+<%= link_to('Create Snapshot', polymorphic_path([@parent_resource, :snapshots]),
             :method => :post, :class => 'btn btn-primary') %>
 
-<%= image_tag_for_key('publish', polymorphic_path(@resource, :action => :check_related_items), nil, {:method=>:post,:class => 'btn btn-default'}, "Publish full #{t(@resource.class.name.downcase)}") if excluded_items.any? %>
+<%= image_tag_for_key('publish', polymorphic_path(@parent_resource, :action => :check_related_items), nil, {:method=>:post,:class => 'btn btn-default'}, "Publish full #{t(@parent_resource.class.name.downcase)}") if excluded_items.any? %>
 
-or <%= cancel_button polymorphic_path(@resource) -%>
+or <%= cancel_button polymorphic_path(@parent_resource) -%>

--- a/app/views/snapshots/show.html.erb
+++ b/app/views/snapshots/show.html.erb
@@ -55,9 +55,9 @@
   </div>
   <div class="col-md-3 col-sm-4">
     <%= render partial: 'assets/citation_box', locals: { doi: @snapshot.doi } unless @snapshot.doi.blank? %>
-    <%= render partial: 'snapshots/snapshots', locals: { snapshots: @resource.snapshots,
+    <%= render partial: 'snapshots/snapshots', locals: { snapshots: @parent_resource.snapshots,
                                                          selected: @snapshot,
-                                                         resource: @resource } %>
+                                                         resource: @parent_resource } %>
     <%#logging for snapshots didnt start until ~september (dates will vary depending on update time, but is to give a rough indication only) %>
     <%= render partial: 'assets/usage_info_box', locals: { resource: @snapshot,
                                                            logging_start_date: Date.parse('01-09-2018')  }

--- a/test/functional/snapshots_controller_test.rb
+++ b/test/functional/snapshots_controller_test.rb
@@ -97,6 +97,22 @@ class SnapshotsControllerTest < ActionController::TestCase
     assert_redirected_to assay_snapshot_path(assay, assigns(:snapshot).snapshot_number)
   end
 
+  test 'can create snapshot under sub-uri' do
+    with_relative_root('/seek/seek123') do
+      user = FactoryBot.create(:user)
+      assay = FactoryBot.create(:assay, policy: FactoryBot.create(:publicly_viewable_policy),
+                                contributor: user.person, creators: [user.person])
+      login_as(user)
+
+      assert_difference('Snapshot.count') do
+        post :create, params: { assay_id: assay }
+      end
+
+      assert assay.can_manage?(user)
+      assert_redirected_to assay_snapshot_path(assay, assigns(:snapshot).snapshot_number)
+    end
+  end
+
   test "can't create snapshot if no manage permissions" do
     user = FactoryBot.create(:user)
     investigation = FactoryBot.create(:investigation, policy: FactoryBot.create(:publicly_viewable_policy),
@@ -194,8 +210,6 @@ class SnapshotsControllerTest < ActionController::TestCase
     assert_response :redirect
     assert flash[:error].include?('exist')
   end
-
-
 
   test 'can get confirmation when minting DOI for snapshot' do
     datacite_mock


### PR DESCRIPTION
- Make snapshots controller re-use `get_parent_resource` instead of using its own method to get resource being snapshotted.
- Use `URL_ROOT` when building links in samples table.

Fixes #2042