### PR TITLE
Better message for querying samples

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -247,7 +247,7 @@ class SamplesController < ApplicationController
       end
     end
 
-    if params[:input_template_id].present? # linked
+    if params[:input_template_id].present? && params[:input_attribute_id].present? # linked
       input_template_attribute =
         TemplateAttribute.find(params[:input_attribute_id])
       @result = filter_linked_samples(@result, :linked_samples,
@@ -256,7 +256,7 @@ class SamplesController < ApplicationController
           template_id: params[:input_template_id] }, input_template_attribute)
     end
 
-    if params[:output_template_id].present? # linking
+    if params[:output_template_id].present? && params[:output_attribute_id].present? # linking
       output_template_attribute =
         TemplateAttribute.find(params[:output_attribute_id])
       @result = filter_linked_samples(@result, :linking_samples,

--- a/app/views/samples/query.js.erb
+++ b/app/views/samples/query.js.erb
@@ -1,3 +1,3 @@
 $j('#samples-table').html('<%= escape_javascript(render(partial: "table_view", locals: { samples: @result, link: true, show_extra_info: true })) -%>');
-$j('#sample-count').html('<%= "#{@visible_samples} sample(s) visible to you" %>')
+$j('#sample-count').html('<span><%= "#{@visible_samples}"%> sample(s) visible to you' + '</span> - <span class=\"text-success\"> Successful query @ <%= "#{Time.now.strftime("%d/%m/%Y %H:%M:%S")}" %></span>')
 Samples.initTable($j('#samples-table'), false, { hideEmptyColumns: true });

--- a/app/views/samples/query_form.html.erb
+++ b/app/views/samples/query_form.html.erb
@@ -121,6 +121,9 @@
 	<div class="row">
 		<div class="col-md-4" style="margin-bottom:20px">
 			<button id="btn_submit" class="btn btn-primary" onclick="submit()">Query</button>
+			<div id= "sample-query-spinner">
+				<%= image("spinner") %>
+			</div>
 			<br>
 			<em id="sample-count"></em>
 		</div>
@@ -137,6 +140,7 @@
 	$j(document).ready(function () {
 		initSelect2($j('.select2'), $j('#query_samples'))
 		Samples.initTable($j('#samples-table'));
+		$j('#sample-query-spinner').hide();
 	});
 
 	$j("#template").on("change", function(){
@@ -187,7 +191,17 @@
 		$j.ajax({
 				url: "<%=query_samples_path%>",
 				method: "POST",
-				data
+				data,
+				beforeSend: function(){
+					$j("#sample-query-spinner").show();
+					$j('#samples-table').html("");
+				},
+				error: function(err){
+					$j('#sample-count').html(`<b><p class="text-danger">Error [code ${err.status}]: Failed to fetch query results!</p></b>`)
+				},
+				complete: function(){
+					$j("#sample-query-spinner").hide()
+				}
 		})
 	}
 </script>

--- a/app/views/samples/query_form.html.erb
+++ b/app/views/samples/query_form.html.erb
@@ -193,6 +193,7 @@
 				method: "POST",
 				data,
 				beforeSend: function(){
+					$j('#sample-count').html("");
 					$j("#sample-query-spinner").show();
 					$j('#samples-table').html("");
 				},


### PR DESCRIPTION
- Doesn't fail if attribute is not selected
 - Provides a message when a query fails
 - Provides an error message when an error occurs
 - Spinner is added to indicate a running query
 - closes #2096 