### PR TITLE
Don't hide ISA graph when viewing project overview on small screens

### DIFF
--- a/app/views/general/_isa_graph.html.erb
+++ b/app/views/general/_isa_graph.html.erb
@@ -7,6 +7,7 @@
   only_tree ||= false
   view = params[:graph_view] || default_view
   is_full_screen = params.key?(:fullscreen).present?
+  standalone ||= false
 %>
 
 <style>
@@ -27,9 +28,9 @@
   }
 </style>
 
-<div style="float:right" class="hidden-xs"><%= help_link :isa_overview, include_icon: true, link_text:'Help' %></div>
+<div style="float:right" class="<%= standalone ? '' : ' hidden-xs' %>"><%= help_link :isa_overview, include_icon: true, link_text:'Help' %></div>
 <div class="row">
-  <div class="col-sm-12 hidden-xs">
+  <div class="col-sm-12<%= standalone ? '' : ' hidden-xs' %>">
     <div id="isa-graph" class="panel panel-default">
       <div id="node_info"></div>
       <div class="isa-controls">

--- a/app/views/projects/overview.html.erb
+++ b/app/views/projects/overview.html.erb
@@ -1,1 +1,1 @@
-<%= render partial: 'general/isa_graph', locals:  { root_item: @project, deep: true, include_parents: true, only_tree: true } %>
+<%= render partial: 'general/isa_graph', locals: { root_item: @project, deep: true, include_parents: true, only_tree: true, standalone: true } %>


### PR DESCRIPTION
Fixes #2059

![image](https://github.com/user-attachments/assets/5659cf77-f02b-42db-8128-aa306cd3dba7)
