### PR TITLE
recognise hidden sample types during fair data station actions

### DIFF
--- a/app/controllers/sample_types_controller.rb
+++ b/app/controllers/sample_types_controller.rb
@@ -216,7 +216,7 @@ class SampleTypesController < ApplicationController
       end
     end
     if fds_sample && fds_sample.all_additional_potential_annotation_predicates.any?
-      @existing_sample_type = fds_sample.find_exact_matching_sample_type
+      @existing_sample_type = fds_sample.find_exact_matching_sample_type(current_person)
       unless @existing_sample_type
         string_attribute_type = SampleAttributeType.where(title: 'String').first
         @sample_type.sample_attributes.build({

--- a/lib/seek/fair_data_station/sample.rb
+++ b/lib/seek/fair_data_station/sample.rb
@@ -11,8 +11,8 @@ module Seek
         super.except(:title, :description)
       end
 
-      def find_closest_matching_sample_type(property_ids = additional_metadata_annotations.collect { |annotation| annotation[0] })
-        candidates = SampleType.includes(:sample_attributes).authorized_for(:view).collect do |sample_type|
+      def find_closest_matching_sample_type(person, property_ids = additional_metadata_annotations.collect { |annotation| annotation[0] })
+        candidates = SampleType.includes(:sample_attributes).authorized_for(:view, person).collect do |sample_type|
           sample_type_property_ids = sample_type.sample_attributes.collect(&:pid).compact_blank
           intersection = (property_ids & sample_type_property_ids)
           difference = (property_ids | sample_type_property_ids) - intersection
@@ -26,10 +26,10 @@ module Seek
         candidates.first&.last
       end
 
-      def find_exact_matching_sample_type
+      def find_exact_matching_sample_type(person)
         property_ids = all_additional_potential_annotation_predicates
         property_ids |= [@schema.title.to_s, @schema.description.to_s]
-        sample_type = find_closest_matching_sample_type(property_ids)
+        sample_type = find_closest_matching_sample_type(person, property_ids)
         return unless sample_type && sample_type.sample_attributes.count == property_ids.count
 
         sample_type

--- a/lib/seek/fair_data_station/writer.rb
+++ b/lib/seek/fair_data_station/writer.rb
@@ -207,7 +207,7 @@ module Seek
       end
 
       def populate_sample(seek_sample, datastation_sample)
-        if (sample_type = datastation_sample.find_closest_matching_sample_type)
+        if (sample_type = datastation_sample.find_closest_matching_sample_type(seek_sample.contributor))
           seek_sample.sample_type = sample_type
           update_sample_metadata(seek_sample, datastation_sample)
         end

--- a/test/unit/fair_data_station/fair_data_station_writer_test.rb
+++ b/test/unit/fair_data_station/fair_data_station_writer_test.rb
@@ -11,7 +11,7 @@ class FairDataStationWriterTest < ActiveSupport::TestCase
     project = contributor.projects.first
     FactoryBot.create(:experimental_assay_class)
     # private but visible to the contributor
-    FactoryBot.create(:fairdatastation_virtual_demo_sample_type, contributor: contributor, policy: FactoryBot.create(:private_policy))
+    sample_type = FactoryBot.create(:fairdatastation_virtual_demo_sample_type, contributor: contributor, policy: FactoryBot.create(:private_policy))
     investigation = Seek::FairDataStation::Writer.new.construct_isa(inv, contributor, [project], policy)
 
     studies = investigation.studies.to_a
@@ -58,6 +58,7 @@ class FairDataStationWriterTest < ActiveSupport::TestCase
     assert_equal 'DRR243856_1.fastq.gz', data_files.first.external_identifier
     assert_equal 'HIV-1_positive', obs_units.first.external_identifier
     assert_equal 'DRS176892', samples.first.external_identifier
+    assert_equal sample_type, samples.first.sample_type
 
     assert_difference('Investigation.count', 1) do
       assert_difference('Study.count', 1) do

--- a/test/unit/fair_data_station/fair_data_station_writer_test.rb
+++ b/test/unit/fair_data_station/fair_data_station_writer_test.rb
@@ -1,6 +1,7 @@
 require 'test_helper'
 
 class FairDataStationWriterTest < ActiveSupport::TestCase
+
   test 'construct seek isa' do
     path = "#{Rails.root}/test/fixtures/files/fair_data_station/demo.ttl"
     inv = Seek::FairDataStation::Reader.new.parse_graph(path).first
@@ -9,7 +10,8 @@ class FairDataStationWriterTest < ActiveSupport::TestCase
     contributor = FactoryBot.create(:person)
     project = contributor.projects.first
     FactoryBot.create(:experimental_assay_class)
-    FactoryBot.create(:fairdatastation_virtual_demo_sample_type)
+    # private but visible to the contributor
+    FactoryBot.create(:fairdatastation_virtual_demo_sample_type, contributor: contributor, policy: FactoryBot.create(:private_policy))
     investigation = Seek::FairDataStation::Writer.new.construct_isa(inv, contributor, [project], policy)
 
     studies = investigation.studies.to_a


### PR DESCRIPTION
Updated to include the contributor when authorizing sample types during FDS imports, or Sample type configuration 

* fix for  #2200