### PR TITLE
Fix some links

### DIFF
--- a/app/views/admin/settings.html.erb
+++ b/app/views/admin/settings.html.erb
@@ -9,7 +9,7 @@
                            'Pubmed API email', 'When adding a publication from PubMed, an email address is required to use the API. No registration is required.') %>
 
     <%= admin_text_setting(:crossref_api_email, Seek::Config.crossref_api_email,
-                           'CrossRef API email', "When adding a publication from a DOI, an email address is required to use the API. The email address needs registering at #{link_to 'http://www.crossref.org/', 'http://www.crossref.org/',:target=>:_blank}") %>
+                           'CrossRef API email', "When adding a publication from a DOI, an email address is required to use the API. No registration is required.") %>
 
     <%= admin_checkbox_setting(:allow_publications_fulltext, 1, Seek::Config.allow_publications_fulltext,
                              "Allow uploading FullTexts", "Allow the registered users to upload Fulltext (pdf) for publications. They can also be made public. Please makes sure it is allowed first.") %>

--- a/config/initializers/seek_configuration.rb
+++ b/config/initializers/seek_configuration.rb
@@ -16,7 +16,7 @@ def load_seek_config_defaults!
   Seek::Config.default :jws_enabled, true
   Seek::Config.default :jws_online_root,"https://jws2.sysmo-db.org/"
   Seek::Config.default :internal_help_enabled, false
-  Seek::Config.default :external_help_url,"https://docs.seek4science.org/help"
+  Seek::Config.default :external_help_url,"https://docs.seek4science.org/help/user-guide/"
   Seek::Config.default :exception_notification_enabled,false
   Seek::Config.default :exception_notification_recipients,""
   Seek::Config.default :error_grouping_enabled,true


### PR DESCRIPTION
Fix the help link, to point to the userguide. Removed the link to register for crossref, as this is no longer required.

Fixes for:
* #2143 
* #2144 