### PR TITLE
Filter and sort sample queries

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -265,6 +265,25 @@ class SamplesController < ApplicationController
           template_id: params[:output_template_id] }, output_template_attribute)
     end
 
+    ####################################################################################################################
+    # Filtering by date range
+    ####################################################################################################################
+    if params[:filter_begin_date_created].present?
+      @result = @result.select { |s| s.created_at >= params[:filter_begin_date_created].to_date }
+    end
+
+    if params[:filter_end_date_created].present?
+      @result = @result.select { |s| s.created_at <= params[:filter_end_date_created].to_date }
+    end
+
+    if params[:filter_begin_date_updated].present?
+      @result = @result.select { |s| s.updated_at >= params[:filter_begin_date_updated].to_date }
+    end
+
+    if params[:filter_end_date_updated].present?
+      @result = @result.select { |s| s.updated_at <= params[:filter_end_date_updated].to_date }
+    end
+
     @result = @result.select { |s| (project_ids & s.project_ids).any? } if project_ids.present?
     @total_samples = @result.length
     @result = @result.any? ? @result.authorized_for('view') : []

--- a/app/views/samples/_table_view.html.erb
+++ b/app/views/samples/_table_view.html.erb
@@ -24,7 +24,13 @@
                     <th <%= 'data-title-column="true" ' if (attribute.is_title && link) -%>data-accessor-name="<%= attribute.accessor_name -%>" data-column-type="<%= attribute.sample_attribute_type.base_type-%>" data-search-title="<%= attribute.title %>">
                       <%= sample_attribute_display_title(attribute) %>
                     </th>
-                <% end %>
+								<% end %>
+								<th>
+									Date created
+								</th>
+								<th>
+									Date updated
+								</th>
               </tr>
           <% end %>
       <% end %>
@@ -57,6 +63,8 @@
                           <td><%= display_attribute(sample, attribute, link: link) %></td>
                       <% end %>
                   <% end %>
+									<td><%= sample.created_at %></td>
+									<td><%= sample.updated_at %></td>
               <% end %>
           <% end %>
           </tbody>

--- a/app/views/samples/query_form.html.erb
+++ b/app/views/samples/query_form.html.erb
@@ -116,7 +116,29 @@
 				<input id="output_attribute_value" class="form-control"/>
 			</div>
 		</div>
-	<% end %>
+		<div class="row">
+			<div class="col-md-4">
+				<h4>
+					Select date range
+				</h4>
+			</div>
+		</div>
+		<div class="row">
+			<div class="col-md-4">
+				<label>Begin date created</label>
+				<input id="filter_begin_date_created" type="date" class="form-control"></input >
+				<label>End date created</label>
+				<input id="filter_end_date_created" type="date" class="form-control"></input >
+			</div>
+			<div class="col-md-4">
+				<label>Begin date updated</label>
+				<input id="filter_begin_date_updated" type="date" class="form-control"></input >
+				<label>End date updated</label>
+				<input id="filter_begin_date_updated" type="date" class="form-control"></input >
+			</div>
+		</div>
+
+<% end %>
 
 	<div class="row">
 		<div class="col-md-4" style="margin-bottom:20px">
@@ -187,6 +209,10 @@
 			output_template_id: $j("#output_template").val(),
 			output_attribute_id: $j("#output_template_attribute").val(),
 			output_attribute_value: $j("#output_attribute_value").val(),
+			filter_begin_date_created: $j("#filter_begin_date_created").val(),
+			filter_end_date_created: $j("#filter_end_date_created").val(),
+			filter_begin_date_updated: $j("#filter_begin_date_updated").val(),
+			filter_end_date_updated: $j("#filter_end_date_updated").val()
 		}
 		$j.ajax({
 				url: "<%=query_samples_path%>",

--- a/test/functional/samples_controller_test.rb
+++ b/test/functional/samples_controller_test.rb
@@ -1439,6 +1439,117 @@ class SamplesControllerTest < ActionController::TestCase
     end
   end
 
+  test 'should filter samples according to the dates created and updated' do
+    with_config_value(:isa_json_compliance_enabled, true) do
+      person = FactoryBot.create(:person)
+      project = FactoryBot.create(:project)
+
+      login_as(person)
+
+      template1 = FactoryBot.create(:isa_source_template)
+
+      sample_type = FactoryBot.create(:simple_sample_type, contributor: person, project_ids: [project.id],
+                                title: 'Source sample type', template_id: template1.id)
+      sample_type.create_sample_attributes_from_isa_template(template1)
+
+      # Create Samples at three different dates
+      travel_to(Time.zone.local(2024, 9, 1, 12, 0, 0))
+      source1 = FactoryBot.create :sample, title: 'Source 1', sample_type: sample_type, project_ids: [project.id], contributor: person,
+                                  data: { 'Source Name': 'Source 1', 'Source Characteristic 1': 'Source Characteristic A', 'Source Characteristic 2': "Cox's Orange Pippin" }
+
+      travel_to(Time.zone.local(2024, 9, 8, 12, 0, 0))
+      source2 = FactoryBot.create :sample, title: 'Source 2', sample_type: sample_type, project_ids: [project.id], contributor: person,
+                        data: { 'Source Name': 'Source 2', 'Source Characteristic 1': 'Source Characteristic B', 'Source Characteristic 2': "Cox's Orange Pippin" }
+
+      travel_to(Time.zone.local(2024, 9, 15, 12, 0, 0))
+      source3 = FactoryBot.create :sample, title: 'Source 3', sample_type: sample_type, project_ids: [project.id], contributor: person,
+                        data: { 'Source Name': 'Source 3', 'Source Characteristic 1': 'Source Characteristic C', 'Source Characteristic 2': "Cox's Orange Pippin" }
+
+      travel_back
+
+      # Query for samples created on 2024-09-01 or later
+      post :query, xhr: true, params: {
+        project_ids: [project.id],
+        template_id: template1.id,
+        template_attribute_id: template1.template_attributes.first.id,
+        template_attribute_value: 'source',
+        filter_begin_date_created: '2024-09-01'
+      }
+
+      assert_response :success
+
+      result = assigns(:result)
+      assert_equal 3, result.length
+
+      # Query for samples created on 2024-09-02 or later
+      post :query, xhr: true, params: {
+        project_ids: [project.id],
+        template_id: template1.id,
+        template_attribute_id: template1.template_attributes.first.id,
+        template_attribute_value: 'source',
+        filter_begin_date_created: '2024-09-02'
+      }
+
+      assert_response :success
+
+      result = assigns(:result)
+      assert_equal 2, result.length
+
+      # Query for samples created between 2024-09-05 and 2024-09-10
+      post :query, xhr: true, params: {
+        project_ids: [project.id],
+        template_id: template1.id,
+        template_attribute_id: template1.template_attributes.first.id,
+        template_attribute_value: 'source',
+        filter_begin_date_created: '2024-09-05',
+        filter_end_date_created: '2024-09-10'
+      }
+
+      assert_response :success
+
+      result = assigns(:result)
+      assert_equal 1, result.length
+      assert_equal 'Source 2', result.first['title']
+
+      # Update the first sample
+      travel_to(Time.zone.local(2024, 9, 20, 12, 0, 0))
+      source1.update!(external_identifier: 's1')
+      source2.update!(external_identifier: 's2')
+      travel_to(Time.zone.local(2024, 9, 25, 12, 0, 0))
+      source3.update!(external_identifier: 's3')
+
+
+      travel_back
+      # Query for samples updated between 2024-09-20 or 2024-09-21
+      post :query, xhr: true, params: {
+        project_ids: [project.id],
+        template_id: template1.id,
+        template_attribute_id: template1.template_attributes.first.id,
+        template_attribute_value: 'source',
+        filter_begin_date_updated: '2024-09-20',
+        filter_end_date_updated: '2024-09-21'
+      }
+
+      assert_response :success
+
+      result = assigns(:result)
+      assert_equal 2, result.length
+
+      # Query for samples updated before 2024-09-26
+      post :query, xhr: true, params: {
+        project_ids: [project.id],
+        template_id: template1.id,
+        template_attribute_id: template1.template_attributes.first.id,
+        template_attribute_value: 'source',
+        filter_end_date_updated: '2024-09-26'
+      }
+
+      result = assigns(:result)
+      assert_equal 3, result.length
+
+    end
+  end
+
   test 'form hides private linked multi samples' do
     person = FactoryBot.create(:person)
     login_as(person)


### PR DESCRIPTION
- Adds date created and date updated to the query results table
- Adds filters to further filter the results on dates created and dates updated.
- Closes #2111 

## Screeshot:
#### Before filtering on date:
![image](https://github.com/user-attachments/assets/cf7a61ea-39ac-44c6-a809-7bf1b816466b)


#### Filtering on creation date
Between 12/08/2024 & 01/11/2025
![image](https://github.com/user-attachments/assets/3dace87f-b5ef-4ed4-803d-d4e3576920a1)


#### Filtering on date updated
Everything after 01/13/2025
![image](https://github.com/user-attachments/assets/efc718e1-9d29-45d2-bb36-fd3673ffde2e)
