### PR TITLE
Ensure sharing links work with various git views

### DIFF
--- a/app/controllers/git_controller.rb
+++ b/app/controllers/git_controller.rb
@@ -192,7 +192,7 @@ class GitController < ApplicationController
   end
 
   def authorize_parent
-    unless @parent_resource.can_download?
+    unless is_auth?(@parent_resource, :download)
       target = @parent_resource.can_view? ? @parent_resource : :root
       render_git_error('Not authorized', status: 403, redirect: target)
     end

--- a/app/models/special_auth_code.rb
+++ b/app/models/special_auth_code.rb
@@ -13,5 +13,5 @@ class SpecialAuthCode < ApplicationRecord
 
   validates_presence_of :code, :expiration_date
 
-  validate ->(code) { errors.add(:special_auth_code, 'asset must be manageable') unless code.asset && code.asset.can_manage? }
+  validate ->(code) { errors.add(:special_auth_code, 'asset must be manageable') unless ((code.asset && code.asset.can_manage?) || !authorization_checks_enabled) }
 end

--- a/app/views/assets/_special_auth_code_display.html.erb
+++ b/app/views/assets/_special_auth_code_display.html.erb
@@ -2,7 +2,7 @@
 <% if special_auth_code.present? && resource.can_manage? %>
   <% temporary_link = polymorphic_url(resource, code: special_auth_code.code) %>
   <b>Temporary access link (Expiration date: <%= date_as_string(special_auth_code.expiration_date) -%>):</b>
-  <div class="input-group">
+  <div class="input-group" id="special-auth-code">
     <%= text_field_tag 'temp_link', temporary_link, readonly: 'readonly', class: 'form-control' %>
     <span class="input-group-btn">
       <button class="btn-default btn clipboard-btn" data-clipboard-target="#temp_link">

--- a/app/views/assets/_special_auth_code_display.html.erb
+++ b/app/views/assets/_special_auth_code_display.html.erb
@@ -1,9 +1,14 @@
 <% special_auth_code = resource.special_auth_codes.first %>
-<% if !special_auth_code.nil? && resource.can_manage? %>
-    <% temporary_link = url_for :action => :show, :only_path => false,  :code => special_auth_code.code %>
-    <p>
-      <b>Temporary access link:</b> <%= temporary_link %>
-      <br/>
-      <b>Expiration date:</b> <%= date_as_string(special_auth_code.expiration_date) -%>
-    </p>
+<% if special_auth_code.present? && resource.can_manage? %>
+  <% temporary_link = polymorphic_url(resource, code: special_auth_code.code) %>
+  <b>Temporary access link (Expiration date: <%= date_as_string(special_auth_code.expiration_date) -%>):</b>
+  <div class="input-group">
+    <%= text_field_tag 'temp_link', temporary_link, readonly: 'readonly', class: 'form-control' %>
+    <span class="input-group-btn">
+      <button class="btn-default btn clipboard-btn" data-clipboard-target="#temp_link">
+        <span class="glyphicon glyphicon-copy" aria-hidden="true"></span>
+        Copy
+      </button>
+    </span>
+  </div>
 <% end %>

--- a/app/views/assets/_special_auth_code_form.html.erb
+++ b/app/views/assets/_special_auth_code_form.html.erb
@@ -12,7 +12,15 @@
               <div class="form-group">
                 <% temporary_link = polymorphic_url(f.object, code: sub_form.object.code) %>
                 Visitors (with no login) can access this <%= f.object.class.name.underscore.humanize %> with:
-                <%= text_field_tag 'temp_link', temporary_link, class: 'form-control' -%>
+                <div class="input-group">
+                  <%= text_field_tag 'temp_link', temporary_link, class: 'form-control' %>
+                  <span class="input-group-btn">
+                    <span class="btn-default btn clipboard-btn" data-clipboard-target="#temp_link">
+                      <span class="glyphicon glyphicon-copy" aria-hidden="true"></span>
+                      Copy
+                    </span>
+                  </span>
+                </div>
                 <p class='help-block'>This link will not be active until you click 'Update'.</p>
                 <%= sub_form.hidden_field :code %>
               </div>

--- a/app/views/general/_show_page_tab_definitions.html.erb
+++ b/app/views/general/_show_page_tab_definitions.html.erb
@@ -8,7 +8,7 @@
   <% end %>
 
   <% if versioned_resource&.is_git_versioned? %>
-    <%= tab('files', disabled_reason: versioned_resource.can_download? ? nil : 'You are not authorized to access this content.') do %>
+    <%= tab('files', disabled_reason: can_download_asset?(resource, params[:code]) ? nil : 'You are not authorized to access this content.') do %>
       <span class="glyphicon glyphicon-folder-close"></span> Files
     <% end %>
   <% end %>
@@ -19,7 +19,7 @@
 
 	<% if resource %>
 		<% resource_is_assay_stream = resource_name == 'Assay' ? resource.is_assay_stream? : false %>
-		<% if Seek::Config.isa_json_compliance_enabled && resource.is_isa_json_compliant? && !resource_is_assay_stream %>
+		<% if Seek::Config.isa_json_compliance_enabled && resource.respond_to?(:is_isa_json_compliant?) && resource.is_isa_json_compliant? && !resource_is_assay_stream %>
 			<%= tab(resource_name&.downcase + "_design") do %>
 				<span class="glyphicon glyphicon-th-list"></span> <%= resource.model_name.human %> design
 			<% end %>

--- a/app/views/git/_blob.html.erb
+++ b/app/views/git/_blob.html.erb
@@ -9,8 +9,8 @@
 <div>
   <div class="pull-right">
     <% if @blob.fetched? %>
-      <%= button_link_to('Download', 'download', polymorphic_path([@parent_resource, :git_download], version: @git_version.version, path: @blob.path)) %>
-      <%= button_link_to('Raw', 'markup', polymorphic_path([@parent_resource, :git_raw], version: @git_version.version, path: @blob.path)) %>
+      <%= button_link_to('Download', 'download', polymorphic_path([@parent_resource, :git_download], version: @git_version.version, path: @blob.path, code: params[:code])) %>
+      <%= button_link_to('Raw', 'markup', polymorphic_path([@parent_resource, :git_raw], version: @git_version.version, path: @blob.path, code: params[:code])) %>
     <% end %>
     <% if @blob.remote? %>
       <%= button_link_to('External Link', 'external_link', @blob.url, target: :_blank) %>

--- a/app/views/git/_files.html.erb
+++ b/app/views/git/_files.html.erb
@@ -37,7 +37,9 @@
             if (node.type === 'blob') {
                 var path = '<%= polymorphic_path([resource, :git_blob], version: git_version.version, path: '__replaceme__') %>'.replace('__replaceme__', Git.encodePath(node.data.path))
                 element.spinner('add');
+                var code = new URLSearchParams(document.location.search).get('code');
                 $j.ajax(path, {
+                    data: code ? { code: code } : {},
                     success: function (html) {
                         $j('#git-preview-modal .modal-body').html(html);
                         $j('#git-preview-modal').modal('show');

--- a/app/views/workflows/show.html.erb
+++ b/app/views/workflows/show.html.erb
@@ -4,7 +4,7 @@
 
 <%= render partial: 'assets/upload_new_version_form', locals: { resource: @workflow } -%>
 
-<%= render partial: 'general/show_page_tab_definitions', locals: { versioned_resource: @display_workflow } %>
+<%= render partial: 'general/show_page_tab_definitions', locals: { resource: @workflow, versioned_resource: @display_workflow } %>
 
 <div class="tab-content">
   <%= tab_pane('overview') do %>
@@ -85,7 +85,7 @@
     </div>
   <% end %>
 
-  <% if @display_workflow.is_git_versioned? && @display_workflow.can_download? %>
+  <% if @display_workflow.is_git_versioned? && can_download_asset?(@workflow, params[:code]) %>
     <%= tab_pane('files') do %>
       <%= render partial: 'git/files', locals: { resource: @workflow, git_version: @display_workflow } %>
     <% end %>

--- a/test/integration/special_auth_codes_access_test.rb
+++ b/test/integration/special_auth_codes_access_test.rb
@@ -145,7 +145,9 @@ class SpecialAuthCodesAccessTest < ActionDispatch::IntegrationTest
         get "/#{type_name}/#{item.id}"
 
         assert_response :success, "failed for asset #{type_name}"
-        assert_select 'p > b', text: /Temporary access link:/, count: 1
+        code = item.special_auth_codes.first.code
+        url = polymorphic_url(item, code: code)
+        assert_select '#special-auth-code input[value=?]', url, count: 1
       end
     end
   end


### PR DESCRIPTION
Also adds a button to copy sharing links to clipboard:
![image](https://github.com/user-attachments/assets/46e5fa62-f8bc-484f-9781-8fb47af58d12)
