### PR TITLE
Fix can_publish? for Observation Units

### DIFF
--- a/app/models/observation_unit.rb
+++ b/app/models/observation_unit.rb
@@ -33,14 +33,6 @@ class ObservationUnit < ApplicationRecord
     [contributor]
   end
 
-  def is_in_isa_publishable?
-    false
-  end
-
-  def can_publish?
-    false
-  end
-
   def related_people
     (creators + contributors).compact.uniq
   end

--- a/test/factories/observation_units.rb
+++ b/test/factories/observation_units.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory(:observation_unit) do
     title { 'Observation Unit' }
     description { 'very simple obs unit'}
-    policy { FactoryBot.create(:public_policy) }
     association :contributor, factory: :person, strategy: :create
     after(:build) do |a|
       a.study ||= FactoryBot.create(:study, contributor: a.contributor)
@@ -11,6 +10,7 @@ FactoryBot.define do
 
   factory(:min_observation_unit, parent: :observation_unit) do
     title { 'A Minimal Observation Unit' }
+    policy { FactoryBot.create(:public_policy) }
     association :study, factory: :study, strategy: :create
     description { nil }
   end

--- a/test/unit/permissions/publishing_permissions_test.rb
+++ b/test/unit/permissions/publishing_permissions_test.rb
@@ -52,7 +52,7 @@ class PublishingPermissionsTest < ActiveSupport::TestCase
       refute item.gatekeeper_required?
 
       case item.class.name
-      when 'Study', 'Assay'
+      when 'Study', 'Assay', 'ObservationUnit'
         disable_authorization_checks { item.investigation.projects = gatekeeper.projects }
       else
         disable_authorization_checks { item.projects = gatekeeper.projects }
@@ -371,12 +371,17 @@ class PublishingPermissionsTest < ActiveSupport::TestCase
       FactoryBot.create(type, contributor: contributor, projects: contributor&.projects)
     end
 
+    #projects handled differently
     study = FactoryBot.create(:study, contributor: contributor,
                               investigation: FactoryBot.create(:investigation, projects: contributor&.projects)
     )
     assay = FactoryBot.create(:assay, contributor: contributor, study:
       FactoryBot.create(:study, contributor: contributor, investigation: FactoryBot.create(:investigation, projects: contributor&.projects))
     )
-    items | [study, assay]
+    obs_unit = FactoryBot.create(:observation_unit, contributor: contributor, policy: FactoryBot.create(:private_policy), study:
+      FactoryBot.create(:study, contributor: contributor, investigation: FactoryBot.create(:investigation, projects: contributor&.projects))
+    )
+    items | [study, assay, obs_unit]
+    [obs_unit]
   end
 end

--- a/test/unit/permissions/publishing_permissions_test.rb
+++ b/test/unit/permissions/publishing_permissions_test.rb
@@ -378,7 +378,7 @@ class PublishingPermissionsTest < ActiveSupport::TestCase
     assay = FactoryBot.create(:assay, contributor: contributor, study:
       FactoryBot.create(:study, contributor: contributor, investigation: FactoryBot.create(:investigation, projects: contributor&.projects))
     )
-    obs_unit = FactoryBot.create(:observation_unit, contributor: contributor, policy: FactoryBot.create(:private_policy), study:
+    obs_unit = FactoryBot.create(:observation_unit, contributor: contributor, study:
       FactoryBot.create(:study, contributor: contributor, investigation: FactoryBot.create(:investigation, projects: contributor&.projects))
     )
     items | [study, assay, obs_unit]

--- a/test/unit/permissions/publishing_permissions_test.rb
+++ b/test/unit/permissions/publishing_permissions_test.rb
@@ -3,57 +3,65 @@ require 'test_helper'
 class PublishingPermissionsTest < ActiveSupport::TestCase
 
   test 'is_rejected?' do
-    df = FactoryBot.create(:data_file)
-    assert !df.is_rejected?
+    items_for_publishing_tests.each do |item|
+      item = FactoryBot.create(:data_file)
+      assert !item.is_rejected?
 
-    ResourcePublishLog.add_log(ResourcePublishLog::REJECTED, df)
-    assert df.is_rejected?
-
+      ResourcePublishLog.add_log(ResourcePublishLog::REJECTED, item)
+      assert item.is_rejected?
+    end
   end
 
   test 'is_updated_since_be_rejected?' do
     person = FactoryBot.create(:person, project:FactoryBot.create(:asset_gatekeeper).projects.first)
 
     User.with_current_user person.user do
-      df = FactoryBot.create(:data_file, contributor: person, projects: person.projects)
-      assert !df.is_rejected?
+      items_for_publishing_tests(person).each do |item|
+        assert !item.is_rejected?
 
-      ResourcePublishLog.add_log(ResourcePublishLog::REJECTED, df)
-      assert df.is_rejected?
+        ResourcePublishLog.add_log(ResourcePublishLog::REJECTED, item)
+        assert item.is_rejected?
 
-      df.title = 'new title'
-      df.updated_at = Time.now + 1.day
-      df.save!
+        item.title = 'new title'
+        item.updated_at = Time.now + 1.day
+        item.save!
 
-      assert df.is_updated_since_be_rejected?
-      assert df.can_publish?
+        assert item.is_updated_since_be_rejected?
+        assert item.can_publish?
+      end
     end
 
   end
 
   test 'is_waiting_approval?' do
-    User.with_current_user FactoryBot.create(:user) do
-      df = FactoryBot.create(:data_file)
-      assert !df.is_waiting_approval?
-      assert !df.is_waiting_approval?(User.current_user)
+    items_for_publishing_tests.each do |item|
+      assert !item.is_waiting_approval?
+      assert !item.is_waiting_approval?(User.current_user)
 
-      log = ResourcePublishLog.add_log(ResourcePublishLog::WAITING_FOR_APPROVAL, df)
-      assert df.is_waiting_approval?
-      assert df.is_waiting_approval?(User.current_user)
-
+      log = ResourcePublishLog.add_log(ResourcePublishLog::WAITING_FOR_APPROVAL, item)
+      assert item.is_waiting_approval?
+      assert item.is_waiting_approval?(User.current_user)
     end
   end
 
   test 'gatekeeper_required?' do
-    df = FactoryBot.create(:data_file)
-    assert !df.gatekeeper_required?
+    items_for_publishing_tests.each do |item|
+      assert !item.gatekeeper_required?
 
-    gatekeeper = FactoryBot.create(:asset_gatekeeper)
-    assert !df.gatekeeper_required?
+      gatekeeper = FactoryBot.create(:asset_gatekeeper)
+      refute item.gatekeeper_required?
 
-    disable_authorization_checks { df.projects = gatekeeper.projects }
-    df.reload
-    assert df.gatekeeper_required?
+      case item.class.name
+      when 'Study', 'Assay'
+        disable_authorization_checks { item.investigation.projects = gatekeeper.projects }
+      else
+        disable_authorization_checks { item.projects = gatekeeper.projects }
+      end
+
+      item.reload
+      assert item.gatekeeper_required?
+    end
+
   end
 
   test 'is_published?' do
@@ -62,11 +70,13 @@ class PublishingPermissionsTest < ActiveSupport::TestCase
       not_public_model = FactoryBot.create(:model, policy: FactoryBot.create(:public_policy, access_type: Policy::VISIBLE))
       public_datafile = FactoryBot.create(:data_file, policy: FactoryBot.create(:public_policy))
       public_assay = FactoryBot.create(:assay, policy: FactoryBot.create(:public_policy, access_type: Policy::VISIBLE))
+      public_obs_unit = FactoryBot.create(:observation_unit, policy: FactoryBot.create(:public_policy, access_type: Policy::VISIBLE))
 
       assert public_sop.is_published?
       assert !not_public_model.is_published?
       assert public_datafile.is_published?
       assert public_assay.is_published?
+      assert public_obs_unit.is_published?
     end
   end
 
@@ -79,156 +89,173 @@ class PublishingPermissionsTest < ActiveSupport::TestCase
     assert !FactoryBot.create(:study).is_in_isa_publishable?
     assert !FactoryBot.create(:event).is_in_isa_publishable?
     assert !FactoryBot.create(:publication).is_in_isa_publishable?
+    refute FactoryBot.create(:observation_unit).is_in_isa_publishable?
   end
 
   test 'publishable when item is manageable and is not yet published and gatekeeper is not required' do
     user = FactoryBot.create(:user)
     User.with_current_user user do
-      df = FactoryBot.create(:data_file, contributor: user.person)
-      assert df.can_manage?, 'This item must be manageable for the test to succeed'
-      assert !df.is_published?, 'This item must be not published for the test to succeed'
-      assert !df.gatekeeper_required?, 'This item must not require gatekeeper for the test to succeed'
+      items_for_publishing_tests(user.person).each do |item|
+        assert item.can_manage?, 'This item must be manageable for the test to succeed'
+        assert !item.is_published?, 'This item must be not published for the test to succeed'
+        assert !item.gatekeeper_required?, 'This item must not require gatekeeper for the test to succeed'
 
-      assert df.can_publish?, 'This item should be publishable'
+        assert item.can_publish?, 'This item should be publishable'
+      end
     end
   end
 
   test 'publishable when item is manageable and is not yet published and gatekeeper is required and is not waiting for approval and is not rejected' do
     person = FactoryBot.create(:person, project:FactoryBot.create(:asset_gatekeeper).projects.first)
     User.with_current_user person.user do
-      df = FactoryBot.create(:data_file, contributor: person, projects: person.projects)
-      assert df.can_manage?, 'This item must be manageable for the test to succeed'
-      refute df.is_published?, 'This item must be not published for the test to succeed'
-      assert df.gatekeeper_required?, 'This item must require gatekeeper for the test to be meaningful'
-      refute df.is_waiting_approval?(User.current_user), 'This item must not be waiting for approval for the test to be meaningful'
-      refute df.is_rejected?, 'This item must require gatekeeper for the test to be meaningful'
+      items_for_publishing_tests(person).each do |item|
+        assert item.can_manage?, 'This item must be manageable for the test to succeed'
+        refute item.is_published?, 'This item must be not published for the test to succeed'
+        assert item.gatekeeper_required?, 'This item must require gatekeeper for the test to be meaningful'
+        refute item.is_waiting_approval?(User.current_user), 'This item must not be waiting for approval for the test to be meaningful'
+        refute item.is_rejected?, 'This item must require gatekeeper for the test to be meaningful'
 
-      assert df.can_publish?, 'This item should be publishable'
+        assert item.can_publish?, 'This item should be publishable'
+      end
     end
   end
 
   test 'not publishable when item is not manageable' do
     user = FactoryBot.create(:user)
     User.with_current_user user do
-      df = FactoryBot.create(:data_file, policy: FactoryBot.create(:all_sysmo_viewable_policy))
-      assert !df.can_manage?, 'This item must be manageable for the test to succeed'
-      assert !df.is_published?, 'This item must be not published for the test to be meaningful'
-      assert !df.gatekeeper_required?, 'This item must require gatekeeper for the test to be meaningful'
+      items_for_publishing_tests.each do |item|
+        item.policy = FactoryBot.create(:all_sysmo_viewable_policy)
+        disable_authorization_checks { item.save! }
+        assert !item.can_manage?, 'This item must be manageable for the test to succeed'
+        assert !item.is_published?, 'This item must be not published for the test to be meaningful'
+        assert !item.gatekeeper_required?, 'This item must require gatekeeper for the test to be meaningful'
 
-      assert !df.can_publish?, 'This item should not be publishable'
+        assert !item.can_publish?, 'This item should not be publishable'
+      end
     end
   end
 
   test 'not publishable when item is already published' do
     user = FactoryBot.create(:user)
     User.with_current_user user do
-      df = FactoryBot.create(:data_file, policy: FactoryBot.create(:public_policy))
-      assert df.can_manage?, 'This item must be manageable for the test to be meaningful'
-      assert df.is_published?, 'This item must be not published for the test to succeed'
-      assert !df.gatekeeper_required?, 'This item must require gatekeeper for the test to be meaningful'
+      items_for_publishing_tests.each do |item|
+        item.policy = FactoryBot.create(:public_policy)
+        disable_authorization_checks { item.save! }
+        assert item.can_manage?, 'This item must be manageable for the test to be meaningful'
+        assert item.is_published?, 'This item must be not published for the test to succeed'
+        assert !item.gatekeeper_required?, 'This item must require gatekeeper for the test to be meaningful'
 
-      assert !df.can_publish?, 'This item should not be publishable'
+        assert !item.can_publish?, 'This item should not be publishable'
+      end
+
     end
   end
 
   test 'not publishable when item is waiting for approval' do
     person = FactoryBot.create(:person,project: FactoryBot.create(:asset_gatekeeper).projects.first)
     User.with_current_user person.user do
-      df = FactoryBot.create( :data_file, contributor: person, projects: person.projects )
-      df.resource_publish_logs.create(publish_state: ResourcePublishLog::WAITING_FOR_APPROVAL, user: User.current_user)
-      assert df.can_manage?, 'This item must be manageable for the test to be meaningful'
-      refute df.is_published?, 'This item must be not published for the test to be meaningful'
-      assert df.gatekeeper_required?, 'This item must require gatekeeper for the test to succeed'
-      assert df.is_waiting_approval?(User.current_user), 'This item must be waiting for approval for the test to succeed'
-      refute df.is_rejected?, 'This item must not be rejected for the test to be meaningful'
+      items_for_publishing_tests(person).each do |item|
+        item.resource_publish_logs.create(publish_state: ResourcePublishLog::WAITING_FOR_APPROVAL, user: User.current_user)
+        assert item.can_manage?, 'This item must be manageable for the test to be meaningful'
+        refute item.is_published?, 'This item must be not published for the test to be meaningful'
+        assert item.gatekeeper_required?, 'This item must require gatekeeper for the test to succeed'
+        assert item.is_waiting_approval?(User.current_user), 'This item must be waiting for approval for the test to succeed'
+        refute item.is_rejected?, 'This item must not be rejected for the test to be meaningful'
 
-      refute df.can_publish?, 'This item should not be publishable'
+        refute item.can_publish?, 'This item should not be publishable'
+      end
     end
   end
 
   test 'not publishable when item was rejected and but publishable again when item was updated' do
     person = FactoryBot.create(:person,project:FactoryBot.create(:asset_gatekeeper).projects.first)
-    df = FactoryBot.create(:data_file, contributor: person, projects:person.projects )
     User.with_current_user person.user do
-      df.resource_publish_logs.create(publish_state: ResourcePublishLog::REJECTED)
-      assert df.can_manage?, 'This item must be manageable for the test to be meaningful'
-      refute df.is_published?, 'This item must be not published for the test to be meaningful'
-      assert df.gatekeeper_required?, 'This item must require gatekeeper for the test to succeed'
-      refute df.is_waiting_approval?(User.current_user), 'This item must be waiting for approval for the test to be meaningful'
-      assert df.is_rejected?, 'This item must not be rejected for the test to succeed'
-      df.title = 'new title'
-      df.updated_at = Time.now + 1.day
-      df.save!
-      assert df.is_updated_since_be_rejected?
-      assert df.can_publish?, 'This item should be publishable after update'
+      items_for_publishing_tests(person).each do |item|
+        item.resource_publish_logs.create(publish_state: ResourcePublishLog::REJECTED)
+        assert item.can_manage?, 'This item must be manageable for the test to be meaningful'
+        refute item.is_published?, 'This item must be not published for the test to be meaningful'
+        assert item.gatekeeper_required?, 'This item must require gatekeeper for the test to succeed'
+        refute item.is_waiting_approval?(User.current_user), 'This item must be waiting for approval for the test to be meaningful'
+        assert item.is_rejected?, 'This item must not be rejected for the test to succeed'
+        item.title = 'new title'
+        item.updated_at = Time.now + 1.day
+        item.save!
+        assert item.is_updated_since_be_rejected?
+        assert item.can_publish?, 'This item should be publishable after update'
+      end
     end
   end
 
   test 'gatekeeper of asset can publish if they can manage it as well' do
     gatekeeper = FactoryBot.create(:asset_gatekeeper)
-    datafile = FactoryBot.create(:data_file, projects: gatekeeper.projects, contributor: gatekeeper)
-
     User.with_current_user gatekeeper.user do
-      assert gatekeeper.is_asset_gatekeeper_of?(datafile), 'The gatekeeper must be the gatekeeper of the datafile for the test to succeed'
-      assert datafile.can_manage?, 'The datafile must be manageable for the test to succeed'
+      items_for_publishing_tests(gatekeeper).each do |item|
+        assert gatekeeper.is_asset_gatekeeper_of?(item), 'The gatekeeper must be the gatekeeper of the item for the test to succeed'
+        assert item.can_manage?, 'The item must be manageable for the test to succeed'
 
-      assert datafile.can_publish?, 'This datafile should be publishable'
+        assert item.can_publish?, 'This item should be publishable'
+      end
     end
   end
 
   test 'gatekeeper of asset can publish, if the asset is waiting for his approval' do
     gatekeeper = FactoryBot.create(:asset_gatekeeper)
-    person = FactoryBot.create(:person,project:gatekeeper.projects.first)
-    datafile = FactoryBot.create(:data_file, projects: gatekeeper.projects, contributor:person)
-    datafile.resource_publish_logs.create(publish_state: ResourcePublishLog::WAITING_FOR_APPROVAL, user: datafile.contributor.user)
+    person = FactoryBot.create(:person, project:gatekeeper.projects.first)
+    items_for_publishing_tests(person).each do |item|
+      item.resource_publish_logs.create(publish_state: ResourcePublishLog::WAITING_FOR_APPROVAL, user: item.contributor.user)
 
-    User.with_current_user gatekeeper.user do
-      assert gatekeeper.is_asset_gatekeeper_of?(datafile), 'The gatekeeper must be the gatekeeper of datafile for the test to succeed'
-      assert !datafile.can_manage?, 'The datafile must be manageable for the test to be meaningful'
-      assert datafile.is_waiting_approval?, 'The datafile must be waiting for approval for the test to succeed'
+      User.with_current_user gatekeeper.user do
+        assert gatekeeper.is_asset_gatekeeper_of?(item), 'The gatekeeper must be the gatekeeper of the item for the test to succeed'
+        assert !item.can_manage?, 'The item must be manageable for the test to be meaningful'
+        assert item.is_waiting_approval?, 'The item must be waiting for approval for the test to succeed'
 
-      assert datafile.can_publish?, 'This datafile should be publishable'
+        assert item.can_publish?, 'This item should be publishable'
+      end
     end
   end
 
   test 'gatekeeper can not publish asset which he is not the gatekeeper of' do
     gatekeeper = FactoryBot.create(:asset_gatekeeper)
-    datafile = FactoryBot.create(:data_file)
-    datafile.resource_publish_logs.create(publish_state: ResourcePublishLog::WAITING_FOR_APPROVAL, user: datafile.contributor.user)
+    items_for_publishing_tests.each do |item|
+      item.resource_publish_logs.create(publish_state: ResourcePublishLog::WAITING_FOR_APPROVAL, user: item.contributor.user)
 
-    User.with_current_user gatekeeper.user do
-      assert !gatekeeper.is_asset_gatekeeper_of?(datafile), 'The gatekeeper must not be the gatekeeper of datafile for the test to be succeed'
-      assert datafile.is_waiting_approval?, 'The datafile must be waiting for approval for the test to be meaningful'
+      User.with_current_user gatekeeper.user do
+        assert !gatekeeper.is_asset_gatekeeper_of?(item), 'The gatekeeper must not be the gatekeeper of the item for the test to be succeed'
+        assert item.is_waiting_approval?, 'The item must be waiting for approval for the test to be meaningful'
 
-      assert !datafile.can_publish?, 'This datafile should not be publishable'
+        assert !item.can_publish?, 'This item should not be publishable'
+      end
     end
   end
 
   test 'gatekeeper of asset can not publish, if they can not manage and the asset is not waiting for his approval' do
     gatekeeper = FactoryBot.create(:asset_gatekeeper)
     person = FactoryBot.create(:person,project:gatekeeper.projects.first)
-    datafile = FactoryBot.create(:data_file, contributor:person)
 
     User.with_current_user gatekeeper.user do
-      assert gatekeeper.is_asset_gatekeeper_of?(datafile), 'The gatekeeper must be the gatekeeper of datafile for the test to be meaningful'
-      refute datafile.can_manage?, 'The datafile must not be manageable for the test to succeed'
-      refute datafile.is_waiting_approval?, 'The datafile must be waiting for approval for the test to succeed'
+      items_for_publishing_tests(person).each do |item|
+        assert gatekeeper.is_asset_gatekeeper_of?(item), 'The gatekeeper must be the gatekeeper of the item for the test to be meaningful'
+        refute item.can_manage?, 'The item must not be manageable for the test to succeed'
+        refute item.is_waiting_approval?, 'The item must be waiting for approval for the test to succeed'
 
-      refute datafile.can_publish?, 'This datafile should not be publishable'
+        refute item.can_publish?, 'This item should not be publishable'
+      end
     end
   end
 
   test 'gatekeeper can not publish if the asset is already published' do
     gatekeeper = FactoryBot.create(:asset_gatekeeper)
-    datafile = FactoryBot.create(:data_file, projects: gatekeeper.projects,
-                                   policy: FactoryBot.create(:public_policy), contributor: gatekeeper)
 
     User.with_current_user gatekeeper.user do
-      assert datafile.is_published?, 'This datafile must be already published for the test to succeed'
-      assert gatekeeper.is_asset_gatekeeper_of?(datafile), 'The gatekeeper must be the gatekeeper of datafile for the test to be meaningful'
-      assert datafile.can_manage?, 'The datafile must not be manageable for the test to succeed'
+      items_for_publishing_tests(gatekeeper).each do |item|
+        item.policy = FactoryBot.create(:public_policy)
+        disable_authorization_checks { item.save! }
+        assert item.is_published?, 'This item must be already published for the test to succeed'
+        assert gatekeeper.is_asset_gatekeeper_of?(item), 'The gatekeeper must be the gatekeeper of the item for the test to be meaningful'
+        assert item.can_manage?, 'The item must not be manageable for the test to succeed'
 
-      assert !datafile.can_publish?, 'This datafile should not be publishable'
+        assert !item.can_publish?, 'This item should not be publishable'
+      end
     end
   end
 
@@ -246,85 +273,110 @@ class PublishingPermissionsTest < ActiveSupport::TestCase
 
   test 'publish! is performed when no gatekeeper is required' do
     user = FactoryBot.create(:user)
-    df = FactoryBot.create(:data_file, contributor: user.person)
     User.with_current_user user do
-      assert df.can_publish?, 'The datafile must be publishable'
-      assert !df.gatekeeper_required?, 'The gatekeeper must not be required for the test to succeed'
-      assert !df.is_published?, 'This datafile must not be published yet for the test to be meaningful'
+      items_for_publishing_tests(user.person).each do |item|
+        assert item.can_publish?, 'The item must be publishable'
+        assert !item.gatekeeper_required?, 'The gatekeeper must not be required for the test to succeed'
+        assert !item.is_published?, 'This item must not be published yet for the test to be meaningful'
 
-      assert df.publish!
-      assert df.is_published?, 'This datafile should be published now'
+        assert item.publish!
+        assert item.is_published?, 'This item should be published now'
+      end
     end
   end
 
   test 'publish! is performed when you are the gatekeeper of the item' do
     gatekeeper = FactoryBot.create(:asset_gatekeeper)
     person = FactoryBot.create(:person,project:gatekeeper.projects.first)
-    df = FactoryBot.create(:data_file, projects: person.projects, contributor:person)
-    df.resource_publish_logs.create(publish_state: ResourcePublishLog::WAITING_FOR_APPROVAL)
+    items_for_publishing_tests(person).each do |item|
+      item.resource_publish_logs.create(publish_state: ResourcePublishLog::WAITING_FOR_APPROVAL)
 
-    User.with_current_user gatekeeper.user do
-      assert df.can_publish?, 'The datafile must be publishable for the test to succeed'
-      assert df.gatekeeper_required?, 'The gatekeeper must not be required for the test to succeed'
-      refute df.is_published?, 'This datafile must not be published yet for the test to be meaningful'
+      User.with_current_user gatekeeper.user do
+        assert item.can_publish?, 'The item must be publishable for the test to succeed'
+        assert item.gatekeeper_required?, 'The gatekeeper must not be required for the test to succeed'
+        refute item.is_published?, 'This item must not be published yet for the test to be meaningful'
 
-      assert df.publish!
-      assert df.is_published?, 'This datafile should be published now'
+        assert item.publish!
+        assert item.is_published?, 'This item should be published now'
+      end
     end
   end
 
   test 'publish! is not performed when the gatekeeper is required and you are not the gatekeeper of the item' do
     gatekeeper = FactoryBot.create(:asset_gatekeeper)
     person = FactoryBot.create(:person,project:gatekeeper.projects.first)
-    df = FactoryBot.create(:data_file, projects: person.projects, contributor: person)
+    items_for_publishing_tests(person).each do |item|
+      User.with_current_user person.user do
+        assert item.can_publish?, 'The item must be publishable for the test to succeed'
+        assert item.gatekeeper_required?, 'The gatekeeper must not be required for the test to succeed'
+        refute person.is_asset_gatekeeper_of?(item), 'You are not the gatekeeper of this item for the test to succeed'
+        refute item.is_published?, 'This item must not be published yet for the test to be meaningful'
 
-    User.with_current_user person.user do
-      assert df.can_publish?, 'The datafile must be publishable for the test to succeed'
-      assert df.gatekeeper_required?, 'The gatekeeper must not be required for the test to succeed'
-      refute person.is_asset_gatekeeper_of?(df), 'You are not the gatekeeper of this datafile for the test to succeed'
-      refute df.is_published?, 'This datafile must not be published yet for the test to be meaningful'
-
-      refute df.publish!
-      refute df.is_published?, 'This datafile should not be published'
+        refute item.publish!
+        refute item.is_published?, 'This item should not be published'
+      end
     end
   end
 
   test 'add log after doing publish!' do
     person = FactoryBot.create(:person)
-    df = FactoryBot.create(:data_file, contributor: person)
     User.with_current_user person.user do
-      assert df.resource_publish_logs.empty?
-      assert df.publish!
-      assert_equal 1, df.resource_publish_logs.count
-      log = df.resource_publish_logs.first
-      assert_equal ResourcePublishLog::PUBLISHED, log.publish_state
+      items_for_publishing_tests(person).each do |item|
+        assert item.resource_publish_logs.empty?
+        assert item.publish!
+        assert_equal 1, item.resource_publish_logs.count
+        log = item.resource_publish_logs.first
+        assert_equal ResourcePublishLog::PUBLISHED, log.publish_state
+      end
     end
   end
 
   test 'disable authorization check for publishing_auth' do
-    df = FactoryBot.create(:data_file)
-    assert_equal Policy::NO_ACCESS, df.policy.access_type
     user = FactoryBot.create(:user)
-    User.with_current_user user do
-      assert !df.can_publish?
+    items_for_publishing_tests.each do |item|
+      assert_equal Policy::NO_ACCESS, item.policy.access_type
+
+      User.with_current_user user do
+        assert !item.can_publish?
+      end
+
+      disable_authorization_checks do
+        item.policy.access_type = Policy::ACCESSIBLE
+        assert item.save
+        item.reload
+        assert_equal Policy::ACCESSIBLE, item.policy.access_type
+      end
     end
 
-    disable_authorization_checks do
-      df.policy.access_type = Policy::ACCESSIBLE
-      assert df.save
-      df.reload
-      assert_equal Policy::ACCESSIBLE, df.policy.access_type
-    end
   end
 
   test 'publishing should clear sharing scope' do
-    df = FactoryBot.create(:data_file,policy:FactoryBot.create(:public_policy,sharing_scope:Policy::ALL_USERS))
-    assert_equal Policy::ALL_USERS,df.policy.sharing_scope
-    User.with_current_user(df.contributor.user) do
-      assert df.can_publish?
-      df.publish!
-      df.reload
-      refute_equal Policy::ALL_USERS,df.policy.sharing_scope
+    items_for_publishing_tests.each do |item|
+      item.policy = FactoryBot.create(:public_policy,sharing_scope:Policy::ALL_USERS)
+      disable_authorization_checks { item.save! }
+      assert_equal Policy::ALL_USERS, item.policy.sharing_scope
+      User.with_current_user(item.contributor.user) do
+        assert item.can_publish?
+        item.publish!
+        item.reload
+        refute_equal Policy::ALL_USERS,item.policy.sharing_scope
+      end
     end
+  end
+
+  private
+
+  def items_for_publishing_tests(contributor = FactoryBot.create(:person))
+    items = [:data_file, :sop, :document, :workflow, :investigation, :sample].collect do |type|
+      FactoryBot.create(type, contributor: contributor, projects: contributor&.projects)
+    end
+
+    study = FactoryBot.create(:study, contributor: contributor,
+                              investigation: FactoryBot.create(:investigation, projects: contributor&.projects)
+    )
+    assay = FactoryBot.create(:assay, contributor: contributor, study:
+      FactoryBot.create(:study, contributor: contributor, investigation: FactoryBot.create(:investigation, projects: contributor&.projects))
+    )
+    items | [study, assay]
   end
 end

--- a/test/unit/permissions/publishing_permissions_test.rb
+++ b/test/unit/permissions/publishing_permissions_test.rb
@@ -5,7 +5,7 @@ class PublishingPermissionsTest < ActiveSupport::TestCase
   test 'is_rejected?' do
     items_for_publishing_tests.each do |item|
       item = FactoryBot.create(:data_file)
-      assert !item.is_rejected?
+      refute item.is_rejected?
 
       ResourcePublishLog.add_log(ResourcePublishLog::REJECTED, item)
       assert item.is_rejected?
@@ -17,7 +17,7 @@ class PublishingPermissionsTest < ActiveSupport::TestCase
 
     User.with_current_user person.user do
       items_for_publishing_tests(person).each do |item|
-        assert !item.is_rejected?
+        refute item.is_rejected?
 
         ResourcePublishLog.add_log(ResourcePublishLog::REJECTED, item)
         assert item.is_rejected?
@@ -35,8 +35,8 @@ class PublishingPermissionsTest < ActiveSupport::TestCase
 
   test 'is_waiting_approval?' do
     items_for_publishing_tests.each do |item|
-      assert !item.is_waiting_approval?
-      assert !item.is_waiting_approval?(User.current_user)
+      refute item.is_waiting_approval?
+      refute item.is_waiting_approval?(User.current_user)
 
       log = ResourcePublishLog.add_log(ResourcePublishLog::WAITING_FOR_APPROVAL, item)
       assert item.is_waiting_approval?
@@ -46,7 +46,7 @@ class PublishingPermissionsTest < ActiveSupport::TestCase
 
   test 'gatekeeper_required?' do
     items_for_publishing_tests.each do |item|
-      assert !item.gatekeeper_required?
+      refute item.gatekeeper_required?
 
       gatekeeper = FactoryBot.create(:asset_gatekeeper)
       refute item.gatekeeper_required?
@@ -73,7 +73,7 @@ class PublishingPermissionsTest < ActiveSupport::TestCase
       public_obs_unit = FactoryBot.create(:observation_unit, policy: FactoryBot.create(:public_policy, access_type: Policy::VISIBLE))
 
       assert public_sop.is_published?
-      assert !not_public_model.is_published?
+      refute not_public_model.is_published?
       assert public_datafile.is_published?
       assert public_assay.is_published?
       assert public_obs_unit.is_published?
@@ -84,11 +84,11 @@ class PublishingPermissionsTest < ActiveSupport::TestCase
     assert FactoryBot.create(:sop).is_in_isa_publishable?
     assert FactoryBot.create(:model).is_in_isa_publishable?
     assert FactoryBot.create(:data_file).is_in_isa_publishable?
-    assert !FactoryBot.create(:assay).is_in_isa_publishable?
-    assert !FactoryBot.create(:investigation).is_in_isa_publishable?
-    assert !FactoryBot.create(:study).is_in_isa_publishable?
-    assert !FactoryBot.create(:event).is_in_isa_publishable?
-    assert !FactoryBot.create(:publication).is_in_isa_publishable?
+    refute FactoryBot.create(:assay).is_in_isa_publishable?
+    refute FactoryBot.create(:investigation).is_in_isa_publishable?
+    refute FactoryBot.create(:study).is_in_isa_publishable?
+    refute FactoryBot.create(:event).is_in_isa_publishable?
+    refute FactoryBot.create(:publication).is_in_isa_publishable?
     refute FactoryBot.create(:observation_unit).is_in_isa_publishable?
   end
 
@@ -97,8 +97,8 @@ class PublishingPermissionsTest < ActiveSupport::TestCase
     User.with_current_user user do
       items_for_publishing_tests(user.person).each do |item|
         assert item.can_manage?, 'This item must be manageable for the test to succeed'
-        assert !item.is_published?, 'This item must be not published for the test to succeed'
-        assert !item.gatekeeper_required?, 'This item must not require gatekeeper for the test to succeed'
+        refute item.is_published?, 'This item must be not published for the test to succeed'
+        refute item.gatekeeper_required?, 'This item must not require gatekeeper for the test to succeed'
 
         assert item.can_publish?, 'This item should be publishable'
       end
@@ -126,11 +126,11 @@ class PublishingPermissionsTest < ActiveSupport::TestCase
       items_for_publishing_tests.each do |item|
         item.policy = FactoryBot.create(:all_sysmo_viewable_policy)
         disable_authorization_checks { item.save! }
-        assert !item.can_manage?, 'This item must be manageable for the test to succeed'
-        assert !item.is_published?, 'This item must be not published for the test to be meaningful'
-        assert !item.gatekeeper_required?, 'This item must require gatekeeper for the test to be meaningful'
+        refute item.can_manage?, 'This item must be manageable for the test to succeed'
+        refute item.is_published?, 'This item must be not published for the test to be meaningful'
+        refute item.gatekeeper_required?, 'This item must require gatekeeper for the test to be meaningful'
 
-        assert !item.can_publish?, 'This item should not be publishable'
+        refute item.can_publish?, 'This item should not be publishable'
       end
     end
   end
@@ -143,9 +143,9 @@ class PublishingPermissionsTest < ActiveSupport::TestCase
         disable_authorization_checks { item.save! }
         assert item.can_manage?, 'This item must be manageable for the test to be meaningful'
         assert item.is_published?, 'This item must be not published for the test to succeed'
-        assert !item.gatekeeper_required?, 'This item must require gatekeeper for the test to be meaningful'
+        refute item.gatekeeper_required?, 'This item must require gatekeeper for the test to be meaningful'
 
-        assert !item.can_publish?, 'This item should not be publishable'
+        refute item.can_publish?, 'This item should not be publishable'
       end
 
     end
@@ -206,7 +206,7 @@ class PublishingPermissionsTest < ActiveSupport::TestCase
 
       User.with_current_user gatekeeper.user do
         assert gatekeeper.is_asset_gatekeeper_of?(item), 'The gatekeeper must be the gatekeeper of the item for the test to succeed'
-        assert !item.can_manage?, 'The item must be manageable for the test to be meaningful'
+        refute item.can_manage?, 'The item must be manageable for the test to be meaningful'
         assert item.is_waiting_approval?, 'The item must be waiting for approval for the test to succeed'
 
         assert item.can_publish?, 'This item should be publishable'
@@ -220,10 +220,10 @@ class PublishingPermissionsTest < ActiveSupport::TestCase
       item.resource_publish_logs.create(publish_state: ResourcePublishLog::WAITING_FOR_APPROVAL, user: item.contributor.user)
 
       User.with_current_user gatekeeper.user do
-        assert !gatekeeper.is_asset_gatekeeper_of?(item), 'The gatekeeper must not be the gatekeeper of the item for the test to be succeed'
+        refute gatekeeper.is_asset_gatekeeper_of?(item), 'The gatekeeper must not be the gatekeeper of the item for the test to be succeed'
         assert item.is_waiting_approval?, 'The item must be waiting for approval for the test to be meaningful'
 
-        assert !item.can_publish?, 'This item should not be publishable'
+        refute item.can_publish?, 'This item should not be publishable'
       end
     end
   end
@@ -254,7 +254,7 @@ class PublishingPermissionsTest < ActiveSupport::TestCase
         assert gatekeeper.is_asset_gatekeeper_of?(item), 'The gatekeeper must be the gatekeeper of the item for the test to be meaningful'
         assert item.can_manage?, 'The item must not be manageable for the test to succeed'
 
-        assert !item.can_publish?, 'This item should not be publishable'
+        refute item.can_publish?, 'This item should not be publishable'
       end
     end
   end
@@ -267,8 +267,8 @@ class PublishingPermissionsTest < ActiveSupport::TestCase
       assert df.publish!
     end
 
-    assert !df.can_publish?
-    assert !df.publish!
+    refute df.can_publish?
+    refute df.publish!
   end
 
   test 'publish! is performed when no gatekeeper is required' do
@@ -276,8 +276,8 @@ class PublishingPermissionsTest < ActiveSupport::TestCase
     User.with_current_user user do
       items_for_publishing_tests(user.person).each do |item|
         assert item.can_publish?, 'The item must be publishable'
-        assert !item.gatekeeper_required?, 'The gatekeeper must not be required for the test to succeed'
-        assert !item.is_published?, 'This item must not be published yet for the test to be meaningful'
+        refute item.gatekeeper_required?, 'The gatekeeper must not be required for the test to succeed'
+        refute item.is_published?, 'This item must not be published yet for the test to be meaningful'
 
         assert item.publish!
         assert item.is_published?, 'This item should be published now'
@@ -337,7 +337,7 @@ class PublishingPermissionsTest < ActiveSupport::TestCase
       assert_equal Policy::NO_ACCESS, item.policy.access_type
 
       User.with_current_user user do
-        assert !item.can_publish?
+        refute item.can_publish?
       end
 
       disable_authorization_checks do


### PR DESCRIPTION
There were some mocked out overridden methods added intially that should have been removed.

Also expanded the publishing-permission tests to cover several other types, including ISA and samples

* fix for #2124 