### PR TITLE
Fix issue with migration test action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,8 +101,15 @@ jobs:
         run: |
           git fetch origin ${{ github.event.before }}
           git checkout ${{ github.event.before }} -- db/schema.rb
+          mv db/migrate db/migrate.bkp
+          git checkout ${{ github.event.before }} -- db/migrate
       - name: Load test database schema
         run: bundle exec rake db:schema:load
+      - name: Restore migrations
+        if: github.event_name == 'push' && matrix.suite == 'rake db:migrate' && github.event.before != '0000000000000000000000000000000000000000'
+        run: |
+          rm -rf db/migrate
+          mv db/migrate.bkp db/migrate
       - name: Seed database
         if: matrix.suite == 'rake seek:upgrade'
         run: bundle exec rake db:seed


### PR DESCRIPTION
Where it would fail if the push contains a migration with a timestamp older than the timestamp of `schema.rb` in the previous commit.