### PR TITLE
Fix workflow UI issues

### DIFF
--- a/app/views/workflows/show.html.erb
+++ b/app/views/workflows/show.html.erb
@@ -29,11 +29,12 @@
 
         <% begin %>
           <% if @display_workflow.diagram_exists? || @display_workflow.can_render_diagram? %>
+            <% diagram_path = diagram_workflow_path(@workflow, version: @display_workflow.version) %>
+            <% is_svg = @display_workflow&.diagram.extension == 'svg' %>
             <div class="row">
               <div class="col-md-12">
                 <div class="workflow-diagram">
-                  <% diagram_path = diagram_workflow_path(@workflow, version: @display_workflow.version) %>
-                  <% if @display_workflow&.diagram.extension == 'svg' %>
+                  <% if is_svg %>
                     <%= content_tag(:embed, '', type: 'image/svg+xml', src: diagram_path, class: 'svg-pan-zoom', width: 1000, height: 500)  %>
                     <p class="help-block">Click and drag the diagram to pan, double click or use the controls to zoom.</p>
                   <% else %>
@@ -44,7 +45,7 @@
             </div>
           <% end %>
         <% rescue StandardError => e %>
-          <% raise e if Rails.env.development? %>
+          <% raise e unless Rails.env.production? %>
           <% Rails.logger.error(e.inspect) %>
           <% Rails.logger.error(e.backtrace.join("\n")) %>
           <div class="alert alert-warning">Could not render the workflow diagram.</div>

--- a/app/views/workflows/show.html.erb
+++ b/app/views/workflows/show.html.erb
@@ -30,7 +30,7 @@
         <% begin %>
           <% if @display_workflow.diagram_exists? || @display_workflow.can_render_diagram? %>
             <% diagram_path = diagram_workflow_path(@workflow, version: @display_workflow.version) %>
-            <% is_svg = @display_workflow&.diagram.extension == 'svg' %>
+            <% is_svg = @display_workflow&.diagram&.extension == 'svg' %>
             <div class="row">
               <div class="col-md-12">
                 <div class="workflow-diagram">

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -403,4 +403,12 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_equal "<p>&amp;&amp; &quot;&quot; &lt; &gt;\n<code>&amp;&amp;</code></p>\n", text_or_not_specified("&& \"\" < >\n```&&```\n\n", markdown: true).to_s
     assert_equal "&amp;&amp; \"\" &lt; &gt;\n```&amp;&amp;```\n\n", text_or_not_specified("&& \"\" < >\n```&&```\n\n", markdown: false).to_s
   end
+
+  test 'markdown generation allows tables without compromising HTML sanitization' do
+    assert_equal "<table><tr><td>hey</td></tr></table>\n",
+                 text_or_not_specified("<table><tr><td>hey</td></tr></table>", markdown: true).to_s
+    assert_equal "<table><tr><td>\nalert('hi');hey</td></tr></table>\n",
+                 text_or_not_specified("<table><tr><td><script>alert('hi');</script>hey</td></tr></table>", markdown: true).to_s
+  end
+
 end


### PR DESCRIPTION
- Changes markdown description rendering to allows `<table>` (and related) tags.
- Changes workflow diagram rendering view to not catch exceptions mid-way through rendering.
