### PR TITLE
Max filters 

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -106,6 +106,7 @@ class AdminController < ApplicationController
 
     Seek::Config.solr_enabled = string_to_boolean params[:solr_enabled]
     Seek::Config.filtering_enabled = string_to_boolean params[:filtering_enabled]
+    Seek::Config.max_filters = params[:max_filters]
     Seek::Config.jws_enabled = string_to_boolean params[:jws_enabled]
     Seek::Config.jws_online_root = params[:jws_online_root]
 

--- a/app/helpers/filtering_helper.rb
+++ b/app/helpers/filtering_helper.rb
@@ -37,7 +37,7 @@ module FilteringHelper
     end
   end
 
-  # returns true of nobody is logged in and the @filters equal or exceeds the configured max_filters
+  # Returns true if no user is logged in and the number of filters is equal to or exceeds the maximum allowed.
   def max_filters_met?
     return false unless @filters && @filters.is_a?(Hash)
     return false if logged_in_and_registered?

--- a/app/helpers/filtering_helper.rb
+++ b/app/helpers/filtering_helper.rb
@@ -1,4 +1,5 @@
 module FilteringHelper
+  include SessionsHelper
   def filter_link(key, filter, hidden: false, replace: false)
     link_to(page_and_sort_params.merge({ page: nil, filter: filter.active ? without_filter(key, filter.value) : with_filter(key, filter.value, replace: replace) }),
             title: filter.label,
@@ -34,5 +35,13 @@ module FilteringHelper
     else
       @filters.merge(key => existing)
     end
+  end
+
+  # returns true of nobody is logged in and the @filters equal or exceeds the configured max_filters
+  def max_filters_met?
+    return false unless @filters && @filters.is_a?(Hash)
+    return false if logged_in_and_registered?
+
+    @filters.values.flatten.size >= Seek::Config.max_filters
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -265,6 +265,7 @@ class User < ApplicationRecord
   end
 
   def self.with_current_user(user)
+    user = user.user if user.is_a?(Person)
     previous = current_user
     self.current_user = user
     begin

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -111,7 +111,7 @@ class User < ApplicationRecord
   # a person can be logged in but not fully registered during
   # the registration process whilst selecting or creating a profile
   def self.logged_in_and_registered?
-    logged_in? && current_user.person && current_user.person.id
+    logged_in? && current_user.registration_complete?
   end
 
   def self.logged_in_and_member?

--- a/app/views/admin/features_enabled.html.erb
+++ b/app/views/admin/features_enabled.html.erb
@@ -5,7 +5,14 @@
   <%= admin_checkbox_setting(:solr_enabled, 1, Seek::Config.solr_enabled,
                              "Search enabled", "Whether the search is enabled. If switched on you need to ensure SOLR is running and its index is up to date. You need to restart both the server, and the Background service, after changing this setting.") %>
 
-  <%= admin_checkbox_setting(:filtering_enabled, 1, Seek::Config.filtering_enabled, "Filtering enabled", "Whether filtering system is enabled on index pages.") %>
+  <%= admin_checkbox_setting(:filtering_enabled, 1, Seek::Config.filtering_enabled,
+                             "Filtering enabled", "Whether filtering system is enabled on index pages.",
+                             onchange: toggle_appear_javascript('filtering_details')) %>
+  <div id="filtering_details" class="additional_settings" style="<%= show_or_hide_block Seek::Config.filtering_enabled -%>">
+    <%= admin_text_setting(:max_filters, Seek::Config.max_filters,
+                           'Filters limit', 'The maximum number of filters that can be applied, after which additional filters cannot be added',
+                           onkeypress: "javascript: return onlyNumbers(event);") %>
+  </div>
 
   <%= render :partial => 'admin/email' %>
 

--- a/app/views/general/_index.html.erb
+++ b/app/views/general/_index.html.erb
@@ -33,8 +33,20 @@
 <%= index_and_new_help_icon controller_name %>
 
 <div class="index-container">
-  <%= render partial: 'assets/resource_filtering' if Seek::Config.filtering_enabled %>
+  <% if Seek::Config.filtering_enabled && !max_filters_met? %>
+    <%= render partial: 'assets/resource_filtering' %>
+  <% end %>
   <div class="index-content">
+    <% if Seek::Config.filtering_enabled && max_filters_met? %>
+      <div class='alert alert-warning'>
+        <p>
+          The maximum of <%= Seek::Config.max_filters %> filters has been reached.
+        </p>
+        <p>
+          You will need to remove a filter to be able to apply a different one.
+        </p>
+      </div>
+    <% end %>
     <div class="row">
       <div class="col-sm-6">
         <%= render partial: 'assets/resource_counts' %>

--- a/app/views/general/_index.html.erb
+++ b/app/views/general/_index.html.erb
@@ -43,7 +43,7 @@
           The maximum of <%= Seek::Config.max_filters %> filters has been reached.
         </p>
         <p>
-          You will need to remove a filter to be able to apply a different one.
+          You will need to remove a filter to be able to apply a different one. If logged in with a registered account the filter limit is removed.
         </p>
       </div>
     <% end %>

--- a/config/initializers/seek_configuration.rb
+++ b/config/initializers/seek_configuration.rb
@@ -173,6 +173,7 @@ def load_seek_config_defaults!
   Seek::Config.default :open_id_authentication_store,:memory
   Seek::Config.default :session_store_timeout, 1.hour
   Seek::Config.default :cv_dropdown_limit, 100
+  Seek::Config.default :max_filters, 5
 
   # Admin setting to allow user impersonation, useful for debugging
   Seek::Config.default :admin_impersonation_enabled, false

--- a/lib/seek/config_setting_attributes.yml
+++ b/lib/seek/config_setting_attributes.yml
@@ -275,3 +275,5 @@ fair_data_station_enabled:
 sandbox_instance_url:
 sandbox_instance_name:
 scraper_config:
+max_filters:
+  convert: :to_i

--- a/lib/seek/index_pager.rb
+++ b/lib/seek/index_pager.rb
@@ -149,7 +149,7 @@ module Seek
 
       # Filters
       @filters = page_and_sort_params[:filter].to_h
-      @filters = remove_excess_filters(@filters) unless User.logged_in_and_registered?
+      @filters = remove_excess_filters(@filters) unless json_api_request? || User.logged_in_and_registered?
       @active_filters = {}
       @available_filters = {}
     end

--- a/lib/seek/index_pager.rb
+++ b/lib/seek/index_pager.rb
@@ -149,8 +149,21 @@ module Seek
 
       # Filters
       @filters = page_and_sort_params[:filter].to_h
+      @filters = remove_excess_filters(@filters) unless User.logged_in_and_registered?
       @active_filters = {}
       @available_filters = {}
+    end
+
+    def remove_excess_filters(filters)
+      # remove the last value from the last key, removing the key if empty, until the limit is met
+      while filters.values.flatten.length > Seek::Config.max_filters
+        key = filters.keys.last
+        value = Array(filters[key])
+        value.pop
+        filters[key] = value
+        filters.compact_blank!
+      end
+      filters
     end
 
     def json_api_links

--- a/test/functional/documents_controller_test.rb
+++ b/test/functional/documents_controller_test.rb
@@ -706,6 +706,16 @@ class DocumentsControllerTest < ActionController::TestCase
     end
   end
 
+  test 'dont remove excess filters if an api call' do
+    document = FactoryBot.create(:document)
+    contributor = document.contributor
+    project = document.projects.first
+    with_config_value(:max_filters, 2) do
+      get :index, params: { filter: { contributor: contributor.id, project: [project.id, project.id+1], creator: [1,2] } }, format: :json
+      assert_equal 5, assigns(:filters).values.flatten.length
+    end
+  end
+
   test 'do not show filters on index if disabled' do
     FactoryBot.create(:public_document)
 

--- a/test/functional/documents_controller_test.rb
+++ b/test/functional/documents_controller_test.rb
@@ -681,12 +681,12 @@ class DocumentsControllerTest < ActionController::TestCase
     assert_select '.alert-warning', count: 0
   end
 
-  test 'dont show filters if max met' do
+  test 'dont show filters if max met and remove excess' do
     document = FactoryBot.create(:document)
     contributor = document.contributor
     project = document.projects.first
     with_config_value(:max_filters, 2) do
-      get :index, params: { filter: { contributor: contributor.id, project: project.id } }
+      get :index, params: { filter: { contributor: contributor.id, project: [project.id, project.id+1], creator: [1,2] } }
       assert_equal 2, assigns(:filters).values.flatten.length
       assert_select '.index-filters', count: 0
       assert_select '.alert-warning', text:/maximum of 2 filters has been reached/, count: 1
@@ -699,8 +699,8 @@ class DocumentsControllerTest < ActionController::TestCase
     project = document.projects.first
     login_as(FactoryBot.create(:user))
     with_config_value(:max_filters, 2) do
-      get :index, params: { filter: { contributor: contributor.id, project: project.id } }
-      assert_equal 2, assigns(:filters).values.flatten.length
+      get :index, params: { filter: { contributor: contributor.id, project: [project.id, project.id+1] } }
+      assert_equal 3, assigns(:filters).values.flatten.length
       assert_select '.index-filters', count: 1
       assert_select '.alert-warning', count: 0
     end

--- a/test/unit/helpers/fail_helper_test.rb
+++ b/test/unit/helpers/fail_helper_test.rb
@@ -1,4 +1,0 @@
-require 'test_helper'
-
-class FailHelperTest < ActionView::TestCase
-end

--- a/test/unit/helpers/filtering_helper_test.rb
+++ b/test/unit/helpers/filtering_helper_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+class FilteringHelperTest < ActionView::TestCase
+
+  test 'max_filters_met?' do
+    with_config_value(:max_filters, 2) do
+      refute max_filters_met?
+      @filters={}
+      refute max_filters_met?
+      @filters={'contributor'=>'1'}
+      refute max_filters_met?
+
+      @filters={'contributor'=>'1', 'creator'=>'1'}
+      assert max_filters_met?
+      @filters={'contributor'=>['1','2']}
+      assert max_filters_met?
+      @filters={'contributor'=>['1','2','3']}
+      assert max_filters_met?
+
+      # logged in but not fully registered
+      user = FactoryBot.create(:brand_new_user)
+      assert_nil user.person
+      User.with_current_user(user) do
+        assert max_filters_met?
+      end
+
+      person = FactoryBot.create(:person)
+      User.with_current_user(person.user) do
+        refute max_filters_met?
+      end
+    end
+  end
+
+
+end


### PR DESCRIPTION
Hide the filter options if max filters has been reached, unless the user is registered and logged in. Also show a warning explaining why. 
Also remove excess filters, should they have been manually added to the URL.
Doesn't affect the API

* fix for #2071 

applied to seek-1.16 for quicker deployment to the Fairdomhub