### PR TITLE
MailDeliveryJob to updates with settings and avoids needing to restart.

### DIFF
--- a/app/jobs/enhanced_mail_delivery_job.rb
+++ b/app/jobs/enhanced_mail_delivery_job.rb
@@ -7,4 +7,10 @@ class EnhancedMailDeliveryJob < ActionMailer::MailDeliveryJob
     Seek::Config.smtp_propagate
     Seek::Config.site_base_host_propagate
   end
+
+  around_perform do |_job, block|
+    if Seek::Config.email_enabled
+      block.call
+    end
+  end
 end

--- a/app/jobs/enhanced_mail_delivery_job.rb
+++ b/app/jobs/enhanced_mail_delivery_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class EnhancedMailDeliveryJob < ActionMailer::MailDeliveryJob
+  # makes sure any changes to the smtp and host settings are picked up without having to restart delayed job
+  before_perform do
+    # make sure the SMTP,site_base_host configuration is in sync with current SEEK settings
+    Seek::Config.smtp_propagate
+    Seek::Config.site_base_host_propagate
+  end
+end

--- a/app/views/admin/_email.html.erb
+++ b/app/views/admin/_email.html.erb
@@ -55,6 +55,7 @@
         <%= link_to '#', id: 'queue-test-email-btn', class: 'btn btn-default' do %>
           <%= image("test", title: "Send testing email", alt: "Test")%> Queue test email
         <% end %>
+        <p class="help-block">Note that testing the Queue requires settings to be saved first</p>
         <div id='ajax_loader_position'></div>
       <% end %>
     </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -72,7 +72,7 @@ module SEEK
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', 'overrides', '**', '*.{rb,yml}')] unless Rails.env.test?
 
     config.active_record.belongs_to_required_by_default = false
-    config.action_mailer.delivery_job = 'ActionMailer::MailDeliveryJob' # Can remove after updating defaults
+    config.action_mailer.delivery_job = 'EnhancedMailDeliveryJob' # sets the configured SMTP settngs before each run
     config.action_mailer.preview_path = "#{Rails.root}/test/mailers/previews" # For some reason it is looking in spec/ by default
   end
 end

--- a/lib/seek/workers.rb
+++ b/lib/seek/workers.rb
@@ -18,7 +18,7 @@ module Seek
     def self.create_commands(action)
       commands = []
       queues = [QueueNames::DEFAULT]
-      queues << QueueNames::MAILERS if Seek::Config.email_enabled
+      queues << QueueNames::MAILERS
       queues << QueueNames::AUTH_LOOKUP if Seek::Config.auth_lookup_enabled
       queues << QueueNames::REMOTE_CONTENT if Seek::Config.cache_remote_files
       queues << QueueNames::SAMPLES if Seek::Config.samples_enabled

--- a/test/unit/jobs/enhanced_mail_delivery_job_test.rb
+++ b/test/unit/jobs/enhanced_mail_delivery_job_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+require 'minitest/mock'
+
+class EnhancedMailDeliveryJobTest < ActiveSupport::TestCase
+  test 'perform' do
+    with_config_value(:email_enabled, true) do
+
+      assert_enqueued_jobs(1, only: EnhancedMailDeliveryJob, queue: QueueNames::MAILERS) do
+        Mailer.test_email('fred@email.com').deliver_later
+      end
+
+      smtp_propagate_called = false
+      site_base_host_propagate_called = false
+
+      Seek::Config.stub :smtp_propagate, ->{smtp_propagate_called = true} do
+        Seek::Config.stub :site_base_host_propagate, ->{site_base_host_propagate_called = true} do
+          assert_emails 1 do
+            assert_performed_jobs(1, only: EnhancedMailDeliveryJob) do
+              Mailer.test_email('fred@email.com').deliver_later
+            end
+          end
+        end
+      end
+
+      assert smtp_propagate_called
+      assert site_base_host_propagate_called
+    end
+  end
+end

--- a/test/unit/jobs/enhanced_mail_delivery_job_test.rb
+++ b/test/unit/jobs/enhanced_mail_delivery_job_test.rb
@@ -26,4 +26,20 @@ class EnhancedMailDeliveryJobTest < ActiveSupport::TestCase
       assert site_base_host_propagate_called
     end
   end
+
+  test 'perform with email disabled' do
+    with_config_value(:email_enabled, true) do
+      assert_enqueued_jobs(1, only: EnhancedMailDeliveryJob, queue: QueueNames::MAILERS) do
+        Mailer.test_email('fred@email.com').deliver_later
+      end
+    end
+
+    with_config_value(:email_enabled, false) do
+      assert_emails 0 do
+        assert_performed_jobs(1, only: EnhancedMailDeliveryJob) do
+          Mailer.test_email('fred@email.com').deliver_later
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Extension of MailDeliveryJob to update smtp settings before running.
Also always start the mailer job, but only send mails if enabled, to avoid having to restart the jobs if enabling email. ( I'm in 2 minds about this and open to reverting it after review. )
Added a note that when queuing a test email, the settings need to have been saved first.

* Fix for #2070 