### PR TITLE
Don't `select` the SQL literals used for sorting

### DIFF
--- a/lib/seek/list_sorter.rb
+++ b/lib/seek/list_sorter.rb
@@ -176,7 +176,7 @@ module Seek
               unless expr.respond_to?(:relation) && expr.relation == items.arel_table
                 columns << expr
               end
-            else
+            elsif !ordering.is_a?(Arel::Nodes::SqlLiteral)
               columns << ordering
             end
           end


### PR DESCRIPTION
Fixes `invalid byte sequence in UTF-8` error that can occur on index pages when combining a filter (e.g. contributor) with a search query that returns many results.

Error was:
```
ArgumentError - invalid byte sequence in UTF-8
/seek/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.1/lib/active_record/associations/join_dependency.rb:121:in `match?'
/seek/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.1/lib/active_record/associations/join_dependency.rb:121:in `block in instantiate'
/seek/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.1/lib/active_record/associations/join_dependency.rb:120:in `each'
/seek/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.1/lib/active_record/associations/join_dependency.rb:120:in `instantiate'
/seek/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.1/lib/active_record/relation.rb:1440:in `instantiate_records'
/seek/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.1/lib/active_record/relation.rb:1395:in `block in exec_queries'
/seek/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.1/lib/active_record/relation.rb:1452:in `skip_query_cache_if_necessary'
/seek/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.1/lib/active_record/relation.rb:1386:in `exec_queries'
/seek/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.1/lib/active_record/relation.rb:1167:in `load'
/seek/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.1/lib/active_record/relation.rb:336:in `records'
/seek/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.1/lib/active_record/relation/delegation.rb:98:in `each'
/seek/app/views/assets/_resources_numerical_paginated.html.erb:107:in `_app_views_assets__resources_numerical_paginated_html_erb__3011958709751285960_754960'
```

Possibly due to it truncating a column name (except in this case it was not really a column name) in the middle of a character:
`FIELD(workflows.id,1140,1204,709,741,1199,1188,1240,1026,1215,1029,1037,742,737,17,1184,1163,1167,1227,1172,1244,1027,1146,1028,1036,1039,1151,1155,1207,1209,1224,1034,1043,1196,1221,1236,1031,1180,1041,1159,1177,1338,1143,1042,1201,14,1033,1032,1171,1038�`

`�` is the "unicode replacement character" `U+FFFD` / `65533`