### PR TITLE
Sample Type and download permissions 

### DIFF
--- a/app/models/sample_type.rb
+++ b/app/models/sample_type.rb
@@ -200,6 +200,19 @@ class SampleType < ApplicationRecord
     can_view?(user)
   end
 
+  def self.is_asset?
+    false
+  end
+
+  # although has a downloadable template, it doesn't have the full downloadable behaviour of an asset with data and it's own accessible permissions
+  def is_downloadable?
+    false
+  end
+
+  def self.supports_extended_metadata?
+    false
+  end
+
   private
 
   # whether the referring sample is valid and gives permission to view
@@ -290,10 +303,6 @@ class SampleType < ApplicationRecord
     if is_title_seek_sample_multi
       errors.add(:sample_attributes, "Attribute type of #{base_type.underscore.humanize} can not be selected as the sample type title.")
     end
-  end
-
-  def self.supports_extended_metadata?
-    false
   end
 
   class UnknownAttributeException < RuntimeError; end

--- a/app/views/sample_types/_template.html.erb
+++ b/app/views/sample_types/_template.html.erb
@@ -1,3 +1,5 @@
+<% return unless @sample_type.can_download? %>
+<h2>Template</h2>
 <div id="template-details">
 
   <% if @sample_type.template %>

--- a/app/views/sample_types/show.html.erb
+++ b/app/views/sample_types/show.html.erb
@@ -11,7 +11,7 @@
     <div class="col-md-9 col-sm-8 box_about_actor">
       <%= item_description h(@sample_type.description) -%>
 
-      <h2>Template</h2>
+
       <%= render :partial => "template" %>
 
       <h2>Attributes</h2>

--- a/lib/tasks/seek_upgrades.rake
+++ b/lib/tasks/seek_upgrades.rake
@@ -13,6 +13,7 @@ namespace :seek do
     update_observation_unit_policies
     fix_xlsx_marked_as_zip
     add_policies_to_existing_sample_types
+    fix_previous_sample_type_permissions
   ]
 
   # these are the tasks that are executes for each upgrade as standard, and rarely change
@@ -104,13 +105,13 @@ namespace :seek do
 
           # Visible if linked to public samples
           if st.samples.any? { |sample| sample.is_published? }
-            policy.access_type = Policy::VISIBLE
+            policy.access_type = Policy::ACCESSIBLE
           else
             policy.access_type = Policy::NO_ACCESS
           end
           # Visible to each project
           st.projects.map do |project|
-            policy.permissions << Permission.new(contributor_type: Permission::PROJECT, contributor_id: project.id, access_type: Policy::VISIBLE)
+            policy.permissions << Permission.new(contributor_type: Permission::PROJECT, contributor_id: project.id, access_type: Policy::ACCESSIBLE)
           end
           # Project admins can manage
           project_admins = st.projects.map(&:project_administrators).flatten
@@ -125,7 +126,22 @@ namespace :seek do
         counter += 1
       end
     end
-    puts "...Added policies to #{counter} sample types"
+    puts "... Added policies to #{counter} sample types"
+  end
+
+  task(fix_previous_sample_type_permissions: [:environment]) do
+    only_once('fix_previous_sample_type_permissions 1.16.0') do
+      puts '... Updating previous sample type permissions ...'
+      SampleType.includes(:policy).where.not(policy_id: nil).each do |sample_type|
+        policy = sample_type.policy
+        if policy.access_type == Policy::VISIBLE
+          policy.update_column(:access_type, Policy::ACCESSIBLE)
+        end
+        policy.permissions.where(access_type: Policy::VISIBLE).where(contributor_type: Permission::PROJECT).update_all(access_type: Policy::ACCESSIBLE)
+        putc('.')
+      end
+      puts '... Finished updating previous sample type permissions'
+    end
   end
 
   private

--- a/test/unit/sample_type_test.rb
+++ b/test/unit/sample_type_test.rb
@@ -114,6 +114,13 @@ class SampleTypeTest < ActiveSupport::TestCase
     end
   end
 
+  test 'not an asset or downloadable' do
+    st = FactoryBot.create(:simple_sample_type)
+    refute st.is_asset?
+    refute st.is_downloadable?
+    refute st.is_downloadable_asset?
+  end
+
   test 'validate title and decription length' do
     long_desc = ('a' * 65536).freeze
     ok_desc = ('a' * 65535).freeze


### PR DESCRIPTION
Override methods to prevent sample types being treated as a downloadable asset. This means it behaves more like Samples, Investigation, Studies and Assays, and the permission options don't include a Download option (however, the ACCESSIBLE access type is applied).

Also updated the upgrade task to apply ACCESSIBLE instead of VIEWABLE, and a new task to update the previously applied permissions.

Although unlikely to be the case, the Download template option isn't shown if viewable but not accessible.

* addresses #2084 
* a side effect also fixed #2076 as the asset actions, with the download button, are no longer shown for list items.