### PR TITLE
Check content type to determine if request is an API call.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -527,7 +527,7 @@ class ApplicationController < ActionController::Base
   end
 
   def json_api_request?
-    request.format.json? || Mime::Type.lookup(request.content_type)&.json?
+    request.format.json? || ( request.content_type && Mime::Type.lookup(request.content_type)&.json? )
   end
 
   # filter that responds with :not_acceptable if request rdf for non rdf capable resource

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -527,7 +527,7 @@ class ApplicationController < ActionController::Base
   end
 
   def json_api_request?
-    request.format.json?
+    request.format.json? || Mime::Type.lookup(request.content_type)&.json?
   end
 
   # filter that responds with :not_acceptable if request rdf for non rdf capable resource

--- a/config/version.yml
+++ b/config/version.yml
@@ -9,4 +9,4 @@
 
 major:        1
 minor:        16
-patch:        0-main 
+patch:        0-pre

--- a/docker-compose-relative-root.yml
+++ b/docker-compose-relative-root.yml
@@ -13,7 +13,7 @@ services:
   seek: # The SEEK application
     #build: .
 
-    image: fairdom/seek:1.15
+    image: fairdom/seek:1.16-dev
 
     container_name: seek
     command: docker/entrypoint.sh
@@ -42,7 +42,7 @@ services:
   seek_workers: # The SEEK delayed job workers
       #build: .
 
-      image: fairdom/seek:1.15
+      image: fairdom/seek:1.16-dev
       container_name: seek-workers
       command: docker/start_workers.sh
       restart: always

--- a/docker-compose-virtuoso.yml
+++ b/docker-compose-virtuoso.yml
@@ -11,7 +11,7 @@ services:
 
   seek: # The SEEK application
     #build: .
-    image: fairdom/seek:1.15
+    image: fairdom/seek:1.16-dev
     container_name: seek
     command: docker/entrypoint.sh
     restart: always
@@ -38,7 +38,7 @@ services:
 
   seek_workers: # The SEEK delayed job workers
     #build: .
-    image: fairdom/seek:1.15
+    image: fairdom/seek:1.16-dev
     container_name: seek-workers
     command: docker/start_workers.sh
     restart: always

--- a/docker-compose-with-email.yml
+++ b/docker-compose-with-email.yml
@@ -13,7 +13,7 @@ services:
   seek: # The SEEK application
     #build: .
 
-    image: fairdom/seek:1.15
+    image: fairdom/seek:1.16-dev
 
     container_name: seek
     command: docker/entrypoint.sh
@@ -42,7 +42,7 @@ services:
   seek_workers: # The SEEK delayed job workers
       #build: .
 
-      image: fairdom/seek:1.15
+      image: fairdom/seek:1.16-dev
       container_name: seek-workers
       command: docker/start_workers.sh
       restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   seek: # The SEEK application
     #build: .
 
-    image: fairdom/seek:1.15
+    image: fairdom/seek:1.16-dev
 
     container_name: seek
     command: docker/entrypoint.sh
@@ -41,7 +41,7 @@ services:
   seek_workers: # The SEEK delayed job workers
       #build: .
 
-      image: fairdom/seek:1.15
+      image: fairdom/seek:1.16-dev
       container_name: seek-workers
       command: docker/start_workers.sh
       restart: always

--- a/test/api_test_helper.rb
+++ b/test/api_test_helper.rb
@@ -76,7 +76,7 @@ module ApiTestHelper
   end
 
   def api_patch_test(resource, template)
-    get member_url(resource), headers: { 'Authorization' => read_access_auth }
+    get member_url(resource), as: :json, headers: { 'Authorization' => read_access_auth }
     assert_response :success
     expected = JSON.parse(response.body)
 

--- a/test/integration/api/data_file_api_test.rb
+++ b/test/integration/api/data_file_api_test.rb
@@ -135,7 +135,7 @@ class DataFileApiTest < ActionDispatch::IntegrationTest
 
     with_config_value(:max_all_visitors_access_type, Policy::VISIBLE) do
       assert_no_difference(-> { model.count }) do
-        post collection_url, params: to_post, headers: { 'Authorization' => write_access_auth }
+        post collection_url, params: to_post, as: :json, headers: { 'Authorization' => write_access_auth }
         assert_response :unprocessable_entity
         validate_json response.body, '#/components/schemas/unprocessableEntityResponse'
       end

--- a/test/integration/api/person_api_test.rb
+++ b/test/integration/api/person_api_test.rb
@@ -47,7 +47,7 @@ class PersonApiTest < ActionDispatch::IntegrationTest
     body = api_max_post_body
     body["data"]["id"] = "#{other_person.id}"
     body["data"]["attributes"]["email"] = "updateTest@email.com"
-    patch "/people/#{other_person.id}.json", params: body, headers: { 'Authorization' => write_access_auth }
+    patch "/people/#{other_person.id}.json", params: body, as: :json, headers: { 'Authorization' => write_access_auth }
     assert_response :success
   end
 end

--- a/test/integration/api/programme_api_test.rb
+++ b/test/integration/api/programme_api_test.rb
@@ -17,7 +17,7 @@ class ProgrammeApiTest < ActionDispatch::IntegrationTest
     user_login(a_person)
     body = api_max_post_body
     assert_difference('Programme.count') do
-      post collection_url, params: body, headers: { 'Authorization' => write_access_auth }
+      post collection_url, params: body, as: :json, headers: { 'Authorization' => write_access_auth }
       assert_response :success
     end
   end
@@ -34,7 +34,7 @@ class ProgrammeApiTest < ActionDispatch::IntegrationTest
     body["data"]['attributes']['title'] = "Updated programme"
     #change_funding_codes_before_CU("min")
 
-    patch member_url(prog), params: body, headers: { 'Authorization' => write_access_auth }
+    patch member_url(prog), params: body, as: :json, headers: { 'Authorization' => write_access_auth }
     assert_response :success
   end
 

--- a/test/integration/api/project_api_test.rb
+++ b/test/integration/api/project_api_test.rb
@@ -22,7 +22,7 @@ class ProjectApiTest < ActionDispatch::IntegrationTest
     user_login(FactoryBot.create(:person))
     body = api_max_post_body
     assert_no_difference('Project.count') do
-      post collection_url, params: body, headers: { 'Authorization' => write_access_auth }
+      post collection_url, params: body, as: :json, headers: { 'Authorization' => write_access_auth }
     end
   end
 
@@ -76,7 +76,7 @@ class ProjectApiTest < ActionDispatch::IntegrationTest
       }
     }
 
-    patch project_path(project, format: :json), params: to_patch, headers: { 'Authorization' => write_access_auth }
+    patch project_path(project, format: :json), params: to_patch, as: :json, headers: { 'Authorization' => write_access_auth }
     assert_response :success
 
     people = project.reload.people.to_a

--- a/test/integration/api/sample_api_test.rb
+++ b/test/integration/api/sample_api_test.rb
@@ -114,7 +114,7 @@ class SampleApiTest < ActionDispatch::IntegrationTest
       }
     }
     assert_difference('Sample.count') do
-      post samples_path(format: :json), params: params, headers: { 'Authorization' => write_access_auth }
+      post samples_path(format: :json), params: params, as: :json, headers: { 'Authorization' => write_access_auth }
     end
     assert_response :success
     sample = Sample.last
@@ -162,7 +162,7 @@ class SampleApiTest < ActionDispatch::IntegrationTest
     }
 
     assert_difference('Sample.count') do
-      post samples_path(format: :json), params: params, headers: { 'Authorization' => write_access_auth }
+      post samples_path(format: :json), params: params, as: :json, headers: { 'Authorization' => write_access_auth }
     end
     assert_response :success
 
@@ -214,7 +214,7 @@ class SampleApiTest < ActionDispatch::IntegrationTest
     }
 
     assert_difference('Sample.count') do
-      post samples_path(format: :json), params: params, headers: { 'Authorization' => write_access_auth }
+      post samples_path(format: :json), params: params, as: :json, headers: { 'Authorization' => write_access_auth }
     end
     assert_response :success
 

--- a/test/integration/api/sample_type_api_test.rb
+++ b/test/integration/api/sample_type_api_test.rb
@@ -47,7 +47,7 @@ class SampleTypeApiTest < ActionDispatch::IntegrationTest
     }
     assert_difference('SampleType.count') do
       assert_difference('SampleAttribute.count') do
-        post sample_types_path(format: :json), params: params, headers: { 'Authorization' => write_access_auth }
+        post sample_types_path(format: :json), params: params, as: :json, headers: { 'Authorization' => write_access_auth }
       end
     end
     assert_response :success
@@ -94,7 +94,7 @@ class SampleTypeApiTest < ActionDispatch::IntegrationTest
     }
     assert_difference('SampleType.count') do
       assert_difference('SampleAttribute.count') do
-        post sample_types_path(format: :json), params: params, headers: { 'Authorization' => write_access_auth }
+        post sample_types_path(format: :json), params: params, as: :json, headers: { 'Authorization' => write_access_auth }
       end
     end
     assert_response :success
@@ -131,7 +131,7 @@ class SampleTypeApiTest < ActionDispatch::IntegrationTest
     }
 
     assert_no_difference('SampleAttribute.count') do
-      patch sample_type_path(sample_type.id, format: :json), params: params, headers: { 'Authorization' => write_access_auth }
+      patch sample_type_path(sample_type.id, format: :json), params: params, as: :json, headers: { 'Authorization' => write_access_auth }
     end
 
     assert_response :success
@@ -166,7 +166,7 @@ class SampleTypeApiTest < ActionDispatch::IntegrationTest
     }
 
     assert_difference('SampleAttribute.count') do
-      patch sample_type_path(sample_type.id, format: :json), params: params, headers: { 'Authorization' => write_access_auth }
+      patch sample_type_path(sample_type.id, format: :json), params: params, as: :json, headers: { 'Authorization' => write_access_auth }
     end
 
     assert_response :success
@@ -204,7 +204,7 @@ class SampleTypeApiTest < ActionDispatch::IntegrationTest
     }
 
     assert_difference('SampleAttribute.count', -1) do
-      patch sample_type_path(sample_type.id, format: :json), params: params, headers: { 'Authorization' => write_access_auth }
+      patch sample_type_path(sample_type.id, format: :json), as: :json, params: params, headers: { 'Authorization' => write_access_auth }
     end
 
     assert_response :success

--- a/test/integration/api/sop_api_test.rb
+++ b/test/integration/api/sop_api_test.rb
@@ -69,7 +69,7 @@ class SopApiTest < ActionDispatch::IntegrationTest
       }
     }
 
-    patch sop_path(sop, format: :json), params: to_patch, headers: { 'Authorization' => write_access_auth }
+    patch sop_path(sop, format: :json), params: to_patch, as: :json, headers: { 'Authorization' => write_access_auth }
     assert_response :success
 
     updated_policy = JSON.parse(@response.body)['data']['attributes']['policy']

--- a/test/integration/api/workflow_api_test.rb
+++ b/test/integration/api/workflow_api_test.rb
@@ -56,7 +56,7 @@ class WorkflowApiTest < ActionDispatch::IntegrationTest
     VCR.use_cassette('bio_tools/fetch_galaxy_tool_names') do
       template = load_template('post_tooled_workflow.json.erb')
 
-      post '/workflows.json', params: template, headers: { 'Authorization' => write_access_auth }
+      post '/workflows.json', params: template, as: :json, headers: { 'Authorization' => write_access_auth }
       assert_response :success
 
       validate_json response.body, "#/components/schemas/#{singular_name.camelize(:lower)}Response"

--- a/test/integration/api/write_api_test_suite.rb
+++ b/test/integration/api/write_api_test_suite.rb
@@ -67,7 +67,7 @@ module WriteApiTestSuite
     body['data']['id'] = '100000000'
 
     assert_no_difference(-> { model.count }) do
-      post collection_url, params: body, headers: { 'Authorization' => write_access_auth }
+      post collection_url, params: body, headers: { 'Authorization' => write_access_auth }, as: :json
 
       assert_response :unprocessable_entity
       validate_json response.body, '#/components/schemas/unprocessableEntityResponse'
@@ -80,7 +80,7 @@ module WriteApiTestSuite
     body['data']['type'] = 'wrong'
 
     assert_no_difference(-> { model.count }) do
-      post collection_url, params: body, headers: { 'Authorization' => write_access_auth }
+      post collection_url, params: body, headers: { 'Authorization' => write_access_auth }, as: :json
       assert_response :unprocessable_entity
       validate_json response.body, '#/components/schemas/unprocessableEntityResponse'
       assert_match "The specified data:type does not match the URL's object (#{body['data']['type']} vs. #{plural_name})", response.body
@@ -92,7 +92,7 @@ module WriteApiTestSuite
     body['data'].delete('type')
 
     assert_no_difference(-> { model.count }) do
-      post collection_url, params: body, headers: { 'Authorization' => write_access_auth }
+      post collection_url, params: body, headers: { 'Authorization' => write_access_auth }, as: :json
       assert_response :unprocessable_entity
       validate_json response.body, '#/components/schemas/unprocessableEntityResponse'
       assert_match "A POST/PUT request must specify a data:type", response.body
@@ -103,7 +103,7 @@ module WriteApiTestSuite
     body = load_template("patch_min_#{singular_name}.json.erb", id: '100000000')
 
     assert_no_difference(-> { model.count }) do
-      put member_url(resource), params: body, headers: { 'Authorization' => write_access_auth }
+      put member_url(resource), params: body, headers: { 'Authorization' => write_access_auth }, as: :json
       assert_response :unprocessable_entity
       validate_json response.body, '#/components/schemas/unprocessableEntityResponse'
       assert_match "id specified by the PUT request does not match object-id in the JSON input", response.body
@@ -115,7 +115,7 @@ module WriteApiTestSuite
     body['data']['type'] = 'wrong'
 
     assert_no_difference(-> { model.count }) do
-      put member_url(resource), params: body, headers: { 'Authorization' => write_access_auth }
+      put member_url(resource), params: body, headers: { 'Authorization' => write_access_auth }, as: :json
       assert_response :unprocessable_entity
       validate_json response.body, '#/components/schemas/unprocessableEntityResponse'
       assert_match "The specified data:type does not match the URL's object (#{body['data']['type']} vs. #{plural_name})", response.body
@@ -127,7 +127,7 @@ module WriteApiTestSuite
     body['data'].delete('type')
 
     assert_no_difference(-> { model.count }) do
-      put member_url(resource), params: body, headers: { 'Authorization' => write_access_auth }
+      put member_url(resource), params: body, headers: { 'Authorization' => write_access_auth }, as: :json
       assert_response :unprocessable_entity
       validate_json response.body, '#/components/schemas/unprocessableEntityResponse'
       assert_match "A POST/PUT request must specify a data:type", response.body
@@ -138,7 +138,7 @@ module WriteApiTestSuite
     skip unless write_examples?
 
     template = load_template("post_max_#{singular_name}.json.erb")
-    post collection_url, params: template, headers: { 'Authorization' => write_access_auth }
+    post collection_url, params: template, headers: { 'Authorization' => write_access_auth }, as: :json
     assert_response :success
 
     write_examples(JSON.pretty_generate(template), "#{singular_name.camelize(:lower)}Post.json")
@@ -149,7 +149,7 @@ module WriteApiTestSuite
     skip unless write_examples?
 
     template = load_template("patch_max_#{singular_name}.json.erb")
-    patch member_url(resource), params: template, headers: { 'Authorization' => write_access_auth }
+    patch member_url(resource), params: template, headers: { 'Authorization' => write_access_auth }, as: :json
     assert_response :success
 
     write_examples(JSON.pretty_generate(template), "#{singular_name.camelize(:lower)}Patch.json")


### PR DESCRIPTION
Updated `json_api_request?` to also check the content type of the request to determine if it is a JSON api call.

Ran the api integration tests without checking the Accept header, and updated any tests that relied on Accept only.

* fix for #2066 