### PR TITLE
Fix the restart workers button, and also rake tasks

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -705,9 +705,9 @@ class AdminController < ApplicationController
 
   def redirect_with_status(error, process)
     if error.blank?
-      flash[:notice] = "The #{process} was restarted"
+      flash[:notice] = "Successfully restarted the #{process}"
     else
-      flash[:error] = "There is a problem with restarting the #{process}. #{error.gsub('Terrapin::', '')}"
+      flash[:error] = "There was a problem with restarting the #{process}. #{error.gsub('Terrapin::', '')}"
     end
     redirect_to action: :show
   end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -689,7 +689,7 @@ class AdminController < ApplicationController
   def execute_command(command)
     return nil if Rails.env.test?
     begin
-      Rails.logger.info("executing admin shell command '#{command}")
+      Rails.logger.info("executing admin shell command '#{command}'")
       cl = Terrapin::CommandLine.new(command)
       cl.run
       Rails.logger.info('admin shell command successfully executed!')

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -21,7 +21,6 @@ module AdminHelper
     words.join(', ').html_safe
   end
 
-  
 
   def action_buttons(user_or_person, action)
     case action
@@ -101,4 +100,5 @@ module AdminHelper
       concat yield
     end
   end
+
 end

--- a/app/views/admin/_restart_buttons.html.erb
+++ b/app/views/admin/_restart_buttons.html.erb
@@ -26,13 +26,13 @@
         </p>
 
         <p>
-          Some background tasks are running in different processes to the main server process,
+          Some background tasks are running in different processes to the main server process to process queued jobs,
           for example to handle solr reindexing or send subscription emails.
           When certain settings such as <strong>'search enabled'</strong>, or changing code,
           you will need to restart these processes.
-          <%= button_to('Restart background tasks', restart_delayed_job_admin_path,
+          <%= button_to('Restart job workers', restart_delayed_job_admin_path,
                         class: 'btn btn-danger', id: 'restart_delayed_job',
-                        data: { confirm: 'Are you sure you want to restart the background tasks?', disable_with: 'Restarting...' }) %>
+                        data: { confirm: 'Are you sure you want to restart the background job workers?', disable_with: 'Restarting...' }) %>
         </p>
       </div>
 

--- a/app/views/admin/_restart_buttons.html.erb
+++ b/app/views/admin/_restart_buttons.html.erb
@@ -30,14 +30,20 @@
           for example to handle solr reindexing or send subscription emails.
           When certain settings such as <strong>'search enabled'</strong>, or changing code,
           you will need to restart these processes.
-          <%= button_to('Restart job workers', restart_delayed_job_admin_path,
+          <%= button_to('Restart background job workers', restart_delayed_job_admin_path,
                         class: 'btn btn-danger', id: 'restart_delayed_job',
                         data: { confirm: 'Are you sure you want to restart the background job workers?', disable_with: 'Restarting...' }) %>
         </p>
       </div>
 
       <div class="col-sm-4">
-        <h4>Background processes</h4>
+        <h4>
+          Background processes
+          <div class="subtle">
+            <%= Seek::Workers.active_queues.count %> expected
+          </div>
+        </h4>
+
         <% begin %>
             <% pids = Seek::Util.delayed_job_pids %>
             <% if pids.any? %>
@@ -56,7 +62,7 @@
             <% else %>
                 <span class="none_text">No background processes running</span>
             <% end %>
-        <% rescue Exception => e %>
+        <% rescue StandardError => e %>
             <span class="text-danger">Unable to determine current status - <%= e.message %></span>
         <% end %>
       </div>

--- a/lib/seek/workers.rb
+++ b/lib/seek/workers.rb
@@ -15,8 +15,8 @@ module Seek
     def self.create_commands(action)
       commands = []
 
-      active_queues.each_index  do |index, queue_name|
-        commands << command(queue_name, index+1, 1, action)
+      active_queues.each_with_index do |queue_name, index|
+        commands << command(queue_name, index + 1, 1, action)
       end
       commands
     end

--- a/lib/seek/workers.rb
+++ b/lib/seek/workers.rb
@@ -4,11 +4,7 @@ require 'delayed/command'
 module Seek
   module Workers
     def self.start
-      invoke('start')
-    end
-
-    def self.invoke(action)
-      commands = create_commands(action)
+      commands = create_commands('start')
       daemonize_commands(commands)
     end
 
@@ -38,7 +34,8 @@ module Seek
     end
 
     def self.stop
-      invoke 'stop'
+      # will stop the first 15, not expecting more than that
+      daemonize_commands(['stop -n 15'])
     end
 
     def self.status
@@ -46,7 +43,8 @@ module Seek
     end
 
     def self.restart
-      invoke 'restart'
+      stop
+      start
     end
 
     def self.command(queue_name, index, number_of_workers, action)

--- a/lib/seek/workers.rb
+++ b/lib/seek/workers.rb
@@ -3,11 +3,13 @@ require 'delayed/command'
 # module for handling interaction with delayed job workers
 module Seek
   module Workers
-    def self.start(action = 'start')
+    def self.start
+      invoke('start')
+    end
+
+    def self.invoke(action)
       @identifier = 0
-
       commands = create_commands(action)
-
       daemonize_commands(commands)
     end
 
@@ -32,7 +34,7 @@ module Seek
     end
 
     def self.stop
-      daemonize_commands(['stop'])
+      invoke 'stop'
     end
 
     def self.status
@@ -40,7 +42,7 @@ module Seek
     end
 
     def self.restart
-      start('restart')
+      invoke 'restart'
     end
 
     def self.start_data_file_auth_lookup_worker(number = 1)


### PR DESCRIPTION
fixes the button, now by calling out to run the restart rake task. Also fixed 'stop' and 'restart' which weren't working.
Also changed the button wording slightly (to indicate it relates to the job queues also on the page) and indicate the number of processes that should be running

* fix for #2215 