### PR TITLE
Fix - FAIR Data Station import should ignore disabled Extended Metadata Types

### DIFF
--- a/lib/seek/fair_data_station/base.rb
+++ b/lib/seek/fair_data_station/base.rb
@@ -157,7 +157,7 @@ module Seek
         annotation[0]
       end)
         # collect and sort those with the most properties that match, eliminating any where no properties match
-        candidates = ::ExtendedMetadataType.where(supported_type: type_name).includes(:extended_metadata_attributes).collect do |emt|
+        candidates = ::ExtendedMetadataType.where(supported_type: type_name).enabled.includes(:extended_metadata_attributes).collect do |emt|
           extended_metadata_property_ids = emt.deep_extended_metadata_attributes.collect(&:pid).compact_blank
           intersection = (property_ids & extended_metadata_property_ids)
           difference = (property_ids | extended_metadata_property_ids) - intersection

--- a/test/unit/fair_data_station/fair_data_station_objects_test.rb
+++ b/test/unit/fair_data_station/fair_data_station_objects_test.rb
@@ -108,6 +108,10 @@ class FairDataStationObjectsTest < ActiveSupport::TestCase
 
     exact_match = FactoryBot.create(:fairdata_test_case_study_extended_metadata)
     assert_equal exact_match, study.find_exact_matching_extended_metadata_type
+
+    #doesn't match if disabled
+    exact_match.update_column(:enabled, false)
+    assert_nil study.find_exact_matching_extended_metadata_type
   end
 
   test 'find_exact_matching_sample_type' do
@@ -139,9 +143,11 @@ class FairDataStationObjectsTest < ActiveSupport::TestCase
     path = "#{Rails.root}/test/fixtures/files/fair_data_station/seek-fair-data-station-test-case.ttl"
     inv = Seek::FairDataStation::Reader.new.parse_graph(path).first
     assay = inv.studies.first.assays.first
-    ::Assay.new
-    detected_type = assay.find_closest_matching_extended_metadata_type
-    assert_equal seek_test_case_assay, detected_type
+    assert_equal seek_test_case_assay, assay.find_closest_matching_extended_metadata_type
+
+    # but not if disabled
+    seek_test_case_assay.update_column(:enabled, false)
+    refute_equal seek_test_case_assay, assay.find_closest_matching_extended_metadata_type
 
     path = "#{Rails.root}/test/fixtures/files/fair_data_station/demo.ttl"
     inv = Seek::FairDataStation::Reader.new.parse_graph(path).first

--- a/test/unit/permissions/auth_lookup_table_test.rb
+++ b/test/unit/permissions/auth_lookup_table_test.rb
@@ -194,9 +194,11 @@ class AuthLookupTableTest < ActiveSupport::TestCase
   end
 
   test 'queues delete job when assets removed' do
-    Person.destroy_all
-    User.destroy_all
-    Sop.destroy_all
+    disable_authorization_checks do
+      Person.destroy_all
+      User.destroy_all
+      Sop.destroy_all
+    end
 
     person = FactoryBot.create(:person)
     FactoryBot.create(:person)


### PR DESCRIPTION
* fixes #2184 