### PR TITLE
Handle exceptions when examining URLs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -134,7 +134,7 @@ gem 'request_store'
 
 gem 'bundler', '>= 1.8.4'
 
-gem 'ro-crate', '~> 0.5.2'
+gem 'ro-crate', '~> 0.5.3'
 
 gem 'rugged'
 gem 'i18n-js'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -737,7 +737,7 @@ GEM
       json (~> 2.3.0)
       ucf (~> 2.0.2)
       uuid (~> 2.3)
-    ro-crate (0.5.2)
+    ro-crate (0.5.3)
       addressable (>= 2.7, < 2.9)
       rubyzip (~> 2.0.0)
     rsolr (2.5.0)
@@ -1069,7 +1069,7 @@ DEPENDENCIES
   rfc-822
   rmagick (= 5.3.0)
   ro-bundle (~> 0.3.0)
-  ro-crate (~> 0.5.2)
+  ro-crate (~> 0.5.3)
   rspec-rails (~> 5.1)
   rubocop
   ruby-prof


### PR DESCRIPTION
- Display error message in event of an exception when testing a remote URL (previously would render the 500 page): ![image](https://github.com/user-attachments/assets/04ea72c3-098f-427a-9ca9-0564c9cb30b0)
- Display specific error message about SSL issues (expired cert, self-signed cert etc.)
- Bump RO-Crate gem to latest patch release (fixes a parsing issue)


