### PR TITLE
prevent hidden sample types showing in select view, and prevent samples being created with them

### DIFF
--- a/app/controllers/sample_types_controller.rb
+++ b/app/controllers/sample_types_controller.rb
@@ -126,7 +126,8 @@ class SampleTypesController < ApplicationController
   # used for ajax call to get the filtered sample types for selection
   def filter_for_select
     scope = Seek::Config.isa_json_compliance_enabled ? SampleType.without_template : SampleType
-    @sample_types = scope.joins(:projects).where('projects.id' => params[:projects]).distinct.to_a
+    sample_types = scope.joins(:projects).where('projects.id' => params[:projects]).distinct.to_a
+    @sample_types = sample_types.authorized_for(:view)
     unless params[:tags].blank?
       @sample_types.select! do |sample_type|
         if params[:exclusive_tags] == '1'

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -9,6 +9,7 @@ class SamplesController < ApplicationController
   before_action :find_index_assets, only: :index
   before_action :find_and_authorize_requested_item, except: [:index, :new, :create, :preview]
   before_action :check_if_locked_sample_type, only: %i[edit new create update]
+  before_action :authorize_sample_type, only: %i[new create]
   before_action :templates_enabled?, only: [:query, :query_form]
 
   before_action :auth_to_create, only: %i[new create batch_create]
@@ -371,4 +372,17 @@ class SamplesController < ApplicationController
     flash[:error] = 'This sample type is locked. You cannot edit the sample.'
     redirect_to sample_types_path(sample_type)
   end
+
+  def authorize_sample_type
+    id = params[:sample_type_id] || params.dig(:sample, :sample_type_id)
+    return unless id
+
+    sample_type = SampleType.find(id)
+    unless sample_type.can_view?
+      flash[:error] = "You are not authorized to use this #{t('sample_type')}"
+      redirect_to root_path
+    end
+
+  end
+
 end

--- a/test/factories/samples.rb
+++ b/test/factories/samples.rb
@@ -42,7 +42,7 @@ FactoryBot.define do
   end
 
   factory(:max_sample, parent: :sample) do
-    association :sample_type, factory: :max_sample_type, strategy: :create
+    association :sample_type, factory: :max_sample_type, strategy: :create, policy: FactoryBot.create(:public_policy)
     association :contributor, factory: :person, strategy: :create
     after(:build) do |sample|
       sample.annotate_with(['tag1', 'tag2'], 'tag', sample.contributor)

--- a/test/factories/samples.rb
+++ b/test/factories/samples.rb
@@ -42,7 +42,7 @@ FactoryBot.define do
   end
 
   factory(:max_sample, parent: :sample) do
-    association :sample_type, factory: :max_sample_type, strategy: :create, policy: FactoryBot.create(:public_policy)
+    association :sample_type, factory: :max_sample_type, strategy: :create
     association :contributor, factory: :person, strategy: :create
     after(:build) do |sample|
       sample.annotate_with(['tag1', 'tag2'], 'tag', sample.contributor)

--- a/test/functional/samples_controller_test.rb
+++ b/test/functional/samples_controller_test.rb
@@ -52,7 +52,7 @@ class SamplesControllerTest < ActionController::TestCase
     get :new, params: { sample_type_id: hidden_type.id }
 
     assert_redirected_to root_path
-    refute_nil flash[:error]
+    assert_equal 'You are not authorized to use this Sample type', flash[:error]
   end
 
   test 'create from form' do
@@ -97,7 +97,7 @@ class SamplesControllerTest < ActionController::TestCase
       end
     end
     assert_redirected_to root_path
-    refute_nil flash[:error]
+    assert_equal 'You are not authorized to use this Sample type', flash[:error]
   end
 
   test 'create' do

--- a/test/functional/samples_controller_test.rb
+++ b/test/functional/samples_controller_test.rb
@@ -35,7 +35,7 @@ class SamplesControllerTest < ActionController::TestCase
 
   test 'new with sample type id' do
     login_as(FactoryBot.create(:person))
-    type = FactoryBot.create(:patient_sample_type)
+    type = FactoryBot.create(:patient_sample_type, policy: FactoryBot.create(:public_policy))
     get :new, params: { sample_type_id: type.id }
     assert_response :success
     assert assigns(:sample)
@@ -45,11 +45,21 @@ class SamplesControllerTest < ActionController::TestCase
     assert_select 'div label+p', text:/the weight of the patient/i, count:1
   end
 
+  test 'cannot access new with hidden sample type' do
+    login_as(FactoryBot.create(:person))
+    hidden_type = FactoryBot.create(:simple_sample_type, policy: FactoryBot.create(:private_policy), contributor: FactoryBot.create(:person))
+    refute hidden_type.can_view?
+    get :new, params: { sample_type_id: hidden_type.id }
+
+    assert_redirected_to root_path
+    refute_nil flash[:error]
+  end
+
   test 'create from form' do
     person = FactoryBot.create(:person)
     creator = FactoryBot.create(:person)
     login_as(person)
-    type = FactoryBot.create(:patient_sample_type)
+    type = FactoryBot.create(:patient_sample_type, policy: FactoryBot.create(:public_policy))
     assert_enqueued_with(job: SampleTypeUpdateJob, args: [type, false]) do
       assert_difference('Sample.count') do
         post :create, params: { sample: { sample_type_id: type.id,
@@ -73,11 +83,28 @@ class SamplesControllerTest < ActionController::TestCase
     assert_equal 'frank, mary',sample.other_creators
   end
 
+  test 'cannot create with hidden sample type' do
+    person = FactoryBot.create(:person)
+    creator = FactoryBot.create(:person)
+    login_as(person)
+    hidden_type = FactoryBot.create(:patient_sample_type, policy: FactoryBot.create(:private_policy), contributor: FactoryBot.create(:person))
+    refute hidden_type.can_view?
+    assert_no_enqueued_jobs do
+      assert_no_difference('Sample.count') do
+        post :create, params: { sample: { sample_type_id: hidden_type.id,
+                                          data: { 'full name': 'Fred Smith', age: '22', weight: '22.1', postcode: 'M13 9PL' },
+                                          project_ids: [person.projects.first.id], creator_ids: [creator.id] } }
+      end
+    end
+    assert_redirected_to root_path
+    refute_nil flash[:error]
+  end
+
   test 'create' do
     person = FactoryBot.create(:person)
     creator = FactoryBot.create(:person)
     login_as(person)
-    type = FactoryBot.create(:patient_sample_type)
+    type = FactoryBot.create(:patient_sample_type, policy: FactoryBot.create(:public_policy))
     obs_unit = FactoryBot.create(:observation_unit, contributor: person)
     assert_enqueued_with(job: SampleTypeUpdateJob, args: [type, false]) do
       assert_difference('Sample.count') do
@@ -103,7 +130,7 @@ class SamplesControllerTest < ActionController::TestCase
     person = FactoryBot.create(:person)
     creator = FactoryBot.create(:person)
     login_as(person)
-    type = FactoryBot.create(:patient_sample_type)
+    type = FactoryBot.create(:patient_sample_type, policy: FactoryBot.create(:public_policy))
     assert_no_difference('Sample.count') do
       post :create, params: { sample: { sample_type_id: type.id,
                                         data: { 'full name': 'Fred Smith', age: 'Fish' },
@@ -123,7 +150,7 @@ class SamplesControllerTest < ActionController::TestCase
   test 'create and update with boolean from form' do
     person = FactoryBot.create(:person)
     login_as(person)
-    type = FactoryBot.create(:simple_sample_type)
+    type = FactoryBot.create(:simple_sample_type, policy: FactoryBot.create(:public_policy))
     type.sample_attributes << FactoryBot.create(:sample_attribute, title: 'bool', 
                                                                    sample_attribute_type: FactoryBot.create(:boolean_sample_attribute_type), required: false, sample_type: type)
     type.save!
@@ -148,7 +175,7 @@ class SamplesControllerTest < ActionController::TestCase
   test 'create with symbols' do
     person = FactoryBot.create(:person)
     login_as(person)
-    type = FactoryBot.create(:sample_type_with_symbols)
+    type = FactoryBot.create(:sample_type_with_symbols, policy: FactoryBot.create(:public_policy))
     assert_difference('Sample.count') do
       post :create, params: { sample: { sample_type_id: type.id,
                                         data: {
@@ -167,7 +194,7 @@ class SamplesControllerTest < ActionController::TestCase
   test 'create and update with boolean' do
     person = FactoryBot.create(:person)
     login_as(person)
-    type = FactoryBot.create(:simple_sample_type)
+    type = FactoryBot.create(:simple_sample_type, policy: FactoryBot.create(:public_policy))
     type.sample_attributes << FactoryBot.create(:sample_attribute, title: 'bool', 
                                                                    sample_attribute_type: FactoryBot.create(:boolean_sample_attribute_type), required: false, sample_type: type)
     type.save!
@@ -190,7 +217,7 @@ class SamplesControllerTest < ActionController::TestCase
     person = FactoryBot.create(:person)
     login_as(person)
 
-    type = FactoryBot.create(:apples_list_controlled_vocab_sample_type)
+    type = FactoryBot.create(:apples_list_controlled_vocab_sample_type, policy: FactoryBot.create(:public_policy))
     assert_difference('Sample.count') do
       post :create, params: { sample: { sample_type_id: type.id,
                                         data: { apples: ['Granny Smith', 'Bramley'] },
@@ -346,7 +373,7 @@ class SamplesControllerTest < ActionController::TestCase
   test 'associate with project on create from form' do
     person = FactoryBot.create(:person_in_multiple_projects)
     login_as(person)
-    type = FactoryBot.create(:patient_sample_type)
+    type = FactoryBot.create(:patient_sample_type, policy: FactoryBot.create(:public_policy))
     assert person.projects.count >= 3 # incase the factory changes
     project_ids = person.projects[0..1].collect(&:id)
     assert_difference('Sample.count') do
@@ -366,7 +393,7 @@ class SamplesControllerTest < ActionController::TestCase
   test 'associate with project on create' do
     person = FactoryBot.create(:person_in_multiple_projects)
     login_as(person)
-    type = FactoryBot.create(:patient_sample_type)
+    type = FactoryBot.create(:patient_sample_type, policy: FactoryBot.create(:public_policy))
     assert person.projects.count >= 3 # incase the factory changes
     project_ids = person.projects[0..1].collect(&:id)
     assert_difference('Sample.count') do
@@ -464,7 +491,7 @@ class SamplesControllerTest < ActionController::TestCase
   test 'create with sharing from form' do
     person = FactoryBot.create(:person)
     login_as(person)
-    type = FactoryBot.create(:patient_sample_type)
+    type = FactoryBot.create(:patient_sample_type, policy: FactoryBot.create(:public_policy))
 
     assert_difference('Sample.count') do
       post :create, params: { sample: { sample_type_id: type.id, title: 'My Sample',
@@ -484,7 +511,7 @@ class SamplesControllerTest < ActionController::TestCase
   test 'create with sharing' do
     person = FactoryBot.create(:person)
     login_as(person)
-    type = FactoryBot.create(:patient_sample_type)
+    type = FactoryBot.create(:patient_sample_type, policy: FactoryBot.create(:public_policy))
 
     assert_difference('Sample.count') do
       post :create, params: { sample: { sample_type_id: type.id, title: 'My Sample',
@@ -1001,7 +1028,7 @@ class SamplesControllerTest < ActionController::TestCase
     person = FactoryBot.create(:person)
     login_as(person)
 
-    type = FactoryBot.create(:patient_sample_type)
+    type = FactoryBot.create(:patient_sample_type, policy: FactoryBot.create(:public_policy))
 
     sample =  {sample_type_id: type.id,
                data: { 'full name': 'Fred Smith', age: '22', weight: '22.1', postcode: 'M13 9PL' },
@@ -1222,8 +1249,8 @@ class SamplesControllerTest < ActionController::TestCase
   test 'create single linked sample' do
     person = FactoryBot.create(:person)
     login_as(person)
-    patient = FactoryBot.create(:patient_sample, contributor: person)
-    linked_sample_type = FactoryBot.create(:linked_sample_type, project_ids: [person.projects.first.id])
+    patient = FactoryBot.create(:patient_sample, contributor: person, policy: FactoryBot.create(:public_policy))
+    linked_sample_type = FactoryBot.create(:linked_sample_type, project_ids: [person.projects.first.id], policy: FactoryBot.create(:public_policy))
     linked_sample_type.sample_attributes.last.linked_sample_type = patient.sample_type
     linked_sample_type.save!
 
@@ -1249,7 +1276,7 @@ class SamplesControllerTest < ActionController::TestCase
     login_as(person)
     patient = FactoryBot.create(:patient_sample, contributor: person)
     patient2 = FactoryBot.create(:patient_sample, sample_type:patient.sample_type, contributor: person )
-    multi_linked_sample_type = FactoryBot.create(:multi_linked_sample_type, project_ids: [person.projects.first.id])
+    multi_linked_sample_type = FactoryBot.create(:multi_linked_sample_type, project_ids: [person.projects.first.id], policy: FactoryBot.create(:public_policy))
     multi_linked_sample_type.sample_attributes.last.linked_sample_type = patient.sample_type
     multi_linked_sample_type.save!
 
@@ -1276,7 +1303,7 @@ class SamplesControllerTest < ActionController::TestCase
     patient = FactoryBot.create(:patient_sample, contributor: FactoryBot.create(:person), 
                                                  policy: FactoryBot.create(:private_policy))
 
-    multi_linked_sample_type = FactoryBot.create(:multi_linked_sample_type, project_ids: [person.projects.first.id])
+    multi_linked_sample_type = FactoryBot.create(:multi_linked_sample_type, project_ids: [person.projects.first.id], policy: FactoryBot.create(:public_policy))
     multi_linked_sample_type.sample_attributes.last.linked_sample_type = patient.sample_type
     multi_linked_sample_type.save!
 
@@ -1555,7 +1582,7 @@ class SamplesControllerTest < ActionController::TestCase
   test 'should show label to say controlled vocab allows free text' do
     login_as(FactoryBot.create(:person))
 
-    type = FactoryBot.create(:simple_sample_type)
+    type = FactoryBot.create(:simple_sample_type, policy: FactoryBot.create(:public_policy))
     FactoryBot.create(:apples_controlled_vocab_attribute, is_title: true, title: 'allowed', allow_cv_free_text: true, 
                                                           sample_type: type)
     FactoryBot.create(:apples_controlled_vocab_attribute, title: 'not allowed', allow_cv_free_text: false, 

--- a/test/integration/api/sample_api_test.rb
+++ b/test/integration/api/sample_api_test.rb
@@ -18,6 +18,7 @@ class SampleApiTest < ActionDispatch::IntegrationTest
 
     @sample = FactoryBot.create(:max_sample, contributor: current_person, policy: FactoryBot.create(:public_policy))
     @sample_type = @sample.sample_type
+    @sample_type.policy.update_column(:access_type, Policy::ACCESSIBLE)
     assert @sample_type.can_view?
     @project = @sample.projects.first
     @assay = FactoryBot.create(:assay, contributor: current_person)

--- a/test/integration/api/sample_api_test.rb
+++ b/test/integration/api/sample_api_test.rb
@@ -18,6 +18,7 @@ class SampleApiTest < ActionDispatch::IntegrationTest
 
     @sample = FactoryBot.create(:max_sample, contributor: current_person, policy: FactoryBot.create(:public_policy))
     @sample_type = @sample.sample_type
+    assert @sample_type.can_view?
     @project = @sample.projects.first
     @assay = FactoryBot.create(:assay, contributor: current_person)
 
@@ -82,7 +83,7 @@ class SampleApiTest < ActionDispatch::IntegrationTest
 
   test 'set sample_type and attributes in post' do
     user_login
-    patient_sample_type = FactoryBot.create(:patient_sample_type)
+    patient_sample_type = FactoryBot.create(:patient_sample_type, policy: FactoryBot.create(:public_policy))
     params = {
       "data": {
         "type": "samples",
@@ -126,7 +127,7 @@ class SampleApiTest < ActionDispatch::IntegrationTest
 
   test 'create with multi sample and cv list' do
     user_login
-    max_sample_type = FactoryBot.create(:max_sample_type)
+    max_sample_type = FactoryBot.create(:max_sample_type, policy: FactoryBot.create(:public_policy))
     patients = [FactoryBot.create(:patient_sample, policy:FactoryBot.create(:public_policy)), FactoryBot.create(:patient_sample, policy:FactoryBot.create(:public_policy))]
 
     params = {
@@ -178,7 +179,7 @@ class SampleApiTest < ActionDispatch::IntegrationTest
 
   test 'create with multi sample and cv list - as array' do
     user_login
-    max_sample_type = FactoryBot.create(:max_sample_type)
+    max_sample_type = FactoryBot.create(:max_sample_type, policy: FactoryBot.create(:public_policy))
     patients = [FactoryBot.create(:patient_sample, policy:FactoryBot.create(:public_policy)), FactoryBot.create(:patient_sample, policy:FactoryBot.create(:public_policy))]
 
     params = {


### PR DESCRIPTION
* fix for #2162