### PR TITLE
Fix observation unit preview

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   tests:
     name: Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       RAILS_ENV: test
       TERM: dumb-color

--- a/app/views/observation_units/_resource_preview.html.erb
+++ b/app/views/observation_units/_resource_preview.html.erb
@@ -1,0 +1,21 @@
+<% unless resource.nil? -%>
+
+  <div data-tooltip='<%= tooltip(h(resource.description)) %>'>
+    <p class="title">
+      <%= list_item_title resource -%>
+    </p>
+
+    <%= list_item_authorized_list([resource.investigation], t('investigation'), false, 50, true ) %>
+
+    <%= list_item_authorized_list([resource.study], t('study'), false, 50, true ) %>
+
+    <%= render :partial => 'projects/show_project_relationship', :locals => {:resource => resource, :list_item => false} -%>
+
+    <%= list_item_contributors resource -%>
+
+    <%= list_item_simple_list resource.creators, t('creator').capitalize.pluralize -%>
+
+    <%= list_item_description resource.description -%>
+  </div>
+
+<% end -%>

--- a/test/functional/observation_units_controller_test.rb
+++ b/test/functional/observation_units_controller_test.rb
@@ -208,9 +208,10 @@ class ObservationUnitsControllerTest < ActionController::TestCase
   test 'preview observation unit' do
     person = FactoryBot.create(:person)
     login_as(person)
-    obs_unit = FactoryBot.create(:observation_unit, policy: FactoryBot.create(:public_policy), contributor:person)
+    obs_unit = FactoryBot.create(:observation_unit, title: 'preview obs unit', policy: FactoryBot.create(:public_policy), contributor:person)
     get :preview, xhr: true, params: { id: obs_unit.id }
     assert_response :success
+    assert_includes response.body, "<a href=\\\"/observation_units/#{obs_unit.id}\\\">preview obs unit<\\/a>"
   end
 
 end

--- a/test/functional/observation_units_controller_test.rb
+++ b/test/functional/observation_units_controller_test.rb
@@ -205,4 +205,12 @@ class ObservationUnitsControllerTest < ActionController::TestCase
     end
   end
 
+  test 'preview observation unit' do
+    person = FactoryBot.create(:person)
+    login_as(person)
+    obs_unit = FactoryBot.create(:observation_unit, policy: FactoryBot.create(:public_policy), contributor:person)
+    get :preview, xhr: true, params: { id: obs_unit.id }
+    assert_response :success
+  end
+
 end


### PR DESCRIPTION
Error was being thrown when displaying the preview in teh fancy-multi-select - due to using the default _resource_preview.html.erb for assets, but not having a version. Now added a specific partial for the type, based on the default but with the addition of Study and Investigation similar to assays.

* fix for #2155 

also changed the Ubuntu for tests to 22.04 due to the scheduled blackout