### PR TITLE
Fix nill error when an update detects new E.M types

### DIFF
--- a/lib/seek/fair_data_station/writer.rb
+++ b/lib/seek/fair_data_station/writer.rb
@@ -199,7 +199,11 @@ module Seek
       end
 
       def update_extended_metadata(seek_entity, datastation_entity)
-        datastation_entity.populate_extended_metadata(seek_entity)
+        if seek_entity.extended_metadata.nil?
+          populate_extended_metadata(seek_entity, datastation_entity)
+        else
+          datastation_entity.populate_extended_metadata(seek_entity)
+        end
       end
 
       def update_sample_metadata(seek_sample, datastation_sample)

--- a/lib/seek/fair_data_station/writer.rb
+++ b/lib/seek/fair_data_station/writer.rb
@@ -194,7 +194,7 @@ module Seek
       def populate_extended_metadata(seek_entity, datastation_entity)
         if (emt = datastation_entity.find_closest_matching_extended_metadata_type)
           if emt != seek_entity.extended_metadata&.extended_metadata_type
-            seek_entity.extended_metadata = ExtendedMetadata.new(extended_metadata_type: emt)
+            seek_entity.build_extended_metadata(extended_metadata_type: emt)
           end
           update_extended_metadata(seek_entity, datastation_entity)
         end

--- a/lib/seek/fair_data_station/writer.rb
+++ b/lib/seek/fair_data_station/writer.rb
@@ -118,7 +118,7 @@ module Seek
       def update_entity(seek_entity, datastation_entity, contributor)
         attributes = datastation_entity.seek_attributes
         seek_entity.assign_attributes(attributes)
-        update_extended_metadata(seek_entity, datastation_entity)
+        populate_extended_metadata(seek_entity, datastation_entity)
         record_update_activity_if_changed(seek_entity, contributor)
         seek_entity
       end
@@ -193,17 +193,15 @@ module Seek
 
       def populate_extended_metadata(seek_entity, datastation_entity)
         if (emt = datastation_entity.find_closest_matching_extended_metadata_type)
-          seek_entity.extended_metadata = ExtendedMetadata.new(extended_metadata_type: emt)
+          if emt != seek_entity.extended_metadata&.extended_metadata_type
+            seek_entity.extended_metadata = ExtendedMetadata.new(extended_metadata_type: emt)
+          end
           update_extended_metadata(seek_entity, datastation_entity)
         end
       end
 
       def update_extended_metadata(seek_entity, datastation_entity)
-        if seek_entity.extended_metadata.nil?
-          populate_extended_metadata(seek_entity, datastation_entity)
-        else
-          datastation_entity.populate_extended_metadata(seek_entity)
-        end
+        datastation_entity.populate_extended_metadata(seek_entity)
       end
 
       def update_sample_metadata(seek_sample, datastation_sample)

--- a/test/factories/extended_metadata_types.rb
+++ b/test/factories/extended_metadata_types.rb
@@ -497,6 +497,14 @@ FactoryBot.define do
     end
   end
 
+  factory(:fairdata_test_case_partial_study_extended_metadata, class: ExtendedMetadataType) do
+    title {'Fair Data Station Partial Study Test Case'}
+    supported_type { 'Study' }
+    after(:build) do |a|
+      a.extended_metadata_attributes << FactoryBot.create(:study_title_extended_metadata_attribute, title: 'Experimental site name', pid:'http://fairbydesign.nl/ontology/experimental_site_name')
+    end
+  end
+
   factory(:fairdata_test_case_study_extended_metadata, class: ExtendedMetadataType) do
     title {'Fair Data Station Study Test Case'}
     supported_type { 'Study' }

--- a/test/unit/fair_data_station/fair_data_station_writer_test.rb
+++ b/test/unit/fair_data_station/fair_data_station_writer_test.rb
@@ -691,8 +691,11 @@ class FairDataStationWriterTest < ActiveSupport::TestCase
     assert_equal expected, investigation.studies.first.extended_metadata.data
 
     study_emt = FactoryBot.create(:fairdata_test_case_study_extended_metadata)
+    path = "#{Rails.root}/test/fixtures/files/fair_data_station/seek-fair-data-station-modified-test-case.ttl"
+    inv = Seek::FairDataStation::Reader.new.parse_graph(path).first
+
     User.with_current_user(contributor.user) do
-      assert_no_difference('ExtendedMetadata.count') do
+      assert_difference('ExtendedMetadata.count', 1) do # 1 new study, other 2 had EMT replaced and old version removed
         investigation = Seek::FairDataStation::Writer.new.update_isa(investigation, inv, contributor,
                                                                      projects, policy)
         investigation.save!
@@ -702,7 +705,7 @@ class FairDataStationWriterTest < ActiveSupport::TestCase
     investigation.reload
     assert_equal study_emt, investigation.studies.first.extended_metadata.extended_metadata_type
     expected = HashWithIndifferentAccess.new({
-                                               'Experimental site name': 'manchester test site',
+                                               'Experimental site name': 'manchester test site - changed',
                                                'End date of Study': '2024-08-08',
                                                'Start date of Study': '2024-08-01'
 

--- a/test/unit/fair_data_station/fair_data_station_writer_test.rb
+++ b/test/unit/fair_data_station/fair_data_station_writer_test.rb
@@ -594,6 +594,68 @@ class FairDataStationWriterTest < ActiveSupport::TestCase
     assert_equal expected, study.extended_metadata.data
   end
 
+  test 'add EMT during update if previously nil' do
+    FactoryBot.create(:fairdatastation_test_case_sample_type)
+    FactoryBot.create(:experimental_assay_class)
+    path = "#{Rails.root}/test/fixtures/files/fair_data_station/seek-fair-data-station-test-case.ttl"
+    inv = Seek::FairDataStation::Reader.new.parse_graph(path).first
+    contributor = FactoryBot.create(:person)
+    projects = contributor.projects
+    policy = Policy.default
+
+    investigation = Seek::FairDataStation::Writer.new.construct_isa(inv, contributor, projects, policy)
+    assert investigation.valid?
+    User.with_current_user(contributor.user) do
+      investigation.save!
+    end
+    investigation.reload
+    assert_nil investigation.extended_metadata
+
+    inv_emt = FactoryBot.create(:fairdata_test_case_investigation_extended_metadata)
+    study_emt = FactoryBot.create(:fairdata_test_case_nested_study_extended_metadata)
+    obs_unit_emt = FactoryBot.create(:fairdata_test_case_nested_obsv_unit_extended_metadata)
+    assay_emt = FactoryBot.create(:fairdata_test_case_assay_extended_metadata)
+
+    path = "#{Rails.root}/test/fixtures/files/fair_data_station/seek-fair-data-station-modified-test-case.ttl"
+    inv = Seek::FairDataStation::Reader.new.parse_graph(path).first
+
+    assert_no_difference('Investigation.count') do
+      assert_difference('Study.count', 1) do
+        assert_difference('ObservationUnit.count', 1) do
+          assert_difference('Sample.count', 1) do
+            assert_difference('Assay.count', 1) do
+              assert_difference('DataFile.count', 3) do
+                assert_difference('ObservationUnitAsset.count', 1) do
+                  assert_difference('AssayAsset.count', 2) do
+                    # 1 for new df, the other is for the sample
+                    assert_difference('ExtendedMetadata.count', 15) do
+                      User.with_current_user(contributor.user) do
+                        investigation = Seek::FairDataStation::Writer.new.update_isa(investigation, inv, contributor,
+                                                                                     projects, policy)
+                        investigation.save!
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+
+    investigation.reload
+    study = investigation.studies.first
+    obs_unit = study.observation_units.first
+    assay = obs_unit.samples.first.assays.first
+
+    assert_equal inv_emt, investigation.extended_metadata.extended_metadata_type
+    assert_equal study_emt, study.extended_metadata.extended_metadata_type
+    assert_equal obs_unit_emt, obs_unit.extended_metadata.extended_metadata_type
+    assert_equal assay_emt, assay.extended_metadata.extended_metadata_type
+
+  end
+
   test 'update isa with nested metadata' do
     FactoryBot.create(:fairdata_test_case_investigation_extended_metadata)
     FactoryBot.create(:fairdata_test_case_nested_study_extended_metadata)


### PR DESCRIPTION
Will now always try and replace the EMT with a closer match if one is found, rather than keeping the type found during the original import.

* fix for #2224 