### PR TITLE
Option needed to create separate SEEK-institutions with identical ROR-id, but manually added department specification

### DIFF
--- a/app/assets/javascripts/institution-ror-typeahead.js.erb
+++ b/app/assets/javascripts/institution-ror-typeahead.js.erb
@@ -90,7 +90,7 @@ function rorQuerySource(query, processSync, processAsync) {
 function localSuggestionTemplate(data) {
     return `
         <div>
-            <strong>${data.department ? `${data.department}, ` : ''}${data.text}</strong>
+            <strong>${data.text}</strong>
             <small>${data.hint || ''}</small>
         </div>`;
 }

--- a/app/assets/javascripts/institution-ror-typeahead.js.erb
+++ b/app/assets/javascripts/institution-ror-typeahead.js.erb
@@ -90,7 +90,7 @@ function rorQuerySource(query, processSync, processAsync) {
 function localSuggestionTemplate(data) {
     return `
         <div>
-            <strong>${data.text}</strong>
+            <strong>${data.department ? `${data.department}, ` : ''}${data.text}</strong>
             <small>${data.hint || ''}</small>
         </div>`;
 }
@@ -172,6 +172,7 @@ $j(document).ready(function () {
         // First Dataset: Local Institutions
         {
             name: 'institutions',
+            limit: 10,
             display: 'text', // Display the 'text' field in the dropdown
             source: function (query, syncResults, asyncResults) {
                 const bloodhound = initializeLocalInstitutions(query);
@@ -235,6 +236,7 @@ $j(document).ready(function () {
             $j('#institution_title').val(data.text);
             $j('#institution_id').val(data.id);
             $j('#institution_ror_id').val(data.ror_id);
+            $j('#institution_department').val(data.department);
             $j('#institution_city').val(data.city);
             $j('#institution_country').val(data.country);
             $j('#institution_web_page').val(data.web_page);

--- a/app/controllers/institutions_controller.rb
+++ b/app/controllers/institutions_controller.rb
@@ -92,6 +92,7 @@ class InstitutionsController < ApplicationController
     items = results.map do |institution|
       { id: institution.id,
         text: institution.title,
+        department: institution.department,
         ror_id: institution.ror_id,
         web_page: institution.web_page,
         city: institution.city,
@@ -148,7 +149,7 @@ class InstitutionsController < ApplicationController
   private
 
   def institution_params
-    params.require(:institution).permit(:title, :web_page, :address, :city, :country, :ror_id,
+    params.require(:institution).permit(:title, :web_page, :address, :city, :country, :ror_id, :department,
                                         discussion_links_attributes:[:id, :url, :label, :_destroy])
   end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -229,20 +229,14 @@ class ProjectsController < ApplicationController
     @project = Project.new(proj_params)
 
     institution_params = params[:institution]
-    department = institution_params[:department].presence
+    department = institution_params[:department]
     ror_id     = institution_params[:ror_id]
     title      = institution_params[:title]
     id         = institution_params[:id]
 
-    @institution = Institution.find_by_id(id) ||
-                   if department
-                     Institution.find_by(ror_id: ror_id, department: department) if ror_id.present? ||
-                                                                                    Institution.find_by(title: title, 
-                                                                                                        department: department)
-                   else
-                     Institution.find_by(ror_id: ror_id) if ror_id.present? ||
-                                                            Institution.find_by(title: title)
-                   end
+    @institution = Institution.find_by(id:id, department: department) ||
+      (Institution.find_by(ror_id: ror_id, department: department) if ror_id.present? ) ||
+                      Institution.find_by(title: title, department: department)
 
     if @institution.nil?
       inst_params = params.require(:institution).permit([:title, :department, :web_page, :city, :country, :ror_id])
@@ -470,7 +464,7 @@ class ProjectsController < ApplicationController
     end
   end
 
-  
+
   # GET /projects/1
   def show
     respond_to do |format|
@@ -671,7 +665,7 @@ class ProjectsController < ApplicationController
       format.html { redirect_to project_path(@project) }
     end
   end
-  
+
   def admin_members
     respond_with(@project)
   end
@@ -743,7 +737,7 @@ class ProjectsController < ApplicationController
       if params['institution']['id']
         @institution = Institution.find(params['institution']['id'])
       else
-        @institution = Institution.new(params.require(:institution).permit([:title, :department,:web_page, :city, 
+        @institution = Institution.new(params.require(:institution).permit([:title, :department,:web_page, :city,
 :country, :ror_id]))
       end
 
@@ -805,7 +799,7 @@ class ProjectsController < ApplicationController
       if params['institution']['id']
         @institution = Institution.find(params['institution']['id'])
       else
-        @institution = Institution.new(params.require(:institution).permit([:title,:department, :web_page, :city, 
+        @institution = Institution.new(params.require(:institution).permit([:title,:department, :web_page, :city,
 :country, :ror_id]))
       end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1109,7 +1109,7 @@ class ProjectsController < ApplicationController
     @people = details.people
     if @institution&.new_record?
       existing_institution = Institution.find_by(ror_id: @institution.ror_id, department: @institution.department.presence) ||
-        Institution.find_by(title: @institution.title, department: @institution.department.presence)
+        Institution.find_by(title: @institution[:title], department: @institution.department.presence)
       @institution = existing_institution if existing_institution
     end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -332,7 +332,7 @@ module ApplicationHelper
   end
 
   def get_object_title(item)
-    h(item.title)
+   item.is_a?(Institution) ? h(item.full_title) : h(item.title)
   end
 
   def can_manage_announcements?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -332,7 +332,7 @@ module ApplicationHelper
   end
 
   def get_object_title(item)
-   item.is_a?(Institution) ? h(item.full_title) : h(item.title)
+    h(item.title)
   end
 
   def can_manage_announcements?

--- a/app/helpers/institutions_helper.rb
+++ b/app/helpers/institutions_helper.rb
@@ -6,4 +6,9 @@ module InstitutionsHelper
   def ror_link(ror_id)
     ror_id.blank? ? text_or_not_specified(nil) : link_to("https://ror.org/#{ror_id}", "https://ror.org/#{ror_id}", target: "_blank", rel: "noopener")
   end
+
+  def other_departments(institution)
+    Institution.where(title: institution.title).where.not(department: institution.department)
+  end
+
 end

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -24,6 +24,13 @@ class Institution < ApplicationRecord
     text :city, :address
   end if Seek::Config.solr_enabled
 
+
+  def full_title
+    return title unless department.present?
+
+    "#{department}, #{title}"
+  end
+
   def can_edit?(user = User.current_user)
     return false unless user
     return true if new_record? && self.class.can_create?

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -25,10 +25,12 @@ class Institution < ApplicationRecord
   end if Seek::Config.solr_enabled
 
 
-  def full_title
-    return title unless department.present?
-
-    "#{department}, #{title}"
+  def title
+    if department.present?
+      "#{department}, #{super}"
+    else
+      super
+    end
   end
 
   def can_edit?(user = User.current_user)

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -7,8 +7,8 @@ class Institution < ApplicationRecord
 
   before_validation :fetch_ror_details, if: -> { ror_id.present? && ror_id_changed? }
 
-  validates :title, uniqueness: true
-  validates :ror_id, uniqueness: true, allow_blank: true
+  validates :title, uniqueness: { scope: :department }
+  validates :ror_id, uniqueness: { scope: :department }, allow_blank: true
   validates :web_page, url: { allow_nil: true, allow_blank: true }
   validates :country, country: true
 

--- a/app/serializers/institution_serializer.rb
+++ b/app/serializers/institution_serializer.rb
@@ -1,6 +1,6 @@
 class InstitutionSerializer < AvatarObjSerializer
   include CountryCodes
-  attributes :title, :ror_id, :country
+  attributes :title, :department, :ror_id, :country
 
   attribute :country_code do
     object.country

--- a/app/views/general/_item_title.html.erb
+++ b/app/views/general/_item_title.html.erb
@@ -6,7 +6,6 @@ avatar = favouritable_icon(version ? display_item : item, 120)
 title_prefix||=""
 title_postfix||=""
 title ||= item.title || ""
-title = item.full_title if item.respond_to?(:full_title)
 title = "#{h(title_prefix) + h(title) + h(title_postfix)}".html_safe
 buttons_partial ||= nil
 col_width = buttons_partial.nil? && !content_for?(:buttons) ? 12 : 6

--- a/app/views/general/_item_title.html.erb
+++ b/app/views/general/_item_title.html.erb
@@ -6,6 +6,7 @@ avatar = favouritable_icon(version ? display_item : item, 120)
 title_prefix||=""
 title_postfix||=""
 title ||= item.title || ""
+title = item.full_title if item.respond_to?(:full_title)
 title = "#{h(title_prefix) + h(title) + h(title_postfix)}".html_safe
 buttons_partial ||= nil
 col_width = buttons_partial.nil? && !content_for?(:buttons) ? 12 : 6

--- a/app/views/institutions/_institution_fields.html.erb
+++ b/app/views/institutions/_institution_fields.html.erb
@@ -32,6 +32,10 @@
     <button type="button" id="fetch-ror-data-with-id" class="btn btn-sm btn-primary">fetch</button>
   </div>
   <div class="form-group">
+    <%= f.label :department -%>
+    <%= f.text_field :department, class:"form-control" -%>
+  </div>
+  <div class="form-group">
     <%= f.label :city -%>
     <%= f.text_field :city, class:"form-control" -%>
   </div>

--- a/app/views/institutions/_resource_list_item.html.erb
+++ b/app/views/institutions/_resource_list_item.html.erb
@@ -1,4 +1,5 @@
 <%= list_item_attribute "ROR ID", ror_link(resource.ror_id) %>
+<%= list_item_attribute "Department", text_or_not_specified(resource.department) %>
 <%= list_item_attribute "Country", (country_text_or_not_specified  resource.country) %>
 <%= list_item_optional_attribute "City", h(resource.city) %>
 <%= list_item_optional_attribute "Web page", h(resource.web_page), h(resource.web_page) %>

--- a/app/views/institutions/_resource_list_item.html.erb
+++ b/app/views/institutions/_resource_list_item.html.erb
@@ -1,3 +1,4 @@
+<%= list_item_attribute "ROR ID", ror_link(resource.ror_id) %>
 <%= list_item_attribute "Country", (country_text_or_not_specified  resource.country) %>
 <%= list_item_optional_attribute "City", h(resource.city) %>
 <%= list_item_optional_attribute "Web page", h(resource.web_page), h(resource.web_page) %>

--- a/app/views/institutions/_select_or_define.html.erb
+++ b/app/views/institutions/_select_or_define.html.erb
@@ -35,6 +35,11 @@
 </div>
 
 <div class="form-group">
+  <label class="control-label">Department</label>
+  <%= text_field_tag('institution[department]', @institution.department, class:'form-control') %>
+</div>
+
+<div class="form-group">
   <label class="control-label">Website</label>
   <%= text_field_tag('institution[web_page]', @institution.web_page, class:'form-control') %>
 </div>

--- a/app/views/institutions/edit.html.erb
+++ b/app/views/institutions/edit.html.erb
@@ -1,4 +1,4 @@
-<h1>Edit <%= t('institution') -%>: <%= link_to @institution.full_title, institution_path(@institution) -%></h1>
+<h1>Edit <%= t('institution') -%>: <%= link_to @institution.title, institution_path(@institution) -%></h1>
 
 <div class="asset_form">
 	<%= form_for(@institution) do |f| %>

--- a/app/views/institutions/edit.html.erb
+++ b/app/views/institutions/edit.html.erb
@@ -1,4 +1,4 @@
-<h1>Edit <%= t('institution') -%>: <%= link_to @institution.title, institution_path(@institution) -%></h1>
+<h1>Edit <%= t('institution') -%>: <%= link_to @institution.full_title, institution_path(@institution) -%></h1>
 
 <div class="asset_form">
 	<%= form_for(@institution) do |f| %>

--- a/app/views/institutions/show.html.erb
+++ b/app/views/institutions/show.html.erb
@@ -30,6 +30,16 @@
         <p class="address">
           <strong>Address: </strong><%= text_or_not_specified @institution.address, :address => true %>
         </p>
+
+          <p class="related-departments">
+            <strong>Other Departments: </strong>
+              <% Institution.where(title: @institution.title).where.not(department: @institution.department).each do |inst| %>
+                <div>
+                   <%= link_to(inst.full_title, inst) %>
+                </div>
+              <% end %>
+          </p>
+
       </div>
 
       <div class="col-md-3 col-sm-4">

--- a/app/views/institutions/show.html.erb
+++ b/app/views/institutions/show.html.erb
@@ -31,14 +31,16 @@
           <strong>Address: </strong><%= text_or_not_specified @institution.address, :address => true %>
         </p>
 
+        <% if other_departments(@institution).present? %>
           <p class="related-departments">
-            <strong>Other Departments: </strong>
-              <% Institution.where(title: @institution.title).where.not(department: @institution.department).each do |inst| %>
-                <div>
-                   <%= link_to(inst.full_title, inst) %>
-                </div>
-              <% end %>
+            <strong>Related Departments: </strong>
+            <% other_departments(@institution).each do |related_dep| %>
+              <div>
+                <%= link_to(related_dep.full_title, related_dep) %>
+              </div>
+            <% end %>
           </p>
+        <% end  %>
 
       </div>
 

--- a/app/views/institutions/show.html.erb
+++ b/app/views/institutions/show.html.erb
@@ -8,6 +8,10 @@
       <div class="col-md-9 col-sm-8 box_about_actor">
 
         <p class="ror_id">
+          <strong>Department: </strong><%= text_or_not_specified @institution.department -%>
+        </p>
+
+        <p class="ror_id">
           <strong>ROR ID: </strong><%= ror_link(@institution.ror_id) -%>
         </p>
 

--- a/app/views/institutions/show.html.erb
+++ b/app/views/institutions/show.html.erb
@@ -36,7 +36,7 @@
             <strong>Related Departments: </strong>
             <% other_departments(@institution).each do |related_dep| %>
               <div>
-                <%= link_to(related_dep.full_title, related_dep) %>
+                <%= link_to(related_dep.title, related_dep) %>
               </div>
             <% end %>
           </p>

--- a/app/views/mailer/request_create_project_and_programme.text.erb
+++ b/app/views/mailer/request_create_project_and_programme.text.erb
@@ -20,12 +20,14 @@ They provided the following details about the <%= t('project') %>
 <% if @institution.id.nil? %>
   <%
     title = @institution.title.blank? ? 'No title provided' : @institution.title
+    department = @institution.department.blank? ? 'No department provided' : @institution.department
     web_page = @institution.web_page.blank? ? 'No web page provided' : @institution.web_page
     country = @institution.country.blank? ? 'No country provided' : CountryCodes.country(@institution.country)
 
   %>
 They provided the following details about their <%= t('institution') %>:
   <%= t('institution') %> title: '<%= title %>'
+  <%= t('institution') %> department: '<%= department %>'
   <%= t('institution') %> web page: '<%= web_page %>'
   <%= t('institution') %> country: '<%= country %>'
 <% else %>

--- a/app/views/mailer/request_create_project_for_programme.text.erb
+++ b/app/views/mailer/request_create_project_for_programme.text.erb
@@ -20,12 +20,14 @@ They provided the following details about the <%= t('project') %>
 <% if @institution.id.nil? %>
   <%
     title = @institution.title.blank? ? 'No title provided' : @institution.title
+    department = @institution.department.blank? ? 'No department provided' : @institution.department
     web_page = @institution.web_page.blank? ? 'No web page provided' : @institution.web_page
     country = @institution.country.blank? ? 'No country provided' : CountryCodes.country(@institution.country)
 
   %>
 They provided the following details about their <%= t('institution') %>:
   <%= t('institution') %> title: '<%= title %>'
+  <%= t('institution') %> department: '<%= department %>'
   <%= t('institution') %> web page: '<%= web_page %>'
   <%= t('institution') %> country: '<%= country %>'
 <% else %>

--- a/app/views/mailer/request_import_project_and_programme.text.erb
+++ b/app/views/mailer/request_import_project_and_programme.text.erb
@@ -20,12 +20,14 @@ They provided the following details about the <%= t('project') %>
 <% if @institution.id.nil? %>
   <%
     title = @institution.title.blank? ? 'No title provided' : @institution.title
+    department = @institution.department.blank? ? 'No department provided' : @institution.department
     web_page = @institution.web_page.blank? ? 'No web page provided' : @institution.web_page
     country = @institution.country.blank? ? 'No country provided' : CountryCodes.country(@institution.country)
 
   %>
 They provided the following details about their <%= t('institution') %>:
   <%= t('institution') %> title: '<%= title %>'
+  <%= t('institution') %> department: '<%= department %>'
   <%= t('institution') %> web page: '<%= web_page %>'
   <%= t('institution') %> country: '<%= country %>'
 <% else %>

--- a/app/views/mailer/request_import_project_for_programme.text.erb
+++ b/app/views/mailer/request_import_project_for_programme.text.erb
@@ -20,12 +20,14 @@ They provided the following details about the <%= t('project') %>
 <% if @institution.id.nil? %>
   <%
     title = @institution.title.blank? ? 'No title provided' : @institution.title
+    department = @institution.department.blank? ? 'No department provided' : @institution.department
     web_page = @institution.web_page.blank? ? 'No web page provided' : @institution.web_page
     country = @institution.country.blank? ? 'No country provided' : CountryCodes.country(@institution.country)
 
   %>
 They provided the following details about their <%= t('institution') %>:
   <%= t('institution') %> title: '<%= title %>'
+  <%= t('institution') %> department: '<%= department %>'
   <%= t('institution') %> web page: '<%= web_page %>'
   <%= t('institution') %> country: '<%= country %>'
 <% else %>

--- a/app/views/mailer/request_join_project.text.erb
+++ b/app/views/mailer/request_join_project.text.erb
@@ -6,12 +6,14 @@ The <%= Seek::Config.instance_name %> user <%= "#{@requester.name} (#{person_url
 <% if @institution.id.nil? %>
   <%
     title = @institution.title.blank? ? 'No title provided' : @institution.title
+    department = @institution.department.blank? ? 'No department provided' : @institution.department
     web_page = @institution.web_page.blank? ? 'No web page provided' : @institution.web_page
     country = @institution.country.blank? ? 'No country provided' : CountryCodes.country(@institution.country)
 
   %>
 They provided the following details about their <%= t('institution') %>:
   <%= t('institution') %> title: '<%= title %>'
+  <%= t('institution') %> department: '<%= department %>'
   <%= t('institution') %> web page: '<%= web_page %>'
   <%= t('institution') %> country: '<%= country %>'
 <% else %>

--- a/app/views/projects/administer_create_project_request.html.erb
+++ b/app/views/projects/administer_create_project_request.html.erb
@@ -71,6 +71,9 @@
                   <%= label_tag 'ROR ID','ROR ID' %>
                   <%= text_field_tag 'institution[ror_id]',@institution.ror_id, class:'form-control' %>
 
+                  <%= label_tag 'Department' %>
+                  <%= text_field_tag 'institution[department]',@institution.department, class:'form-control' %>
+
                   <%= label_tag 'Website' %>
                   <%= text_field_tag 'institution[web_page]',@institution.web_page, class:'form-control' %>
 
@@ -84,7 +87,7 @@
               </div>
             <% else %>
               <div>
-                They wish to be associated with <%= link_to(@institution.title, @institution) %>
+                They wish to be associated with  <%= link_to([@institution.department.presence, @institution.title].compact.join(', '), @institution) %>.
               </div>
               <%= hidden_field_tag 'institution[id]',@institution.id %>
             <% end %>

--- a/app/views/projects/administer_create_project_request.html.erb
+++ b/app/views/projects/administer_create_project_request.html.erb
@@ -87,7 +87,7 @@
               </div>
             <% else %>
               <div>
-                They wish to be associated with  <%= link_to([@institution.department.presence, @institution.title].compact.join(', '), @institution) %>.
+                They wish to be associated with  <%= link_to(@institution.full_title, @institution) %>.
               </div>
               <%= hidden_field_tag 'institution[id]',@institution.id %>
             <% end %>

--- a/app/views/projects/administer_create_project_request.html.erb
+++ b/app/views/projects/administer_create_project_request.html.erb
@@ -87,7 +87,7 @@
               </div>
             <% else %>
               <div>
-                They wish to be associated with  <%= link_to(@institution.full_title, @institution) %>.
+                They wish to be associated with <%= link_to(@institution.title, @institution) %>
               </div>
               <%= hidden_field_tag 'institution[id]',@institution.id %>
             <% end %>

--- a/app/views/projects/administer_import_project_request.html.erb
+++ b/app/views/projects/administer_import_project_request.html.erb
@@ -83,7 +83,7 @@
               </div>
             <% else %>
               <div>
-                They wish to be associated with <%= link_to(@institution.full_title, @institution) %>
+                They wish to be associated with <%= link_to(@institution.title, @institution) %>
               </div>
               <%= hidden_field_tag 'institution[id]',@institution.id %>
             <% end %>

--- a/app/views/projects/administer_import_project_request.html.erb
+++ b/app/views/projects/administer_import_project_request.html.erb
@@ -68,6 +68,9 @@
                   <%= label_tag 'Title' %><span class="required">*</span>
                   <%= text_field_tag 'institution[title]',@institution.title, class:'form-control' %>
 
+                  <%= label_tag 'Department' %>
+                  <%= text_field_tag 'institution[department]',@institution.department, class:'form-control' %>
+
                   <%= label_tag 'Website' %>
                   <%= text_field_tag 'institution[web_page]',@institution.web_page, class:'form-control' %>
 
@@ -80,7 +83,7 @@
               </div>
             <% else %>
               <div>
-                They wish to be associated with <%= link_to(@institution.title, @institution) %>
+                They wish to be associated with <%= link_to(@institution.full_title, @institution) %>
               </div>
               <%= hidden_field_tag 'institution[id]',@institution.id %>
             <% end %>

--- a/app/views/projects/administer_join_request.html.erb
+++ b/app/views/projects/administer_join_request.html.erb
@@ -45,7 +45,7 @@
             </div>
           <% else %>
             <div>
-              They wish to be associated with <%= link_to(@institution.full_title, @institution) %>
+              They wish to be associated with <%= link_to(@institution.title, @institution) %>
             </div>
             <%= hidden_field_tag 'institution[id]',@institution.id %>
           <% end %>

--- a/app/views/projects/administer_join_request.html.erb
+++ b/app/views/projects/administer_join_request.html.erb
@@ -30,6 +30,9 @@
                 <%= label_tag 'Title' %><span class="required">*</span>
                 <%= text_field_tag 'institution[title]',@institution.title, class:'form-control' %>
 
+                <%= label_tag 'Department' %>
+                <%= text_field_tag 'institution[department]',@institution.department, class:'form-control' %>
+
                 <%= label_tag 'Website' %>
                 <%= text_field_tag 'institution[web_page]',@institution.web_page, class:'form-control' %>
 
@@ -42,7 +45,7 @@
             </div>
           <% else %>
             <div>
-              They wish to be associated with <%= link_to(@institution.title, @institution) %>
+              They wish to be associated with <%= link_to(@institution.full_title, @institution) %>
             </div>
             <%= hidden_field_tag 'institution[id]',@institution.id %>
           <% end %>

--- a/app/views/projects/request_create.html.erb
+++ b/app/views/projects/request_create.html.erb
@@ -46,9 +46,9 @@
             You have described a new <%= t('institution') %> with the following details:
           <ul>
             <li><strong>Title:</strong> <%= text_or_not_specified(@institution.title) %></li>
+            <li><strong>Department:</strong> <%= text_or_not_specified(@institution.department) %></li>
             <li><strong>ROR ID:</strong> <%= ror_link(@institution.ror_id) %></li>
-            <li><strong>Web page:</strong> <%= text_or_not_specified(@institution.web_page, external_link: true) -%>
-            </li>
+            <li><strong>Web page:</strong> <%= text_or_not_specified(@institution.web_page, external_link: true) -%></li>
             <li><strong>City:</strong> <%= text_or_not_specified(@institution.city) -%></li>
             <li><strong>Country:</strong> <%= country_text_or_not_specified @institution.country -%></li>
           </ul>

--- a/app/views/projects/request_create.html.erb
+++ b/app/views/projects/request_create.html.erb
@@ -53,7 +53,7 @@
             <li><strong>Country:</strong> <%= country_text_or_not_specified @institution.country -%></li>
           </ul>
         <% else %>
-          You have indicated that you are associated with <%= link_to(@institution.title, @institution) %>
+          You have indicated that you are associated with <%= link_to(@institution.full_title, @institution) %>
         <% end %>
         </p>
 

--- a/app/views/projects/request_create.html.erb
+++ b/app/views/projects/request_create.html.erb
@@ -53,7 +53,7 @@
             <li><strong>Country:</strong> <%= country_text_or_not_specified @institution.country -%></li>
           </ul>
         <% else %>
-          You have indicated that you are associated with <%= link_to(@institution.full_title, @institution) %>
+          You have indicated that you are associated with <%= link_to(@institution.title, @institution) %>
         <% end %>
         </p>
 

--- a/app/views/projects/request_join.html.erb
+++ b/app/views/projects/request_join.html.erb
@@ -19,6 +19,7 @@
               You have described a new <%= t('institution') %> with the following details:
             <ul>
               <li><strong>Title:</strong><%= text_or_not_specified(@institution.title) %></li>
+              <li><strong>Department:</strong><%= text_or_not_specified(@institution.department) %></li>
               <li><strong>Web page:</strong><%= text_or_not_specified(@institution.web_page, external_link:true) -%></li>
               <li><strong>City:</strong><%= text_or_not_specified(@institution.city) -%></li>
               <li><strong>Country:</strong><%= country_text_or_not_specified @institution.country -%></li>

--- a/db/migrate/20250512075916_add_department_to_institutions.rb
+++ b/db/migrate/20250512075916_add_department_to_institutions.rb
@@ -1,0 +1,5 @@
+class AddDepartmentToInstitutions < ActiveRecord::Migration[7.2]
+  def change
+    add_column :institutions, :department, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_20_141118) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_12_075916) do
   create_table "activity_logs", id: :integer, force: :cascade do |t|
     t.string "action"
     t.string "format"
@@ -926,6 +926,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_20_141118) do
     t.string "first_letter", limit: 1
     t.string "uuid"
     t.string "ror_id"
+    t.string "department"
   end
 
   create_table "investigation_auth_lookup", force: :cascade do |t|

--- a/lib/seek/project_message_log_details.rb
+++ b/lib/seek/project_message_log_details.rb
@@ -26,7 +26,7 @@ module Seek
 
     REQUIRED_ATTRIBUTES = {
       Project => %w[id title description web_page programme_id],
-      Institution => %w[id title city country web_page ror_id],
+      Institution => %w[id title city country web_page ror_id department],
       Person => %w[id first_name last_name email],
       Programme => %w[id title description]
     }.freeze

--- a/lib/seek/title_trimmer.rb
+++ b/lib/seek/title_trimmer.rb
@@ -14,6 +14,7 @@ module Seek
 
     module InstanceMethods
       def trim_title
+        title = self[:title]
         self.title = title.strip if has_attribute?(:title) && title
       end
     end

--- a/public/api/definitions/_schemas.yml
+++ b/public/api/definitions/_schemas.yml
@@ -1791,6 +1791,8 @@ institutionPost:
               $ref: "#/components/schemas/nullableUriString"
             title:
               $ref: "#/components/schemas/nonEmptyString"
+            department:
+              $ref: "#/components/schemas/nullableNonEmptyString"
             ror_id:
               $ref: "#/components/schemas/nullableNonEmptyString"
             country:
@@ -1831,6 +1833,8 @@ institutionPatch:
               $ref: "#/components/schemas/nullableUriString"
             title:
               $ref: "#/components/schemas/nonEmptyString"
+            department:
+              $ref: "#/components/schemas/nullableNonEmptyString"
             ror_id:
               $ref: "#/components/schemas/nullableNonEmptyString"
             country:
@@ -3752,6 +3756,8 @@ institutionResponse:
               $ref: "#/components/schemas/nullableUriString"
             title:
               $ref: "#/components/schemas/nonEmptyString"
+            department:
+              $ref: "#/components/schemas/nullableNonEmptyString"
             ror_id:
               $ref: "#/components/schemas/nullableNonEmptyString"
             country:

--- a/public/api/examples/institutionPatch.json
+++ b/public/api/examples/institutionPatch.json
@@ -1,13 +1,13 @@
 {
   "data": {
     "type": "institutions",
-    "id": "1572",
+    "id": "980192435",
     "attributes": {
-      "title": "Patched institution",
+      "title": "University of Manchester",
       "ror_id": "027m9bs27",
-      "web_page": "http://my.institution.com",
-      "country": "Germany",
-      "city": "Heidelberg",
+      "web_page": "http://www.manchester.ac.uk/",
+      "country": "United Kingdom",
+      "city": "Manchester",
       "address": "NoName street 23"
     }
   }

--- a/public/api/examples/institutionPatchResponse.json
+++ b/public/api/examples/institutionPatchResponse.json
@@ -1,19 +1,20 @@
 {
   "data": {
-    "id": "1572",
+    "id": "980192435",
     "type": "institutions",
     "attributes": {
       "discussion_links": [
 
       ],
       "avatar": null,
-      "title": "Patched institution",
+      "title": "University of Manchester",
+      "department": null,
       "ror_id": "027m9bs27",
-      "country": "Germany",
-      "country_code": "DE",
-      "city": "Heidelberg",
+      "country": "United Kingdom",
+      "country_code": "GB",
+      "city": "Manchester",
       "address": "NoName street 23",
-      "web_page": "http://my.institution.com"
+      "web_page": "http://www.manchester.ac.uk/"
     },
     "relationships": {
       "people": {
@@ -28,14 +29,14 @@
       }
     },
     "links": {
-      "self": "/institutions/1572"
+      "self": "/institutions/980192435"
     },
     "meta": {
-      "created": "2024-11-20T10:14:31.000Z",
-      "modified": "2024-11-20T10:14:31.000Z",
+      "created": "2025-05-12T10:01:49.310Z",
+      "modified": "2025-05-12T10:01:49.326Z",
       "api_version": "0.3",
       "base_url": "http://localhost:3000",
-      "uuid": "2864d0a0-8956-013d-24a2-0a81884ed284"
+      "uuid": "0b6c3040-1146-013e-72d8-7efdca78d793"
     }
   },
   "jsonapi": {

--- a/public/api/examples/institutionPost.json
+++ b/public/api/examples/institutionPost.json
@@ -2,12 +2,12 @@
   "data": {
     "type": "institutions",
     "attributes": {
-      "title": "Post Institution 1555 Max",
+      "title": "University of Manchester",
       "ror_id": "027m9bs27",
       "country": "United Kingdom",
       "city": "Manchester",
       "address": "Manchester Centre for Integrative Systems Biology, MIB/CEAS, The University of Manchester Faraday Building, Sackville Street, Manchester M60 1QD United Kingdom",
-      "web_page": "http://www.mib.ac.uk/"
+      "web_page": "http://www.manchester.ac.uk/"
     }
   }
 }

--- a/public/api/examples/institutionPostResponse.json
+++ b/public/api/examples/institutionPostResponse.json
@@ -1,19 +1,20 @@
 {
   "data": {
-    "id": "1555",
+    "id": "980192418",
     "type": "institutions",
     "attributes": {
       "discussion_links": [
 
       ],
       "avatar": null,
-      "title": "Post Institution 1555 Max",
+      "title": "University of Manchester",
+      "department": null,
       "ror_id": "027m9bs27",
       "country": "United Kingdom",
       "country_code": "GB",
       "city": "Manchester",
       "address": "Manchester Centre for Integrative Systems Biology, MIB/CEAS, The University of Manchester Faraday Building, Sackville Street, Manchester M60 1QD United Kingdom",
-      "web_page": "http://www.mib.ac.uk/"
+      "web_page": "http://www.manchester.ac.uk/"
     },
     "relationships": {
       "people": {
@@ -28,14 +29,14 @@
       }
     },
     "links": {
-      "self": "/institutions/1555"
+      "self": "/institutions/980192418"
     },
     "meta": {
-      "created": "2024-11-20T10:14:30.000Z",
-      "modified": "2024-11-20T10:14:30.000Z",
+      "created": "2025-05-12T10:01:48.837Z",
+      "modified": "2025-05-12T10:01:48.837Z",
       "api_version": "0.3",
       "base_url": "http://localhost:3000",
-      "uuid": "27d3ed50-8956-013d-24a2-0a81884ed284"
+      "uuid": "0b22ce80-1146-013e-72d8-7efdca78d793"
     }
   },
   "jsonapi": {

--- a/public/api/examples/institutionResponse.json
+++ b/public/api/examples/institutionResponse.json
@@ -1,23 +1,24 @@
 {
   "data": {
-    "id": "1568",
+    "id": "980192431",
     "type": "institutions",
     "attributes": {
       "discussion_links": [
         {
-          "id": "62",
+          "id": "50",
           "label": "Slack",
           "url": "http://www.slack.com/"
         }
       ],
       "avatar": null,
-      "title": "A Maximal Institution",
+      "title": "University of Manchester",
+      "department": "Manchester Institute of Biotechnology",
       "ror_id": "027m9bs27",
       "country": "United Kingdom",
       "country_code": "GB",
       "city": "Manchester",
       "address": "Manchester Centre for Integrative Systems Biology, MIB/CEAS, The University of Manchester Faraday Building, Sackville Street, Manchester M60 1QD United Kingdom",
-      "web_page": "http://www.mib.ac.uk/"
+      "web_page": "http://www.manchester.ac.uk/"
     },
     "relationships": {
       "people": {
@@ -32,14 +33,14 @@
       }
     },
     "links": {
-      "self": "/institutions/1568"
+      "self": "/institutions/980192431"
     },
     "meta": {
-      "created": "2024-11-20T10:14:31.000Z",
-      "modified": "2024-11-20T10:14:31.000Z",
+      "created": "2025-05-12T10:01:49.186Z",
+      "modified": "2025-05-12T10:01:49.186Z",
       "api_version": "0.3",
       "base_url": "http://localhost:3000",
-      "uuid": "283e6e30-8956-013d-24a2-0a81884ed284"
+      "uuid": "0b585ca0-1146-013e-72d8-7efdca78d793"
     }
   },
   "jsonapi": {

--- a/public/api/examples/institutionsResponse.json
+++ b/public/api/examples/institutionsResponse.json
@@ -1,33 +1,33 @@
 {
   "data": [
     {
-      "id": "1562",
-      "type": "institutions",
-      "attributes": {
-        "title": "A Maximal Institution"
-      },
-      "links": {
-        "self": "/institutions/1562"
-      }
-    },
-    {
-      "id": "1560",
+      "id": "980192423",
       "type": "institutions",
       "attributes": {
         "title": "A Minimal Institution"
       },
       "links": {
-        "self": "/institutions/1560"
+        "self": "/institutions/980192423"
       }
     },
     {
-      "id": "1561",
+      "id": "980192424",
       "type": "institutions",
       "attributes": {
-        "title": "An Institution: 1553"
+        "title": "An Institution: 90"
       },
       "links": {
-        "self": "/institutions/1561"
+        "self": "/institutions/980192424"
+      }
+    },
+    {
+      "id": "980192425",
+      "type": "institutions",
+      "attributes": {
+        "title": "University of Manchester"
+      },
+      "links": {
+        "self": "/institutions/980192425"
       }
     }
   ],

--- a/test/factories/institutions.rb
+++ b/test/factories/institutions.rb
@@ -12,6 +12,7 @@ FactoryBot.define do
   
   factory(:max_institution, class: Institution) do
     title { "University of Manchester" }
+    department { "Manchester Institute of Biotechnology" }
     country { "GB" }
     city { "Manchester" }
     ror_id { "027m9bs27" }

--- a/test/fixtures/json/responses/get_max_institution.json.erb
+++ b/test/fixtures/json/responses/get_max_institution.json.erb
@@ -5,6 +5,7 @@
     "attributes": {
       "avatar": null,
       "title": "University of Manchester",
+      "department": "Manchester Institute of Biotechnology",
       "ror_id": "027m9bs27",
       "country": "United Kingdom",
       "country_code": "GB",

--- a/test/fixtures/json/responses/get_max_institution.json.erb
+++ b/test/fixtures/json/responses/get_max_institution.json.erb
@@ -4,7 +4,7 @@
     "type": "institutions",
     "attributes": {
       "avatar": null,
-      "title": "University of Manchester",
+      "title": "Manchester Institute of Biotechnology, University of Manchester",
       "department": "Manchester Institute of Biotechnology",
       "ror_id": "027m9bs27",
       "country": "United Kingdom",

--- a/test/fixtures/json/responses/get_min_institution.json.erb
+++ b/test/fixtures/json/responses/get_min_institution.json.erb
@@ -5,6 +5,7 @@
     "attributes": {
       "avatar": null,
       "title": "A Minimal Institution",
+      "department": null,
       "ror_id": null,
       "country": "Germany",
       "country_code": "DE",

--- a/test/functional/institutions_controller_test.rb
+++ b/test/functional/institutions_controller_test.rb
@@ -70,15 +70,64 @@ class InstitutionsControllerTest < ActionController::TestCase
     assert_select 'h1', text: 'Manchester Institute of Biotechnology, University of Manchester', count: 1
   end
 
-  def test_should_create_institution_with_title_department
+  def test_should_create_institution_with_or_without_title_department_
 
+    # If creating a new institution with a title first,
+    # it should still be possible to create another institution with the same title but a different department.
     assert_difference('Institution.count') do
-      post :create, params: { institution: { title: 'German Cancer Research Center', department: 'Division of Applied Bioinformatics' } }
+      post :create, params: { institution: { title: 'Institution 1', department: 'Division 1' } }
     end
 
     assert_redirected_to institution_path(assigns(:institution))
-    assert_equal 'German Cancer Research Center', assigns(:institution).title
-    assert_equal 'Division of Applied Bioinformatics', assigns(:institution).department
+    assert_equal 'Institution 1', assigns(:institution).title
+    assert_equal 'Division 1', assigns(:institution).department
+    assert_equal 'Division 1, Institution 1', assigns(:institution).full_title
+
+    get :show, params: { id: assigns(:institution) }
+    assert_select 'h1', text: 'Division 1, Institution 1', count: 1
+
+    assert_difference('Institution.count') do
+      post :create, params: { institution: { title: 'Institution 1' }}
+    end
+
+    assert_equal 'Institution 1', assigns(:institution).title
+    assert_equal 'Institution 1', assigns(:institution).full_title
+
+    get :show, params: { id: assigns(:institution) }
+    assert_select 'h1', text: 'Institution 1', count: 1
+
+
+    assert_difference('Institution.count') do
+      post :create, params: { institution: { title: 'Institution 1',department: 'Division 2' }}
+    end
+
+    assert_equal 'Institution 1', assigns(:institution).title
+    assert_equal 'Division 2, Institution 1', assigns(:institution).full_title
+
+    # If creating a new institution with a title and a department first,
+    # it should still be possible to create another institution with the title but without a different department.
+    assert_difference('Institution.count') do
+      post :create, params: { institution: { title: 'Institution 2' }}
+    end
+
+    assert_equal 'Institution 2', assigns(:institution).title
+    assert_equal 'Institution 2', assigns(:institution).full_title
+
+    get :show, params: { id: assigns(:institution) }
+    assert_select 'h1', text: 'Institution 2', count: 1
+
+    assert_difference('Institution.count') do
+      post :create, params: { institution: { title: 'Institution 2', department: 'Division 2' } }
+    end
+
+    assert_redirected_to institution_path(assigns(:institution))
+    assert_equal 'Institution 2', assigns(:institution).title
+    assert_equal 'Division 2', assigns(:institution).department
+    assert_equal 'Division 2, Institution 2', assigns(:institution).full_title
+
+    get :show, params: { id: assigns(:institution) }
+    assert_select 'h1', text: 'Division 2, Institution 2', count: 1
+
   end
 
 

--- a/test/functional/institutions_controller_test.rb
+++ b/test/functional/institutions_controller_test.rb
@@ -53,6 +53,21 @@ class InstitutionsControllerTest < ActionController::TestCase
 
     assert_redirected_to institution_path(assigns(:institution))
     assert_equal 'test', assigns(:institution).title
+    assert_equal 'test', assigns(:institution).full_title
+
+    get :show, params: { id: assigns(:institution) }
+    assert_select 'h1', text: 'test', count: 1
+
+
+    assert_difference('Institution.count') do
+      post :create, params: { institution: { title: 'University of Manchester', department: 'Manchester Institute of Biotechnology'} }
+    end
+
+    assert_redirected_to institution_path(assigns(:institution))
+    assert_equal 'University of Manchester', assigns(:institution).title
+    assert_equal 'Manchester Institute of Biotechnology, University of Manchester', assigns(:institution).full_title
+    get :show, params: { id: assigns(:institution) }
+    assert_select 'h1', text: 'Manchester Institute of Biotechnology, University of Manchester', count: 1
   end
 
   def test_should_create_institution_with_title_department

--- a/test/functional/institutions_controller_test.rb
+++ b/test/functional/institutions_controller_test.rb
@@ -55,6 +55,17 @@ class InstitutionsControllerTest < ActionController::TestCase
     assert_equal 'test', assigns(:institution).title
   end
 
+  def test_should_create_institution_with_title_department
+
+    assert_difference('Institution.count') do
+      post :create, params: { institution: { title: 'German Cancer Research Center', department: 'Division of Applied Bioinformatics' } }
+    end
+
+    assert_redirected_to institution_path(assigns(:institution))
+    assert_equal 'German Cancer Research Center', assigns(:institution).title
+    assert_equal 'Division of Applied Bioinformatics', assigns(:institution).department
+  end
+
 
   def test_can_not_create_institution_with_invalid_ror_id
     VCR.use_cassette("ror/fetch_invalid_id") do

--- a/test/functional/institutions_controller_test.rb
+++ b/test/functional/institutions_controller_test.rb
@@ -53,7 +53,6 @@ class InstitutionsControllerTest < ActionController::TestCase
 
     assert_redirected_to institution_path(assigns(:institution))
     assert_equal 'test', assigns(:institution).title
-    assert_equal 'test', assigns(:institution).full_title
 
     get :show, params: { id: assigns(:institution) }
     assert_select 'h1', text: 'test', count: 1
@@ -64,8 +63,7 @@ class InstitutionsControllerTest < ActionController::TestCase
     end
 
     assert_redirected_to institution_path(assigns(:institution))
-    assert_equal 'University of Manchester', assigns(:institution).title
-    assert_equal 'Manchester Institute of Biotechnology, University of Manchester', assigns(:institution).full_title
+    assert_equal 'Manchester Institute of Biotechnology, University of Manchester', assigns(:institution).title
     get :show, params: { id: assigns(:institution) }
     assert_select 'h1', text: 'Manchester Institute of Biotechnology, University of Manchester', count: 1
   end
@@ -79,9 +77,8 @@ class InstitutionsControllerTest < ActionController::TestCase
     end
 
     assert_redirected_to institution_path(assigns(:institution))
-    assert_equal 'Institution 1', assigns(:institution).title
     assert_equal 'Division 1', assigns(:institution).department
-    assert_equal 'Division 1, Institution 1', assigns(:institution).full_title
+    assert_equal 'Division 1, Institution 1', assigns(:institution).title
 
     get :show, params: { id: assigns(:institution) }
     assert_select 'h1', text: 'Division 1, Institution 1', count: 1
@@ -91,7 +88,6 @@ class InstitutionsControllerTest < ActionController::TestCase
     end
 
     assert_equal 'Institution 1', assigns(:institution).title
-    assert_equal 'Institution 1', assigns(:institution).full_title
 
     get :show, params: { id: assigns(:institution) }
     assert_select 'h1', text: 'Institution 1', count: 1
@@ -101,8 +97,7 @@ class InstitutionsControllerTest < ActionController::TestCase
       post :create, params: { institution: { title: 'Institution 1',department: 'Division 2' }}
     end
 
-    assert_equal 'Institution 1', assigns(:institution).title
-    assert_equal 'Division 2, Institution 1', assigns(:institution).full_title
+    assert_equal 'Division 2, Institution 1', assigns(:institution).title
 
     # If creating a new institution with a title and a department first,
     # it should still be possible to create another institution with the title but without a different department.
@@ -111,7 +106,6 @@ class InstitutionsControllerTest < ActionController::TestCase
     end
 
     assert_equal 'Institution 2', assigns(:institution).title
-    assert_equal 'Institution 2', assigns(:institution).full_title
 
     get :show, params: { id: assigns(:institution) }
     assert_select 'h1', text: 'Institution 2', count: 1
@@ -121,9 +115,8 @@ class InstitutionsControllerTest < ActionController::TestCase
     end
 
     assert_redirected_to institution_path(assigns(:institution))
-    assert_equal 'Institution 2', assigns(:institution).title
     assert_equal 'Division 2', assigns(:institution).department
-    assert_equal 'Division 2, Institution 2', assigns(:institution).full_title
+    assert_equal 'Division 2, Institution 2', assigns(:institution).title
 
     get :show, params: { id: assigns(:institution) }
     assert_select 'h1', text: 'Division 2, Institution 2', count: 1
@@ -166,7 +159,7 @@ class InstitutionsControllerTest < ActionController::TestCase
       end
 
       assert_redirected_to institution_path(assigns(:institution))
-      assert_equal 'Harvard University', assigns(:institution).title
+      assert_equal 'Applied Mathematics, Harvard University', assigns(:institution).title
       assert_equal 'Applied Mathematics', assigns(:institution).department
 
       assert_difference('Institution.count') do
@@ -174,7 +167,7 @@ class InstitutionsControllerTest < ActionController::TestCase
       end
 
       assert_redirected_to institution_path(assigns(:institution))
-      assert_equal 'Harvard University', assigns(:institution).title
+      assert_equal 'Computer Science, Harvard University', assigns(:institution).title
       assert_equal 'Computer Science', assigns(:institution).department
       assert_equal '03vek6s52', assigns(:institution).ror_id
 

--- a/test/functional/projects_controller_test.rb
+++ b/test/functional/projects_controller_test.rb
@@ -2204,7 +2204,7 @@ class ProjectsControllerTest < ActionController::TestCase
     with_config_value(:managed_programme_id, nil) do
       params = {
         project: { title: 'The Project',description:'description',web_page:'web_page'},
-        institution: {id: [institution.id]}
+        institution: {id: institution.id}
       }
       assert_enqueued_emails(0) do
         assert_difference('ProjectCreationMessageLog.count',1) do
@@ -2237,7 +2237,7 @@ class ProjectsControllerTest < ActionController::TestCase
     with_config_value(:managed_programme_id, programme.id) do
       params = {
         project: { title: 'The Project', description:'description', web_page:'web_page'},
-        institution: { title: institution_existing.title},
+        institution: { title: institution_existing.title, department:'Manchester Institute of Biotechnology' },
         programme_id: '',
         programme: {title: 'the prog'}
       }
@@ -2256,11 +2256,15 @@ class ProjectsControllerTest < ActionController::TestCase
       assert_response :success
       assert flash[:notice]
 
-      assert_select 'p', text: /You have indicated that you are associated with #{institution_existing.title}/
-
+      assert_select 'p' do
+        assert_select 'a', text: 'Manchester Institute of Biotechnology, University of Manchester'
+        assert_select 'p', /You have indicated that you are associated with/
+      end
     end
 
 
+    # institution_existing has the department.
+    # if creating a new institution with the same title or ror id, but without department, it is considered a new institution
     with_config_value(:managed_programme_id, programme.id) do
       params = {
         project: { title: 'The Project', description:'description', web_page:'web_page'},
@@ -2281,9 +2285,7 @@ class ProjectsControllerTest < ActionController::TestCase
       end
 
       assert_response :success
-      assert flash[:notice]
-
-      assert_select 'p', text: /You have indicated that you are associated with #{institution_existing.title}/
+      assert_select 'p', text: /You have described a new Institution with the following details:/
 
     end
 
@@ -3017,21 +3019,24 @@ class ProjectsControllerTest < ActionController::TestCase
 
     login_as(person)
     project = Project.new(title:'new project')
-    institution = Institution.new(title:'my new institution', ror_id: institution_existing.ror_id, country: "GB")
+    institution = Institution.new(title:'my new institution', department:'Manchester Institute of Biotechnology', ror_id: institution_existing.ror_id)
     log = ProjectCreationMessageLog.log_request(sender:FactoryBot.create(:person), project:project, institution:institution)
     get :administer_create_project_request, params:{message_log_id:log.id}
 
     assert_response :success
-    assert_select 'div', text: /They wish to be associated with University of Manchester/
-
-    institution2 = Institution.new(title: institution_existing.title)
+    assert_select 'div' do
+      assert_select 'a', text: 'Manchester Institute of Biotechnology, University of Manchester'
+      assert_select 'div', /They wish to be associated with/
+    end
+    institution2 = Institution.new(title: institution_existing.title,department:'Manchester Institute of Biotechnology')
     log2 = ProjectCreationMessageLog.log_request(sender:FactoryBot.create(:person), project:project, institution:institution2)
     get :administer_create_project_request, params:{message_log_id:log2.id}
 
     assert_response :success
-    assert_select 'div', text: /They wish to be associated with University of Manchester/
-
-
+    assert_select 'div' do
+      assert_select 'a', text: 'Manchester Institute of Biotechnology, University of Manchester'
+      assert_select 'div', /They wish to be associated with/
+    end
   end
 
 

--- a/test/functional/projects_controller_test.rb
+++ b/test/functional/projects_controller_test.rb
@@ -2237,7 +2237,7 @@ class ProjectsControllerTest < ActionController::TestCase
     with_config_value(:managed_programme_id, programme.id) do
       params = {
         project: { title: 'The Project', description:'description', web_page:'web_page'},
-        institution: { title: institution_existing.title, department:'Manchester Institute of Biotechnology' },
+        institution: { title: institution_existing[:title], department:'Manchester Institute of Biotechnology' },
         programme_id: '',
         programme: {title: 'the prog'}
       }
@@ -3028,7 +3028,8 @@ class ProjectsControllerTest < ActionController::TestCase
       assert_select 'a', text: 'Manchester Institute of Biotechnology, University of Manchester'
       assert_select 'div', /They wish to be associated with/
     end
-    institution2 = Institution.new(title: institution_existing.title,department:'Manchester Institute of Biotechnology')
+
+    institution2 = Institution.new(title: institution_existing[:title], department:'Manchester Institute of Biotechnology')
     log2 = ProjectCreationMessageLog.log_request(sender:FactoryBot.create(:person), project:project, institution:institution2)
     get :administer_create_project_request, params:{message_log_id:log2.id}
 

--- a/test/unit/bio_schema/schema_ld_generation_test.rb
+++ b/test/unit/bio_schema/schema_ld_generation_test.rb
@@ -694,7 +694,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
       '@type' => 'ResearchOrganization',
       'dct:conformsTo' => 'https://schema.org/ResearchOrganization',
       '@id' => "http://localhost:3000/institutions/#{institution.id}",
-      "name"=>"University of Manchester",
+      "name"=>"Manchester Institute of Biotechnology, University of Manchester",
       'url' => 'http://www.manchester.ac.uk/',
       "address"=>{"address_country"=>"GB", "address_locality"=>"Manchester", "street_address"=>"Manchester Centre for Integrative Systems Biology, MIB/CEAS, The University of Manchester Faraday Building, Sackville Street, Manchester M60 1QD United Kingdom"}
     }

--- a/test/unit/institution_test.rb
+++ b/test/unit/institution_test.rb
@@ -53,11 +53,12 @@ class InstitutionTest < ActiveSupport::TestCase
   end
 
   test 'title combines title and department correctly' do
-    assert_equal 'Science, University', FactoryBot.create(:institution, title: 'University', department: 'Science').full_title
-    assert_equal 'University', FactoryBot.create(:institution, title: 'University', department: '').full_title
-    assert_equal 'University', FactoryBot.create(:institution, title: 'University', department: nil).full_title
-    assert_equal 'A Minimal Institution', FactoryBot.create(:min_institution).full_title
-    assert_equal 'Manchester Institute of Biotechnology, University of Manchester', FactoryBot.create(:max_institution).full_title
+
+    assert_equal 'Science, University', FactoryBot.create(:institution, title: 'University', department: 'Science').title
+    assert_equal 'University', FactoryBot.create(:institution, title: 'University', department: '').title
+    assert_equal 'University', FactoryBot.create(:institution, title: 'University', department: nil).title
+    assert_equal 'A Minimal Institution', FactoryBot.create(:min_institution).title
+    assert_equal 'Manchester Institute of Biotechnology, University of Manchester', FactoryBot.create(:max_institution).title
   end
 
   def test_update_first_letter

--- a/test/unit/institution_test.rb
+++ b/test/unit/institution_test.rb
@@ -52,6 +52,14 @@ class InstitutionTest < ActiveSupport::TestCase
     assert_equal('an institution', i.title)
   end
 
+  test 'title combines title and department correctly' do
+    assert_equal 'Science, University', FactoryBot.create(:institution, title: 'University', department: 'Science').full_title
+    assert_equal 'University', FactoryBot.create(:institution, title: 'University', department: '').full_title
+    assert_equal 'University', FactoryBot.create(:institution, title: 'University', department: nil).full_title
+    assert_equal 'A Minimal Institution', FactoryBot.create(:min_institution).full_title
+    assert_equal 'Manchester Institute of Biotechnology, University of Manchester', FactoryBot.create(:max_institution).full_title
+  end
+
   def test_update_first_letter
     i = FactoryBot.create(:institution, title: 'an institution', country: 'NL')
     assert_equal 'A', i.first_letter

--- a/test/unit/message_log_test.rb
+++ b/test/unit/message_log_test.rb
@@ -435,7 +435,7 @@ class MessageLogTest < ActiveSupport::TestCase
 
     actual = JSON.parse(log.details)
     expected = {
-      institution: {id: institution.id, title: institution.title, ror_id: institution.ror_id, city: institution.city, web_page: institution.web_page, country: institution.country},
+      institution: {id: institution.id, title: institution.title, ror_id: institution.ror_id, city: institution.city, department: institution.department, web_page: institution.web_page, country: institution.country},
       project: {id:nil, title:'new project', description: 'blah', web_page: 'https://webpage.com', programme_id:programme.id},
       programme: {id:programme.id, title:programme.title, description: programme.description}
     }.with_indifferent_access


### PR DESCRIPTION
### Summary

- Added support for setting the `department` attribute when creating an Institution.
- `department` is also included when assigning an Institution during project creation.
