### PR TITLE
updated help links for extended metadata to point to the website 

### DIFF
--- a/config/help_links.yml
+++ b/config/help_links.yml
@@ -31,7 +31,7 @@ Document: https://docs.seek4science.org/help/user-guide/adding-assets.html
 Presentation: https://docs.seek4science.org/help/user-guide/adding-assets.html
 Event: https://docs.seek4science.org/help/user-guide/general-attributes.html#events
 clipboard_api_mozilla: https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API
-ExtendedMetadataType: https://docs.seek4science.org/tech/extended-metadata
-extended_metadata_technical_overview: https://github.com/seek4science/seek-documentation/blob/gh-pages-extended_metadata-type/tech/extended_metadata/extended-metadata-type.md
-extended_metadata_type_json_schema: https://github.com/seek4science/seek-documentation/blob/gh-pages-extended_metadata-type/tech/extended_metadata/extended_metadata_type_schema.json
-extended_metadata_type_example: https://github.com/seek4science/seek-documentation/blob/gh-pages-extended_metadata-type/tech/extended_metadata/a-complete-example.md
+ExtendedMetadataType: https://docs.seek4science.org/tech/extended-metadata/extended-metadata-type.html
+extended_metadata_technical_overview: https://docs.seek4science.org/tech/extended-metadata/extended-metadata-type.html
+extended_metadata_type_json_schema: https://docs.seek4science.org/tech/extended-metadata/extended-metadata-type-schema.json
+extended_metadata_type_example: https://docs.seek4science.org/tech/extended-metadata/a-complete-example.html


### PR DESCRIPTION
* fix for #2080

also updated the links and added redirect for the moved page in the documentation - https://github.com/seek4science/seek-documentation/commit/5f0830a8707e5efc9a7af292b2e42bba477203a6 - and tested

There will a brief period where the links will point to pages that are not yet live, but only on sites we administer and will be fine once released.