### PR TITLE
Fix to avoid a nil error when viewing data file with no content blob

### DIFF
--- a/app/models/data_file.rb
+++ b/app/models/data_file.rb
@@ -119,7 +119,7 @@ class DataFile < ApplicationRecord
   
   def zipped_folder?
     return false if external_asset.is_a? OpenbisExternalAsset
-    content_blob.is_unzippable_datafile?
+    content_blob&.is_unzippable_datafile?
   end
 
   def matching_sample_type?

--- a/test/factories/data_files.rb
+++ b/test/factories/data_files.rb
@@ -14,6 +14,13 @@ FactoryBot.define do
       end
     end
   end
+
+  factory(:data_file_with_no_content_blob, parent: :data_file) do
+    after(:create) do |data_file|
+      data_file.content_blob = nil
+      data_file.save!
+    end
+  end
   
   factory(:public_data_file, parent: :data_file) do
     policy { FactoryBot.create(:downloadable_public_policy) }

--- a/test/functional/data_files_controller_test.rb
+++ b/test/functional/data_files_controller_test.rb
@@ -4415,4 +4415,20 @@ class DataFilesControllerTest < ActionController::TestCase
       assert flash[:error].include?('disabled')
     end
   end
+
+  test 'view data file with nil content blob' do
+    df = FactoryBot.create(:data_file_with_no_content_blob)
+    assert_nil df.content_blob
+    login_as(df.contributor)
+    get :show, params: { id: df }
+    assert_response :success
+  end
+
+  test 'edit data file with nil content blob' do
+    df = FactoryBot.create(:data_file_with_no_content_blob)
+    assert_nil df.content_blob
+    login_as(df.contributor)
+    get :edit, params: { id: df }
+    assert_response :success
+  end
 end

--- a/test/functional/data_files_controller_test.rb
+++ b/test/functional/data_files_controller_test.rb
@@ -4431,4 +4431,14 @@ class DataFilesControllerTest < ActionController::TestCase
     get :edit, params: { id: df }
     assert_response :success
   end
+
+  test 'update data file with nil content blob' do
+    df = FactoryBot.create(:data_file_with_no_content_blob, title: 'old title')
+    assert_nil df.content_blob
+    login_as(df.contributor)
+    put :update, params: { id: df, data_file: { title: 'new title' } }
+    assert_response :redirect
+    df.reload
+    assert_equal 'new title', df.title
+  end
 end


### PR DESCRIPTION
* fix for #2139 

also extended tests to avoid in the future