### PR TITLE
Discipline annotations

### DIFF
--- a/app/assets/javascripts/sharing.js.erb
+++ b/app/assets/javascripts/sharing.js.erb
@@ -27,13 +27,6 @@ var Sharing = {
       }
     }
 
-    // This ensures that if a project permission is added, and that project is associated with the resource, it gains
-    //  the "isMandatory" flag.
-    if (permission.contributor_type === 'Project' &&
-        Sharing.getSelectedProjectIds().includes(permission.contributor_id)) {
-        permission.isMandatory = true;
-    }
-
     Sharing.permissionsTable.permissions.push(permission);
   },
 
@@ -43,20 +36,7 @@ var Sharing = {
         contributor_type: 'Project',
         contributor_id: project.id,
         title: project.title,
-        access_type: Sharing.associatedProjectAccessType,
-        isMandatory: true }, true);
-  },
-
-  removeMandatoryProjectPermissions: function () {
-    if (!Sharing.permissionsTable)
-      return;
-    var indices = [];
-    for (var i = Sharing.permissionsTable.permissions.length - 1; i >= 0; i--) {
-      if (Sharing.permissionsTable.permissions[i].contributor_type === 'Project' &&
-          Sharing.permissionsTable.permissions[i].isMandatory) {
-        Sharing.permissionsTable.permissions.splice(i, 1);
-      }
-    }
+        access_type: Sharing.associatedProjectAccessType }, true);
   },
 
   removePermissionForProject: function (project) {
@@ -68,8 +48,6 @@ var Sharing = {
     }
     if (confirm('Do you want to remove any permissions for ' + project.title + '?')) {
       Sharing.permissionsTable.permissions.splice(i, 1);
-    } else {
-      Sharing.permissionsTable.permissions[i].isMandatory = false;
     }
   },
 
@@ -230,9 +208,10 @@ Vue.component('permission-row', {
       return '<%= asset_path icon_filename_for_key('world') %>';
     },
     mandatory: function () {
-        if (this.permission.isMandatory) {
+        if (this.permission.isPublic) {
             return true;
-        } else if (this.permission.contributor_type === 'Project') {
+        }
+        if (this.permission.contributor_type === 'Project') {
             return Sharing.getSelectedProjectIds().includes(this.permission.contributor_id);
         }
         return false;

--- a/app/assets/javascripts/sharing.js.erb
+++ b/app/assets/javascripts/sharing.js.erb
@@ -29,13 +29,9 @@ var Sharing = {
 
     // This ensures that if a project permission is added, and that project is associated with the resource, it gains
     //  the "isMandatory" flag.
-    if (permission.contributor_type === 'Project' && Sharing.projectsSelector) {
-      for (var j = 0; j < Sharing.projectsSelector.selected.length; j++) {
-        if (Sharing.projectsSelector.selected[j].id === permission.contributor_id) {
-          permission.isMandatory = true;
-          break;
-        }
-      }
+    if (permission.contributor_type === 'Project' &&
+        Sharing.getSelectedProjectIds().includes(permission.contributor_id)) {
+        permission.isMandatory = true;
     }
 
     Sharing.permissionsTable.permissions.push(permission);
@@ -79,6 +75,7 @@ var Sharing = {
 
   requestInstitutionsUrl: '<%= request_institutions_projects_path %>',
   requestAllInstitutionsUrl: '<%= request_all_sharing_form_institutions_path %>',
+  requestDefaultDataUrl: '<%= default_data_project_path('_replaceme_') %>',
 
   accessTypes: {
     noAccess: <%= Policy::NO_ACCESS %>,
@@ -120,15 +117,29 @@ var Sharing = {
   },
 
   // Ask if they want to use the default policy (if there is one)
-  defaultPolicyPrompt: function (project, skipPrompt) {
+  defaultPolicyPrompt: function (project, policy, skipPrompt) {
       if (!Sharing.permissionsTable)
           return;
 
-      if (Sharing.defaultPolicies[project.id] && (skipPrompt || confirm('' + project.title + ' has a default sharing policy specified, do you want to apply it?'))) {
-          Sharing.applyPolicy(Sharing.defaultPolicies[project.id]);
+      if (policy && (skipPrompt || confirm('' + project.title + ' has a default sharing policy specified, do you want to apply it?'))) {
+          Sharing.applyPolicy(policy);
       } else { // Otherwise just add a permission for the project
           Sharing.addPermissionForProject(project);
       }
+  },
+
+  fetchDefaultData: function (project) {
+      return new Promise((resolve, reject) => {
+        $j.ajax(Sharing.requestDefaultDataUrl.replace('_replaceme_', project.id), {
+                success: function (data) {
+                    resolve(data);
+                },
+                complete: function () {
+                    resolve({});
+                }
+            }
+        );
+      });
   }
 };
 
@@ -171,7 +182,8 @@ Vue.component('permissions-table', {
   computed: {
     sortedPermissions: function () {
       return this.permissions.sort(function (a, b) {
-        return (b.isMandatory || false) - (a.isMandatory || false);
+          return ((b.contributor_type === 'Project') && Sharing.getSelectedProjectIds().includes(b.contributor_id)) -
+                 ((a.contributor_type === 'Project') && Sharing.getSelectedProjectIds().includes(a.contributor_id));
       });
     }
   },
@@ -185,14 +197,14 @@ Vue.component('permissions-table', {
 Vue.component('permission-row', {
   props: ['index', 'permission', 'accessTypes', 'publicAccessType', 'fieldPrefixOrig'],
   template:
-  '<tr class="permission-row" :class="{ mandatory: permission.isMandatory, hidden: permission.contributor_type === \'FavouriteGroup\' }">' +
+  '<tr class="permission-row" :class="{ mandatory: mandatory, hidden: permission.contributor_type === \'FavouriteGroup\' }">' +
   '<td class="name-cell" :title="permission.title"><span class="type-icon-wrapper"><img :src="typeIcon" class="type-icon" :title="permission.contributor_type || \'All visitors\'"/></span> {{ permission.title }}' +
   '<input v-if="permission.contributor_type" type="hidden" :name="fieldPrefix+\'[contributor_type]\'" v-model="permission.contributor_type"/>' +
   '<input v-if="permission.contributor_id" type="hidden" :name="fieldPrefix+\'[contributor_id]\'" v-model="permission.contributor_id"/>' +
   '</td>' +
   '<td is="privilege-cell" v-for="accessType in accessTypes" :fieldPrefix="fieldPrefix" :permission="permission" :access-type="accessType" :public-access-type="publicAccessType"></td>' +
   '<td class="actions-cell">'+
-  '<a v-if="!permission.isMandatory" @click="$emit(\'delete-permission\')" class="clickable remove-button" title="Remove this permission">' +
+  '<a v-if="!mandatory" @click="$emit(\'delete-permission\')" class="clickable remove-button" title="Remove this permission">' +
   '<span class="glyphicon glyphicon-remove" aria-hidden="true"></span>' +
   '</a>' +
   '</td>' +
@@ -216,6 +228,14 @@ Vue.component('permission-row', {
       }
 
       return '<%= asset_path icon_filename_for_key('world') %>';
+    },
+    mandatory: function () {
+        if (this.permission.isMandatory) {
+            return true;
+        } else if (this.permission.contributor_type === 'Project') {
+            return Sharing.getSelectedProjectIds().includes(this.permission.contributor_id);
+        }
+        return false;
     }
   }
 });

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -18,14 +18,16 @@ class ProjectsController < ApplicationController
                                         :administer_create_project_request, :respond_create_project_request,
                                         :administer_import_project_request, :respond_import_project_request,
                                         :import_from_fairdata_station, :submit_fairdata_station,
-                                        :project_join_requests, :project_creation_requests, :project_importation_requests, :typeahead]
+                                        :project_join_requests, :project_creation_requests, :project_importation_requests,
+                                        :typeahead, :default_data]
 
   before_action :find_requested_item, only: %i[show admin edit update destroy admin_members
                                                asset_report populate populate_from_spreadsheet
                                                admin_member_roles update_members storage_report
                                                overview administer_join_request respond_join_request
                                                import_from_fairdata_station submit_fairdata_station
-                                               fair_data_station_import_status hide_fair_data_station_import_status]
+                                               fair_data_station_import_status hide_fair_data_station_import_status
+                                               default_data]
 
   before_action :has_spreadsheets, only: %i[:populate populate_from_spreadsheet]
 
@@ -36,7 +38,8 @@ class ProjectsController < ApplicationController
   before_action :administerable_by_user, only: %i[admin admin_members admin_member_roles destroy update_members storage_report administer_join_request respond_join_request populate populate_from_spreadsheet]
 
   before_action :member_of_this_project, only: [:asset_report, :import_from_fairdata_station, :submit_fairdata_station,
-                                                :fair_data_station_import_status, :hide_fair_data_station_import_status], unless: :admin_logged_in?
+                                                :fair_data_station_import_status, :hide_fair_data_station_import_status,
+                                                :default_data], unless: :admin_logged_in?
 
   before_action :validate_message_log_for_join, only: [:administer_join_request, :respond_join_request]
   before_action :validate_message_log_for_create, only: [:administer_create_project_request, :respond_create_project_request]
@@ -974,6 +977,12 @@ class ProjectsController < ApplicationController
 
     respond_to do |format|
       format.json { render json: {results: items}.to_json }
+    end
+  end
+
+  def default_data
+    respond_to do |format|
+      format.json
     end
   end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1098,10 +1098,10 @@ class ProjectsController < ApplicationController
     @project = Project.find(params[:id])
     if @project.nil? || !@project.has_member?(current_user)
       flash[:error] = "You are not a member of this #{t('project')}, so cannot access this page."
-      redirect_to project_path(@project)
-      false
-    else
-      true
+      respond_to do |format|
+        format.html { redirect_to project_path(@project) }
+        format.json { head :forbidden }
+      end
     end
   end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -993,7 +993,7 @@ class ProjectsController < ApplicationController
   def project_params
     permitted_params = [:title, :web_page, :wiki_page, :description, { organism_ids: [] }, :parent_id, :start_date,
                         :end_date,
-                        { funding_codes: [] }, { human_disease_ids: [] }, topic_annotations: [],
+                        { funding_codes: [] }, { human_disease_ids: [] }, { topic_annotations: [] }, { discipline_annotations: [] },
                         discussion_links_attributes:[:id, :url, :label, :_destroy], extended_metadata_attributes: determine_extended_metadata_keys ]
 
     if User.admin_logged_in?

--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -377,7 +377,7 @@ class WorkflowsController < ApplicationController
                                      { publication_ids: [] }, { presentation_ids: [] }, { document_ids: [] }, { data_file_ids: [] }, { sop_ids: [] },
                                      { workflow_data_files_attributes:[:id, :data_file_id, :workflow_data_file_relationship_id, :_destroy] },
                                      :internals, :maturity_level, :source_link_url, :execution_instance_url,
-                                     { topic_annotations: [] }, { operation_annotations: [] },
+                                     { topic_annotations: [] }, { operation_annotations: [] }, { discipline_annotations: [] },
                                      { discussion_links_attributes: [:id, :url, :label, :_destroy] },
                                      { git_version_attributes: [:name, :comment, :ref, :commit, :root_path,
                                                                 :git_repository_id, :main_workflow_path,

--- a/app/helpers/license_helper.rb
+++ b/app/helpers/license_helper.rb
@@ -53,12 +53,6 @@ module LicenseHelper
     current_user.person.projects_with_default_license.any?
   end
 
-  # JSON that creates a lookup for project license by id
-  def project_licenses_json
-    projects = current_user.person.projects_with_default_license
-    Hash[projects.collect { |proj| [proj.id, proj.default_license] }].to_json.html_safe
-  end
-
   private
 
   def license_description_content(license)

--- a/app/helpers/policy_helper.rb
+++ b/app/helpers/policy_helper.rb
@@ -120,7 +120,6 @@ module PolicyHelper
       # Mark associated project permissions as "mandatory"
       if permission.contributor_type == 'Project' && project_ids.include?(permission.contributor_id)
         project_ids.delete(permission.contributor_id)
-        h[:isMandatory] = true
       end
 
       h[:title] = permission_title(permission)
@@ -133,8 +132,7 @@ module PolicyHelper
       hash[:permissions] << { access_type: policy.access_type,
                               contributor_id: project.id,
                               contributor_type: 'Project',
-                              title: project.title,
-                              isMandatory: true }
+                              title: project.title }
     end
 
     hash
@@ -142,16 +140,6 @@ module PolicyHelper
 
   def policy_json(policy, associated_projects)
     policy_hash(policy, associated_projects).to_json.html_safe
-  end
-
-  def project_policies_json(projects)
-    hash = {}
-
-    projects.each do |p|
-      hash[p.id] = policy_hash(p.default_policy, [p]) if p.use_default_policy
-    end
-
-    hash.to_json.html_safe
   end
 
   def project_policy_json(project)

--- a/app/models/concerns/has_controlled_vocabulary_annotations.rb
+++ b/app/models/concerns/has_controlled_vocabulary_annotations.rb
@@ -92,6 +92,7 @@ module HasControlledVocabularyAnnotations
       vocab = annotation_controlled_vocab(property)
       values = Array(vals.split(',').flatten).map do |value|
         value = value.strip
+        next if value.blank?
         vocab.sample_controlled_vocab_terms.find_by_label(value) ||
           vocab.sample_controlled_vocab_terms.find_by_iri(value)
       end.compact.uniq

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -75,7 +75,7 @@ class Project < ApplicationRecord
   #  is to be used)
   belongs_to :default_policy, class_name: 'Policy', dependent: :destroy, autosave: true
 
-  has_controlled_vocab_annotations :topics
+  has_controlled_vocab_annotations :topics, :disciplines
 
   # FIXME: temporary handler, projects need to support multiple programmes
   def programmes

--- a/app/models/sample_controlled_vocab.rb
+++ b/app/models/sample_controlled_vocab.rb
@@ -116,7 +116,8 @@ class SampleControlledVocab < ApplicationRecord
       topics: 'topic_annotations',
       operations: 'operation_annotations',
       data_formats: 'data_format_annotations',
-      data_types: 'data_type_annotations'
+      data_types: 'data_type_annotations',
+      disciplines: 'discipline_annotations',
     }
 
     def self.vocab_for_property(property)

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -14,7 +14,7 @@ class Workflow < ApplicationRecord
 
   acts_as_doi_parent
 
-  has_controlled_vocab_annotations :topics, :operations
+  has_controlled_vocab_annotations :topics, :operations, :disciplines
 
   validates :projects, presence: true, projects: { self: true }
 
@@ -285,5 +285,11 @@ class Workflow < ApplicationRecord
 
   def self.find_by_source_url(source_url)
     joins(:source_link).where('asset_links.url' => source_url)
+  end
+
+  def discipline_annotation_labels
+    mine = controlled_vocab_annotation_labels(:disciplines)
+    return projects.first.discipline_annotation_labels if mine.empty? && projects.first
+    mine
   end
 end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -287,9 +287,10 @@ class Workflow < ApplicationRecord
     joins(:source_link).where('asset_links.url' => source_url)
   end
 
-  def discipline_annotation_labels
-    mine = controlled_vocab_annotation_labels(:disciplines)
-    return projects.first.discipline_annotation_labels if mine.empty? && projects.first
+  alias_method :orig_discipline_annotation_values, :discipline_annotation_values
+  def discipline_annotation_values
+    mine = orig_discipline_annotation_values
+    return projects.first.discipline_annotation_values if mine.empty? && projects.first
     mine
   end
 end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -286,11 +286,4 @@ class Workflow < ApplicationRecord
   def self.find_by_source_url(source_url)
     joins(:source_link).where('asset_links.url' => source_url)
   end
-
-  alias_method :orig_discipline_annotation_values, :discipline_annotation_values
-  def discipline_annotation_values
-    mine = orig_discipline_annotation_values
-    return projects.first.discipline_annotation_values if mine.empty? && projects.first
-    mine
-  end
 end

--- a/app/views/assays/_form.html.erb
+++ b/app/views/assays/_form.html.erb
@@ -19,11 +19,13 @@
 
 <%= render partial: 'extended_metadata/extended_metadata_attribute_input', locals:{f:f,resource:@assay} %>
 
-<div class="form-group">
-  <label class="required"><%= t('study') -%></label>
+<% if show_form_manage_specific_attributes? %>
+  <div class="form-group">
+    <label class="required"><%= t('study') -%></label>
 
-  <%= resource_study_selection('assay[study_id]', @assay.study) %>
-</div>
+    <%= resource_study_selection('assay[study_id]', @assay.study) %>
+  </div>
+<% end %>
 
 <div class="form-group">
   <%= f.label "Assay position" -%><br/>

--- a/app/views/assets/_controlled_vocab_annotations_form_properties.html.erb
+++ b/app/views/assets/_controlled_vocab_annotations_form_properties.html.erb
@@ -8,3 +8,5 @@
 
 <%= render partial: "assets/controlled_vocab_annotations_form_property", locals: { resource: resource, property: :data_formats} -%>
 
+<%= render partial: "assets/controlled_vocab_annotations_form_property", locals: { resource: resource, property: :disciplines} -%>
+

--- a/app/views/assets/_controlled_vocab_annotations_properties_box.html.erb
+++ b/app/views/assets/_controlled_vocab_annotations_properties_box.html.erb
@@ -8,4 +8,6 @@
 
   <%= render partial: "assets/controlled_vocab_annotations_property_box", locals: { resource: resource, property: :data_formats} -%>
 
+  <%= render partial: "assets/controlled_vocab_annotations_property_box", locals: { resource: resource, property: :disciplines} -%>
+
 <% end %>

--- a/app/views/assets/_manage_form.html.erb
+++ b/app/views/assets/_manage_form.html.erb
@@ -9,7 +9,29 @@
   <%= f.error_messages -%>
 
   <% if show_projects %>
-    <%= render :partial => 'projects/project_selector', :locals => {:resource => resource } %>
+    <%= render partial: 'projects/project_selector', locals: { resource: resource } %>
+  <% elsif resource.is_a?(Study) %>
+    <%= folding_panel("#{t('investigation')} details") do %>
+      <label class="required"><%= t('investigation') %></label>
+      <div id="investigation_collection">
+        <%= render partial: 'studies/investigation_list', locals: {
+          investigations: Investigation.all.select { |i| current_user.person.member_of?(i.projects)} } -%>
+      </div>
+    <% end %>
+
+    <%= render partial: 'projects/implicit_project_selector', locals: { action: 'manage',
+                                                                        select_id: '#study_investigation_id',
+                                                                        parents: Investigation.authorized_for('edit') } %>
+  <% elsif resource.is_a?(Assay) %>
+    <div class="form-group">
+      <label class="required"><%= t('study') -%></label>
+
+      <%= resource_study_selection('assay[study_id]', @assay.study) %>
+    </div>
+
+    <%= render partial: 'projects/implicit_project_selector', locals: { action: 'manage',
+                                                                        select_id: '#assay_study_id',
+                                                                        parents: Study.authorized_for('edit') } %>
   <% end %>
   <%= render partial: 'assets/manage_specific_attributes', locals: {f: f, sharing_link: sharing_link} %>
 

--- a/app/views/assets/sharing/_permission_table.html.erb
+++ b/app/views/assets/sharing/_permission_table.html.erb
@@ -27,8 +27,7 @@
             publicPermission: {
                 access_type: policy.access_type, <%# Uses snake case because that's how rails returns the JSON %>
                 title: 'Public',
-                isPublic: true,
-                isMandatory: true
+                isPublic: true
             },
             permissions: policy.permissions
         }

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -61,8 +61,6 @@
     <%= render :partial=> "projects/select_add_current_user_to_project" %>
 <% end %>
 
-<%= render partial: "assets/controlled_vocab_annotations_form_property", locals: { resource: @project, property: :disciplines} -%>
-
 <%= f.fancy_multiselect :organisms, { possibilities: Organism.order(:title).all, hidden: false } %>
 
 <%= f.fancy_multiselect :human_diseases, { possibilities: HumanDisease.order(:title).all, with_new_link: true, hidden: false } %>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -37,7 +37,6 @@
   <%= f.text_field :wiki_page, :class=>"form-control" -%>
 </div>
 
-
 <div class="form-group">
   <div class="row">
     <div class="col-md-2">
@@ -61,6 +60,8 @@
 <% unless project %>
     <%= render :partial=> "projects/select_add_current_user_to_project" %>
 <% end %>
+
+<%= render partial: "assets/controlled_vocab_annotations_form_property", locals: { resource: @project, property: :disciplines} -%>
 
 <%= f.fancy_multiselect :organisms, { possibilities: Organism.order(:title).all, hidden: false } %>
 

--- a/app/views/projects/_implicit_project_selector.html.erb
+++ b/app/views/projects/_implicit_project_selector.html.erb
@@ -1,12 +1,10 @@
 <%# Selects a project implicitly when a study/investigation is selected from an assay/study.%>
 <%# Populates the sharing form, prompts to apply the default policy%>
 
-<%= content_tag :script, project_policies_json(parents.map(&:projects).flatten.uniq), type: 'application/json', id: 'project-default-policies-json' %>
 <%= content_tag :script, project_lookup_json(parents), type: 'application/json', id: 'project-lookup-json' %>
 <script>
   var projectsLookup = JSON.parse($j('#project-lookup-json').text());
   Sharing.implicitProjects = [];
-  Sharing.defaultPolicies = JSON.parse($j('#project-default-policies-json').text());
 
   function setImplicitProjects(lookupId, skipPrompt) {
     Sharing.removeMandatoryProjectPermissions();
@@ -16,7 +14,9 @@
         Sharing.implicitProjects = projects;
 
         if (projects.length === 1) {
-          Sharing.defaultPolicyPrompt(projects[0], skipPrompt);
+            Sharing.fetchDefaultData(projects[0]).then((data) => {
+              Sharing.defaultPolicyPrompt(projects[0], data.policy, skipPrompt);
+            });
         }
 
         for (var i = 0; i < projects.length; i++) {

--- a/app/views/projects/_implicit_project_selector.html.erb
+++ b/app/views/projects/_implicit_project_selector.html.erb
@@ -3,37 +3,41 @@
 
 <%= content_tag :script, project_lookup_json(parents), type: 'application/json', id: 'project-lookup-json' %>
 <script>
-  var projectsLookup = JSON.parse($j('#project-lookup-json').text());
-  Sharing.implicitProjects = [];
+    Sharing.implicitProjects = [];
 
-  function setImplicitProjects(lookupId, skipPrompt) {
-    Sharing.removeMandatoryProjectPermissions();
-    if (lookupId) {
-      var projects = projectsLookup[parseInt(lookupId)];
-      if (projects && projects.length) {
-        Sharing.implicitProjects = projects;
+    $j(document).ready(function () {
+        const projectsLookup = JSON.parse($j('#project-lookup-json').text());
+        function setImplicitProjects(projectId) {
+            if (projectId) {
+                var projects = projectsLookup[parseInt(projectId)];
+                if (projects && projects.length) {
+                    Sharing.implicitProjects = projects;
 
-        if (projects.length === 1) {
-            Sharing.fetchDefaultData(projects[0]).then((data) => {
-              Sharing.defaultPolicyPrompt(projects[0], data.policy, skipPrompt);
-            });
+                    for (var i = 0; i < projects.length; i++) {
+                        Sharing.addPermissionForProject(projects[i]);
+                    }
+                }
+            }
         }
 
-        for (var i = 0; i < projects.length; i++) {
-          Sharing.addPermissionForProject(projects[i]);
+        function applyDefaultPolicy(skipPrompt) {
+            if (Sharing.implicitProjects.length === 1) {
+                Sharing.fetchDefaultData(Sharing.implicitProjects[0]).then((data) => {
+                    Sharing.defaultPolicyPrompt(Sharing.implicitProjects[0], data.policy, skipPrompt);
+                });
+            }
         }
-      }
-    }
-  }
 
-  $j(document).ready(function () {
-    $j('<%= select_id -%>').change(function () {
-      setImplicitProjects($j(this).val());
+        const select = $j('<%= select_id -%>');
+        select.change(function () {
+            setImplicitProjects($j(this).val());
+            applyDefaultPolicy();
+        });
+
+        // Handle initial state
+        setImplicitProjects(select.val());
+        <% if action == :new %>
+          applyDefaultPolicy(true); // Set default policy page load if it is a new resource
+        <% end %>
     });
-
-    <% if action == :new %>
-      // Set on page load if it is a new resource
-      setImplicitProjects($j('<%= select_id -%>').val());
-    <% end %>
-  });
 </script>

--- a/app/views/projects/_project_selector.html.erb
+++ b/app/views/projects/_project_selector.html.erb
@@ -107,6 +107,16 @@
                           licenseSelect.val(data.license).change().trigger('select2:select');
                       }
                   }
+
+                  // Select default disciplines
+                  if (select.selected.length === 1 && data.disciplines) {
+                      var disciplineSelect = $j('#<%= controller_name.singularize -%>_discipline_annotations');
+                      if (disciplineSelect.length && !disciplineSelect.val()) {
+                          disciplineSelect.val(data.disciplines).change().trigger('select2:select');
+                      }
+                  }
+
+                  // Remove project option from list
                   this.possibilities.splice(i, 1);
               });
 

--- a/app/views/projects/_project_selector.html.erb
+++ b/app/views/projects/_project_selector.html.erb
@@ -70,13 +70,8 @@
 <% end %>
 <%= content_tag :script, possible_projects_json.html_safe, type: 'application/json', id: 'project-selector-possibilities-json' %>
 <%= content_tag :script, selected_projects_json.html_safe, type: 'application/json', id: 'project-selector-selected-json' %>
-<%= content_tag :script, project_policies_json(possible_projects | selected_projects), type: 'application/json', id: 'project-default-policies-json' %>
-<%= content_tag :script, enable_auto_project_license? ? project_licenses_json : '{}', type: 'application/json', id: 'project-default-licenses-json' %>
 
 <script id="project-selector-script">
-  Sharing.defaultPolicies = JSON.parse($j('#project-default-policies-json').text());
-  Sharing.defaultLicenses = JSON.parse($j('#project-default-licenses-json').text());
-
   Sharing.projectsSelector = new Vue({
     el: '#project-selector',
     data: {
@@ -100,18 +95,21 @@
         for (var i = 0; i < this.possibilities.length; i++) {
           var project = this.possibilities[i];
           if (project.id == projectId) {
-            this.selected.push(project);
-            Sharing.defaultPolicyPrompt(project, skipPrompt);
+              const select = this;
+              select.selected.push(project);
+              Sharing.fetchDefaultData(project).then((data) => {
+                  Sharing.defaultPolicyPrompt(project, data.policy, skipPrompt);
+                  // Select the default license
+                  if (select.selected.length === 1 && data.license) {
+                      var licenseSelect = $j('#license-select');
+                      if (licenseSelect.length && licenseSelect.data('canOverwrite') &&
+                          $j('option[value="'+data.license+'"]', licenseSelect).length) {
+                          licenseSelect.val(data.license).change().trigger('select2:select');
+                      }
+                  }
+                  this.possibilities.splice(i, 1);
+              });
 
-            // Select the default license
-            if (this.selected.length === 1 && Sharing.defaultLicenses[project.id]) {
-                var licenseSelect = $j('#license-select');
-                if (licenseSelect.length && licenseSelect.data('canOverwrite') &&
-                    $j('option[value="'+Sharing.defaultLicenses[project.id]+'"]', licenseSelect).length) {
-                    licenseSelect.val(Sharing.defaultLicenses[project.id]).change();
-                }
-            }
-            this.possibilities.splice(i, 1);
             return false;
           }
         }

--- a/app/views/projects/default_data.json.jbuilder
+++ b/app/views/projects/default_data.json.jbuilder
@@ -1,0 +1,5 @@
+# Doing this using jbuilder so I can use the helper method `policy_hash`
+json.policy policy_hash(@project.default_policy, []) if @project.default_policy
+json.license @project.default_license if @project.default_license
+disciplines = @project.discipline_annotation_labels
+json.disciplines disciplines if disciplines.present?

--- a/app/views/sharing/_permissions_table.html.erb
+++ b/app/views/sharing/_permissions_table.html.erb
@@ -21,8 +21,7 @@
       publicPermission: {
         access_type: policy.access_type, <%# Uses snake case because that's how rails returns the JSON %>
         title: 'Public',
-        isPublic: true,
-        isMandatory: true },
+        isPublic: true },
       permissions: policy.permissions
     }
   });

--- a/app/views/studies/_form.html.erb
+++ b/app/views/studies/_form.html.erb
@@ -19,11 +19,13 @@
   </div>
 <% end %>
 
-<%= folding_panel("#{t('investigation')} details") do %>
-    <label class="required"><%= t('investigation') %></label>
-    <div id="investigation_collection">
-      <%= render :partial=>"studies/investigation_list",:locals=>{:investigations=>Investigation.all.select {|i|current_user.person.member_of? i.projects}} -%>
-    </div>    
+<% if show_form_manage_specific_attributes? %>
+  <%= folding_panel("#{t('investigation')} details") do %>
+      <label class="required"><%= t('investigation') %></label>
+      <div id="investigation_collection">
+        <%= render :partial=>"studies/investigation_list",:locals=>{:investigations=>Investigation.all.select {|i|current_user.person.member_of? i.projects}} -%>
+      </div>
+  <% end %>
 <% end %>
 
 <div class="form-group">

--- a/app/views/workflows/edit.html.erb
+++ b/app/views/workflows/edit.html.erb
@@ -34,6 +34,8 @@
 
     <%= render partial: 'assets/controlled_vocab_annotations_form_properties', locals: { resource: @workflow } %>
 
+    <%= render partial: 'assets/controlled_vocab_annotations_form_property', locals: { resource: @workflow, property: :disciplines} -%>
+
     <div class="form-group">
       <label>Maturity</label>
       <%= f.select :maturity_level, Workflow::MATURITY_LEVELS.values.map { |k| [t("maturity_level.#{k}"), k] }, { include_blank: 'Not specified' }, class: 'form-control' -%>

--- a/app/views/workflows/edit.html.erb
+++ b/app/views/workflows/edit.html.erb
@@ -34,8 +34,6 @@
 
     <%= render partial: 'assets/controlled_vocab_annotations_form_properties', locals: { resource: @workflow } %>
 
-    <%= render partial: 'assets/controlled_vocab_annotations_form_property', locals: { resource: @workflow, property: :disciplines} -%>
-
     <div class="form-group">
       <label>Maturity</label>
       <%= f.select :maturity_level, Workflow::MATURITY_LEVELS.values.map { |k| [t("maturity_level.#{k}"), k] }, { include_blank: 'Not specified' }, class: 'form-control' -%>

--- a/app/views/workflows/provide_metadata.html.erb
+++ b/app/views/workflows/provide_metadata.html.erb
@@ -61,6 +61,8 @@
 
     <%= render partial: 'assets/controlled_vocab_annotations_form_properties', locals: { resource: @workflow } %>
 
+    <%= render partial: 'assets/controlled_vocab_annotations_form_property', locals: { resource: @workflow, property: :disciplines} -%>
+
     <div class="form-group">
       <label>Maturity</label>
       <%= select_tag 'workflow[maturity_level]',

--- a/app/views/workflows/provide_metadata.html.erb
+++ b/app/views/workflows/provide_metadata.html.erb
@@ -61,8 +61,6 @@
 
     <%= render partial: 'assets/controlled_vocab_annotations_form_properties', locals: { resource: @workflow } %>
 
-    <%= render partial: 'assets/controlled_vocab_annotations_form_property', locals: { resource: @workflow, property: :disciplines} -%>
-
     <div class="form-group">
       <label>Maturity</label>
       <%= select_tag 'workflow[maturity_level]',

--- a/config/default_data/controlled-vocabs/openalex_fields.json
+++ b/config/default_data/controlled-vocabs/openalex_fields.json
@@ -1,0 +1,130 @@
+[
+  {
+    "id": "https://openalex.org/domains/3",
+    "display_name": "Physical Sciences",
+    "fields": [
+      {
+        "id": "https://openalex.org/fields/15",
+        "display_name": "Chemical Engineering"
+      },
+      {
+        "id": "https://openalex.org/fields/16",
+        "display_name": "Chemistry"
+      },
+      {
+        "id": "https://openalex.org/fields/17",
+        "display_name": "Computer Science"
+      },
+      {
+        "id": "https://openalex.org/fields/19",
+        "display_name": "Earth and Planetary Sciences"
+      },
+      {
+        "id": "https://openalex.org/fields/21",
+        "display_name": "Energy"
+      },
+      {
+        "id": "https://openalex.org/fields/22",
+        "display_name": "Engineering"
+      },
+      {
+        "id": "https://openalex.org/fields/23",
+        "display_name": "Environmental Science"
+      },
+      {
+        "id": "https://openalex.org/fields/25",
+        "display_name": "Materials Science"
+      },
+      {
+        "id": "https://openalex.org/fields/26",
+        "display_name": "Mathematics"
+      },
+      {
+        "id": "https://openalex.org/fields/31",
+        "display_name": "Physics and Astronomy"
+      }
+    ]
+  },
+  {
+    "id": "https://openalex.org/domains/2",
+    "display_name": "Social Sciences",
+    "fields": [
+      {
+        "id": "https://openalex.org/fields/12",
+        "display_name": "Arts and Humanities"
+      },
+      {
+        "id": "https://openalex.org/fields/14",
+        "display_name": "Business, Management and Accounting"
+      },
+      {
+        "id": "https://openalex.org/fields/18",
+        "display_name": "Decision Sciences"
+      },
+      {
+        "id": "https://openalex.org/fields/20",
+        "display_name": "Economics, Econometrics and Finance"
+      },
+      {
+        "id": "https://openalex.org/fields/32",
+        "display_name": "Psychology"
+      },
+      {
+        "id": "https://openalex.org/fields/33",
+        "display_name": "Social Sciences"
+      }
+    ]
+  },
+  {
+    "id": "https://openalex.org/domains/4",
+    "display_name": "Health Sciences",
+    "fields": [
+      {
+        "id": "https://openalex.org/fields/35",
+        "display_name": "Dentistry"
+      },
+      {
+        "id": "https://openalex.org/fields/36",
+        "display_name": "Health Professions"
+      },
+      {
+        "id": "https://openalex.org/fields/27",
+        "display_name": "Medicine"
+      },
+      {
+        "id": "https://openalex.org/fields/29",
+        "display_name": "Nursing"
+      },
+      {
+        "id": "https://openalex.org/fields/34",
+        "display_name": "Veterinary"
+      }
+    ]
+  },
+  {
+    "id": "https://openalex.org/domains/1",
+    "display_name": "Life Sciences",
+    "fields": [
+      {
+        "id": "https://openalex.org/fields/11",
+        "display_name": "Agricultural and Biological Sciences"
+      },
+      {
+        "id": "https://openalex.org/fields/13",
+        "display_name": "Biochemistry, Genetics and Molecular Biology"
+      },
+      {
+        "id": "https://openalex.org/fields/24",
+        "display_name": "Immunology and Microbiology"
+      },
+      {
+        "id": "https://openalex.org/fields/28",
+        "display_name": "Neuroscience"
+      },
+      {
+        "id": "https://openalex.org/fields/30",
+        "display_name": "Pharmacology, Toxicology and Pharmaceutics"
+      }
+    ]
+  }
+]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -162,6 +162,7 @@ en:
     data_format_annotation_values: 'Data format annotations'
     topic_annotation_values: 'Topic annotations'
     operation_annotation_values: 'Operation annotations'
+    discipline_annotation_values: 'Scientific disciplines'
     contributor: 'Submitter'
     # Mostly for associations in other models (has_one or has_many)
     programme: *programme

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -336,7 +336,7 @@ SEEK::Application.routes.draw do
       get :project_join_requests
       get :project_creation_requests
       get :project_importation_requests
-      get  :typeahead
+      get :typeahead
     end
     member do
       get :asset_report
@@ -357,6 +357,7 @@ SEEK::Application.routes.draw do
       post :hide_fair_data_station_import_status
       post :submit_fairdata_station
       post :update_annotations_ajax
+      get :default_data
     end
     resources :programmes, :people, :institutions, :assays, :studies, :investigations, :models, :sops, :workflows, :data_files, :observation_units, :presentations,
               :publications, :events, :sample_types, :samples, :specimens, :strains, :search, :organisms, :human_diseases, :documents, :file_templates, :placeholders, :collections, :templates, only: [:index]

--- a/db/seeds/018_discipline_vocab.seeds.rb
+++ b/db/seeds/018_discipline_vocab.seeds.rb
@@ -1,35 +1,32 @@
-DISCIPLINES = %(
-Chemistry
-Computer Science
-Earth Science
-Health Science
-Life Science
-Space Science
-Social Science
-Astronomy
-Physics
-Climate Science
-Humanities
-Library Science
-Cross-discipline
-Environmental Science
-Engineering
-Mathematics
-Neuroscience
-).split("\n").map(&:strip).compact_blank.freeze
+# Made up from a subset of EDAM Topics, plus some others
+DISCIPLINES = [
+  { label: 'Astronomy', iri: '' },
+  { label: 'Chemistry', iri: 'http://edamontology.org/topic_3314' },
+  { label: 'Climate Science', iri: '' },
+  { label: 'Computer Science', iri: 'http://edamontology.org/topic_3316' },
+  { label: 'Cross-discipline', iri: '' },
+  { label: 'Earth Science', iri: '' },
+  { label: 'Engineering', iri: '' },
+  { label: 'Environmental Science', iri: 'http://edamontology.org/topic_3855' },
+  { label: 'Humanities', iri: '' },
+  { label: 'Library Science', iri: '' },
+  { label: 'Life Science', iri: 'http://edamontology.org/topic_4019' },
+  { label: 'Machine Learning', iri: 'http://edamontology.org/topic_3474' },
+  { label: 'Mathematics', iri: 'http://edamontology.org/topic_3315' },
+  { label: 'Medicine', iri: 'http://edamontology.org/topic_3303' },
+  { label: 'Physics', iri: 'http://edamontology.org/topic_3318' },
+  { label: 'Social Science', iri: '' }
+].freeze
 
 data = {
   title: 'Scientific disciplines',
   description: 'A list of scientific disciplines.',
-  ols_root_term_uris: '',
-  source_ontology: '',
+  ols_root_term_uris: 'http://edamontology.org/topic_0003',
+  source_ontology: 'edam',
   sample_controlled_vocab_terms_attributes: DISCIPLINES.map do |d|
-    {
-      label: d,
-      iri: '',
-      parent_iri: ''
-    }
+    d[:parent_iri] = 'http://edamontology.org/topic_0003' if d[:iri].present?
+    d
   end
-}.with_indifferent_access
+}
 
-Seek::Data::SeedControlledVocab.seed(data, :disciplines)
+Seek::Data::SeedControlledVocab.seed(data.with_indifferent_access, :disciplines)

--- a/db/seeds/018_discipline_vocab.seeds.rb
+++ b/db/seeds/018_discipline_vocab.seeds.rb
@@ -1,31 +1,18 @@
-# Made up from a subset of EDAM Topics, plus some others
-DISCIPLINES = [
-  { label: 'Astronomy', iri: '' },
-  { label: 'Chemistry', iri: 'http://edamontology.org/topic_3314' },
-  { label: 'Climate Science', iri: '' },
-  { label: 'Computer Science', iri: 'http://edamontology.org/topic_3316' },
-  { label: 'Cross-discipline', iri: '' },
-  { label: 'Earth Science', iri: '' },
-  { label: 'Engineering', iri: '' },
-  { label: 'Environmental Science', iri: 'http://edamontology.org/topic_3855' },
-  { label: 'Humanities', iri: '' },
-  { label: 'Library Science', iri: '' },
-  { label: 'Life Science', iri: 'http://edamontology.org/topic_4019' },
-  { label: 'Machine Learning', iri: 'http://edamontology.org/topic_3474' },
-  { label: 'Mathematics', iri: 'http://edamontology.org/topic_3315' },
-  { label: 'Medicine', iri: 'http://edamontology.org/topic_3303' },
-  { label: 'Physics', iri: 'http://edamontology.org/topic_3318' },
-  { label: 'Social Science', iri: '' }
-].freeze
+FIELDS = JSON.parse(File.read(Rails.root.join('config', 'default_data', 'controlled-vocabs', 'openalex_fields.json')))
 
 data = {
   title: 'Scientific disciplines',
-  description: 'A list of scientific disciplines.',
-  ols_root_term_uris: 'http://edamontology.org/topic_0003',
-  source_ontology: 'edam',
-  sample_controlled_vocab_terms_attributes: DISCIPLINES.map do |d|
-    d[:parent_iri] = 'http://edamontology.org/topic_0003' if d[:iri].present?
-    d
+  description: 'A list of scientific disciplines, from https://openalex.org/',
+  ols_root_term_uris: '',
+  source_ontology: '',
+  sample_controlled_vocab_terms_attributes: FIELDS.flat_map do |domain|
+    domain['fields'].map do |field|
+      {
+        label: field['display_name'],
+        iri: field['id'],
+        parent_iri: domain['id']
+      }
+    end
   end
 }
 

--- a/db/seeds/018_discipline_vocab.seeds.rb
+++ b/db/seeds/018_discipline_vocab.seeds.rb
@@ -1,0 +1,35 @@
+DISCIPLINES = %(
+Chemistry
+Computer Science
+Earth Science
+Health Science
+Life Science
+Space Science
+Social Science
+Astronomy
+Physics
+Climate Science
+Humanities
+Library Science
+Cross-cutting
+Environmental Science
+Engineering
+Mathematics
+Neuroscience
+).split('\n').map(&:strip).compact_blank.freeze
+
+data = {
+  title: 'Scientific disciplines',
+  description: 'A list of scientific disciplines.',
+  ols_root_term_uris: '',
+  source_ontology: '',
+  sample_controlled_vocab_terms_attributes: DISCIPLINES.map do |d|
+    {
+      label: d,
+      iri: '',
+      parent_iri: ''
+    }
+  end
+}.with_indifferent_access
+
+Seek::Data::SeedControlledVocab.seed(data, :disciplines)

--- a/db/seeds/018_discipline_vocab.seeds.rb
+++ b/db/seeds/018_discipline_vocab.seeds.rb
@@ -11,12 +11,12 @@ Physics
 Climate Science
 Humanities
 Library Science
-Cross-cutting
+Cross-discipline
 Environmental Science
 Engineering
 Mathematics
 Neuroscience
-).split('\n').map(&:strip).compact_blank.freeze
+).split("\n").map(&:strip).compact_blank.freeze
 
 data = {
   title: 'Scientific disciplines',

--- a/lib/seek/data/seed_controlled_vocab.rb
+++ b/lib/seek/data/seed_controlled_vocab.rb
@@ -75,9 +75,13 @@ module Seek
         end
       end
 
-      def self.read_data(json_file, property)
-        json = File.read(File.join(Rails.root, 'config/default_data/controlled-vocabs', json_file))
-        data = JSON.parse(json).with_indifferent_access
+      def self.read_data(input, property)
+        if input.is_a?(String)
+          json = File.read(File.join(Rails.root, 'config/default_data/controlled-vocabs', input))
+          data = JSON.parse(json).with_indifferent_access
+        else
+          data = input
+        end
         data[:key] = SampleControlledVocab::SystemVocabs.database_key_for_property(property)
         data
       end

--- a/lib/tasks/seek_dev.rake
+++ b/lib/tasks/seek_dev.rake
@@ -449,4 +449,19 @@ namespace :seek_dev do
     end
 
   end
+
+  task fetch_openalex_fields: :environment do
+    url = 'https://api.openalex.org/domains'
+    puts "Fetching from: #{url}"
+    res = URI.open(url)
+    json = res.read
+    doc = JSON.parse(json)
+    domains = doc['results'].map do |dom|
+      dom.slice('id', 'display_name', 'fields')
+    end
+
+    filename = Rails.root.join('config', 'default_data', 'controlled-vocabs', 'openalex_fields.json')
+    File.write(filename, JSON.pretty_generate(domains))
+    puts "Written to: #{filename}"
+  end
 end

--- a/lib/tasks/seek_upgrades.rake
+++ b/lib/tasks/seek_upgrades.rake
@@ -16,6 +16,7 @@ namespace :seek do
     db:seed:004_model_recommended_environments
     update_rdf
     update_morpheus_model
+    db:seed:018_discipline_vocab
   ]
 
   # these are the tasks that are executes for each upgrade as standard, and rarely change

--- a/spec/javascripts/permissions_form_spec.js
+++ b/spec/javascripts/permissions_form_spec.js
@@ -10,8 +10,7 @@ describe('Permissions form and projects selector', function() {
                 publicPermission: {
                     access_type: Sharing.accessTypes.accessible,
                     title: 'Public',
-                    isPublic: true,
-                    isMandatory: true },
+                    isPublic: true },
                 permissions: []
             }
         });

--- a/test/factories/sample_attribute_types.rb
+++ b/test/factories/sample_attribute_types.rb
@@ -189,6 +189,18 @@ FactoryBot.define do
       vocab.sample_controlled_vocab_terms << FactoryBot.build(:sample_controlled_vocab_term, label: 'JSON',iri: 'http://edamontology.org/format_3464', parent_iri:'http://edamontology.org/format_1915')
     end
   end
+
+  factory(:disciplines_controlled_vocab, parent: :sample_controlled_vocab) do
+    title { 'Disciplines' }
+    ols_root_term_uris { 'http://disciplineontology.org/discipline_1' }
+    key { SampleControlledVocab::SystemVocabs.database_key_for_property(:disciplines) }
+    source_ontology { 'discipline' }
+    after(:build) do |vocab|
+      vocab.sample_controlled_vocab_terms << FactoryBot.build(:sample_controlled_vocab_term, label: 'Discipline', iri: 'http://disciplineontology.org/discipline_1', parent_iri:'')
+      vocab.sample_controlled_vocab_terms << FactoryBot.build(:sample_controlled_vocab_term, label: 'Biology', iri: 'http://disciplineontology.org/discipline_2', parent_iri: 'http://disciplineontology.org/discipline_1')
+      vocab.sample_controlled_vocab_terms << FactoryBot.build(:sample_controlled_vocab_term, label: 'Chemistry', iri: 'http://disciplineontology.org/discipline_3', parent_iri: 'http://disciplineontology.org/discipline_1')
+    end
+  end
   
   factory(:efo_ontology, class: SampleControlledVocab) do
     sequence(:title) { |n| "EFO ontology #{n}" }

--- a/test/factories/sample_attribute_types.rb
+++ b/test/factories/sample_attribute_types.rb
@@ -192,14 +192,14 @@ FactoryBot.define do
 
   factory(:disciplines_controlled_vocab, parent: :sample_controlled_vocab) do
     title { 'Disciplines' }
-    ols_root_term_uris { 'http://disciplineontology.org/discipline_1' }
+    ols_root_term_uris { 'http://edamontology.org/topic_0003' }
     key { SampleControlledVocab::SystemVocabs.database_key_for_property(:disciplines) }
-    source_ontology { 'discipline' }
+    source_ontology { 'edam' }
     after(:build) do |vocab|
-      vocab.sample_controlled_vocab_terms << FactoryBot.build(:sample_controlled_vocab_term, label: 'Discipline', iri: 'http://disciplineontology.org/discipline_1', parent_iri:'')
-      vocab.sample_controlled_vocab_terms << FactoryBot.build(:sample_controlled_vocab_term, label: 'Biology', iri: 'http://disciplineontology.org/discipline_2', parent_iri: 'http://disciplineontology.org/discipline_1')
-      vocab.sample_controlled_vocab_terms << FactoryBot.build(:sample_controlled_vocab_term, label: 'Chemistry', iri: 'http://disciplineontology.org/discipline_3', parent_iri: 'http://disciplineontology.org/discipline_1')
-      vocab.sample_controlled_vocab_terms << FactoryBot.build(:sample_controlled_vocab_term, label: 'Physics', iri: 'http://disciplineontology.org/discipline_4', parent_iri: 'http://disciplineontology.org/discipline_1')
+      vocab.sample_controlled_vocab_terms << FactoryBot.build(:sample_controlled_vocab_term, label: 'Biology', iri: 'http://edamontology.org/topic_3070', parent_iri: 'http://edamontology.org/topic_0003')
+      vocab.sample_controlled_vocab_terms << FactoryBot.build(:sample_controlled_vocab_term, label: 'Chemistry', iri: 'http://edamontology.org/topic_3314', parent_iri: 'http://edamontology.org/topic_0003')
+      vocab.sample_controlled_vocab_terms << FactoryBot.build(:sample_controlled_vocab_term, label: 'Physics', iri: 'http://edamontology.org/topic_3318', parent_iri: 'http://edamontology.org/topic_0003')
+      vocab.sample_controlled_vocab_terms << FactoryBot.build(:sample_controlled_vocab_term, label: 'Secret science', iri: '', parent_iri: '')
     end
   end
   

--- a/test/factories/sample_attribute_types.rb
+++ b/test/factories/sample_attribute_types.rb
@@ -196,9 +196,9 @@ FactoryBot.define do
     key { SampleControlledVocab::SystemVocabs.database_key_for_property(:disciplines) }
     source_ontology { 'edam' }
     after(:build) do |vocab|
-      vocab.sample_controlled_vocab_terms << FactoryBot.build(:sample_controlled_vocab_term, label: 'Biology', iri: 'http://edamontology.org/topic_3070', parent_iri: 'http://edamontology.org/topic_0003')
-      vocab.sample_controlled_vocab_terms << FactoryBot.build(:sample_controlled_vocab_term, label: 'Chemistry', iri: 'http://edamontology.org/topic_3314', parent_iri: 'http://edamontology.org/topic_0003')
-      vocab.sample_controlled_vocab_terms << FactoryBot.build(:sample_controlled_vocab_term, label: 'Physics', iri: 'http://edamontology.org/topic_3318', parent_iri: 'http://edamontology.org/topic_0003')
+      vocab.sample_controlled_vocab_terms << FactoryBot.build(:sample_controlled_vocab_term, label: 'Biochemistry, Genetics and Molecular Biology', iri: 'https://openalex.org/fields/13', parent_iri: 'https://openalex.org/domains/1')
+      vocab.sample_controlled_vocab_terms << FactoryBot.build(:sample_controlled_vocab_term, label: 'Chemistry', iri: 'https://openalex.org/fields/16', parent_iri: 'https://openalex.org/domains/3')
+      vocab.sample_controlled_vocab_terms << FactoryBot.build(:sample_controlled_vocab_term, label: 'Physics and Astronomy', iri: 'https://openalex.org/fields/31', parent_iri: 'https://openalex.org/domains/3')
       vocab.sample_controlled_vocab_terms << FactoryBot.build(:sample_controlled_vocab_term, label: 'Secret science', iri: '', parent_iri: '')
     end
   end

--- a/test/factories/sample_attribute_types.rb
+++ b/test/factories/sample_attribute_types.rb
@@ -199,6 +199,7 @@ FactoryBot.define do
       vocab.sample_controlled_vocab_terms << FactoryBot.build(:sample_controlled_vocab_term, label: 'Discipline', iri: 'http://disciplineontology.org/discipline_1', parent_iri:'')
       vocab.sample_controlled_vocab_terms << FactoryBot.build(:sample_controlled_vocab_term, label: 'Biology', iri: 'http://disciplineontology.org/discipline_2', parent_iri: 'http://disciplineontology.org/discipline_1')
       vocab.sample_controlled_vocab_terms << FactoryBot.build(:sample_controlled_vocab_term, label: 'Chemistry', iri: 'http://disciplineontology.org/discipline_3', parent_iri: 'http://disciplineontology.org/discipline_1')
+      vocab.sample_controlled_vocab_terms << FactoryBot.build(:sample_controlled_vocab_term, label: 'Physics', iri: 'http://disciplineontology.org/discipline_4', parent_iri: 'http://disciplineontology.org/discipline_1')
     end
   end
   

--- a/test/functional/projects_controller_test.rb
+++ b/test/functional/projects_controller_test.rb
@@ -5590,6 +5590,53 @@ class ProjectsControllerTest < ActionController::TestCase
     assert upload.show_status?
   end
 
+  test 'get default data if project member' do
+    FactoryBot.create(:disciplines_controlled_vocab) unless SampleControlledVocab::SystemVocabs.disciplines_controlled_vocab
+    person = FactoryBot.create(:person)
+    project = person.projects.first
+    disable_authorization_checks do
+      project.default_license = 'CC0-1.0'
+      project.default_policy = FactoryBot.create(:private_policy)
+      project.use_default_policy = true
+      project.discipline_annotations = 'Biology'
+      project.save!
+    end
+    login_as(person)
+
+    get :default_data, params: { id: project, format: :json }
+
+    assert_response :success
+    data = JSON.parse(response.body)
+    assert_equal 0, data.dig('policy', 'access_type')
+    assert_equal ['Biology'], data['disciplines']
+    assert_equal 'CC0-1.0', data['license']
+  end
+
+  test 'cannot get default data if not project member' do
+    person = FactoryBot.create(:person)
+    project = FactoryBot.create(:project)
+    refute project.has_member?(person)
+    login_as(person)
+
+    get :default_data, params: { id: project, format: :json }
+
+    assert_response :forbidden
+  end
+
+  test 'default data excludes blank values' do
+    FactoryBot.create(:disciplines_controlled_vocab) unless SampleControlledVocab::SystemVocabs.disciplines_controlled_vocab
+    person = FactoryBot.create(:person)
+    project = person.projects.first
+    login_as(person)
+
+    get :default_data, params: { id: project, format: :json }
+
+    assert_response :success
+    data = JSON.parse(response.body)
+    assert_equal 'CC-BY-4.0', data['license']
+    assert ['license'], data.keys
+  end
+
   private
 
   def check_project(project)

--- a/test/functional/projects_controller_test.rb
+++ b/test/functional/projects_controller_test.rb
@@ -5598,7 +5598,7 @@ class ProjectsControllerTest < ActionController::TestCase
       project.default_license = 'CC0-1.0'
       project.default_policy = FactoryBot.create(:private_policy)
       project.use_default_policy = true
-      project.discipline_annotations = 'Biology'
+      project.discipline_annotations = ['Biochemistry, Genetics and Molecular Biology']
       project.save!
     end
     login_as(person)
@@ -5608,7 +5608,7 @@ class ProjectsControllerTest < ActionController::TestCase
     assert_response :success
     data = JSON.parse(response.body)
     assert_equal 0, data.dig('policy', 'access_type')
-    assert_equal ['Biology'], data['disciplines']
+    assert_equal ['Biochemistry, Genetics and Molecular Biology'], data['disciplines']
     assert_equal 'CC0-1.0', data['license']
   end
 

--- a/test/unit/project_test.rb
+++ b/test/unit/project_test.rb
@@ -985,30 +985,30 @@ class ProjectTest < ActiveSupport::TestCase
     workflow = FactoryBot.create(:workflow, projects: [project])
     workflow_with_disciplines = FactoryBot.create(:workflow, projects: [project])
     User.with_current_user(workflow_with_disciplines.contributor.user) do
-      workflow_with_disciplines.discipline_annotations = 'Physics'
+      workflow_with_disciplines.discipline_annotations = ['Physics and Astronomy']
       workflow_with_disciplines.save!
     end
-    assert_equal ['Physics'], workflow_with_disciplines.reload.discipline_annotation_labels
+    assert_equal ['Physics and Astronomy'], workflow_with_disciplines.reload.discipline_annotation_labels
 
     assert_empty workflow.discipline_annotation_labels
     assert_empty project.discipline_annotation_labels
 
     User.with_current_user(workflow.contributor.user) do
-      project.discipline_annotations = 'Biology'
+      project.discipline_annotations = ['Biochemistry, Genetics and Molecular Biology']
       project.save!
     end
 
-    assert_equal ['Biology'], project.discipline_annotation_labels
-    assert_equal ['Biology'], workflow.reload.discipline_annotation_labels
-    assert_equal ['Physics'], workflow_with_disciplines.reload.discipline_annotation_labels
+    assert_equal ['Biochemistry, Genetics and Molecular Biology'], project.discipline_annotation_labels
+    assert_equal ['Biochemistry, Genetics and Molecular Biology'], workflow.reload.discipline_annotation_labels
+    assert_equal ['Physics and Astronomy'], workflow_with_disciplines.reload.discipline_annotation_labels
 
     User.with_current_user(workflow.contributor.user) do
-      workflow.discipline_annotations = 'Chemistry'
+      workflow.discipline_annotations = ['Chemistry']
       workflow.save!
     end
 
-    assert_equal ['Biology'], project.discipline_annotation_labels
+    assert_equal ['Biochemistry, Genetics and Molecular Biology'], project.discipline_annotation_labels
     assert_equal ['Chemistry'], workflow.discipline_annotation_labels
-    assert_equal ['Physics'], workflow_with_disciplines.reload.discipline_annotation_labels
+    assert_equal ['Physics and Astronomy'], workflow_with_disciplines.reload.discipline_annotation_labels
   end
 end

--- a/test/unit/project_test.rb
+++ b/test/unit/project_test.rb
@@ -978,4 +978,37 @@ class ProjectTest < ActiveSupport::TestCase
     assert_equal df_blob_size + 2 * repo_size, project.total_asset_size, "total_asset_size includes each workflow and df"
   end
 
+  test 'propagates disciplines to workflows' do
+    FactoryBot.create(:disciplines_controlled_vocab) unless SampleControlledVocab::SystemVocabs.disciplines_controlled_vocab
+
+    project = FactoryBot.create(:project)
+    workflow = FactoryBot.create(:workflow, projects: [project])
+    workflow_with_disciplines = FactoryBot.create(:workflow, projects: [project])
+    User.with_current_user(workflow_with_disciplines.contributor.user) do
+      workflow_with_disciplines.discipline_annotations = 'Physics'
+      workflow_with_disciplines.save!
+    end
+    assert_equal ['Physics'], workflow_with_disciplines.reload.discipline_annotation_labels
+
+    assert_empty workflow.discipline_annotation_labels
+    assert_empty project.discipline_annotation_labels
+
+    User.with_current_user(workflow.contributor.user) do
+      project.discipline_annotations = 'Biology'
+      project.save!
+    end
+
+    assert_equal ['Biology'], project.discipline_annotation_labels
+    assert_equal ['Biology'], workflow.reload.discipline_annotation_labels
+    assert_equal ['Physics'], workflow_with_disciplines.reload.discipline_annotation_labels
+
+    User.with_current_user(workflow.contributor.user) do
+      workflow.discipline_annotations = 'Chemistry'
+      workflow.save!
+    end
+
+    assert_equal ['Biology'], project.discipline_annotation_labels
+    assert_equal ['Chemistry'], workflow.discipline_annotation_labels
+    assert_equal ['Physics'], workflow_with_disciplines.reload.discipline_annotation_labels
+  end
 end

--- a/test/unit/workflow_test.rb
+++ b/test/unit/workflow_test.rb
@@ -958,4 +958,30 @@ class WorkflowTest < ActiveSupport::TestCase
       assert_equal 0, policy.permissions.count
     end
   end
+
+  test 'inherits discipline from project' do
+    FactoryBot.create(:disciplines_controlled_vocab) unless SampleControlledVocab::SystemVocabs.disciplines_controlled_vocab
+
+    workflow = FactoryBot.create(:workflow)
+    project = workflow.projects.first
+
+    assert_empty workflow.discipline_annotation_labels
+    assert_empty project.discipline_annotation_labels
+
+    User.with_current_user(workflow.contributor.user) do
+      project.discipline_annotations = 'Biology'
+      project.save!
+    end
+
+    assert_equal ['Biology'], project.discipline_annotation_labels
+    assert_equal ['Biology'], workflow.discipline_annotation_labels
+
+    User.with_current_user(workflow.contributor.user) do
+      workflow.discipline_annotations = 'Chemistry'
+      workflow.save!
+    end
+
+    assert_equal ['Biology'], project.discipline_annotation_labels
+    assert_equal ['Chemistry'], workflow.discipline_annotation_labels
+  end
 end

--- a/test/unit/workflow_test.rb
+++ b/test/unit/workflow_test.rb
@@ -958,30 +958,4 @@ class WorkflowTest < ActiveSupport::TestCase
       assert_equal 0, policy.permissions.count
     end
   end
-
-  test 'inherits discipline from project' do
-    FactoryBot.create(:disciplines_controlled_vocab) unless SampleControlledVocab::SystemVocabs.disciplines_controlled_vocab
-
-    workflow = FactoryBot.create(:workflow)
-    project = workflow.projects.first
-
-    assert_empty workflow.discipline_annotation_labels
-    assert_empty project.discipline_annotation_labels
-
-    User.with_current_user(workflow.contributor.user) do
-      project.discipline_annotations = 'Biology'
-      project.save!
-    end
-
-    assert_equal ['Biology'], project.discipline_annotation_labels
-    assert_equal ['Biology'], workflow.discipline_annotation_labels
-
-    User.with_current_user(workflow.contributor.user) do
-      workflow.discipline_annotations = 'Chemistry'
-      workflow.save!
-    end
-
-    assert_equal ['Biology'], project.discipline_annotation_labels
-    assert_equal ['Chemistry'], workflow.discipline_annotation_labels
-  end
 end

--- a/test/unit/workflow_test.rb
+++ b/test/unit/workflow_test.rb
@@ -958,4 +958,16 @@ class WorkflowTest < ActiveSupport::TestCase
       assert_equal 0, policy.permissions.count
     end
   end
+
+  test 'ignores blank value when setting disciplines' do
+    FactoryBot.create(:disciplines_controlled_vocab) unless SampleControlledVocab::SystemVocabs.disciplines_controlled_vocab
+
+    workflow = FactoryBot.create(:workflow)
+    User.with_current_user(workflow.contributor.user) do
+      workflow.discipline_annotations = ['', 'Physics']
+      assert workflow.save
+    end
+
+    assert_equal ['Physics'], workflow.reload.discipline_annotation_labels
+  end
 end

--- a/test/unit/workflow_test.rb
+++ b/test/unit/workflow_test.rb
@@ -964,10 +964,10 @@ class WorkflowTest < ActiveSupport::TestCase
 
     workflow = FactoryBot.create(:workflow)
     User.with_current_user(workflow.contributor.user) do
-      workflow.discipline_annotations = ['', 'Physics']
+      workflow.discipline_annotations = ['', 'Physics and Astronomy']
       assert workflow.save
     end
 
-    assert_equal ['Physics'], workflow.reload.discipline_annotation_labels
+    assert_equal ['Physics and Astronomy'], workflow.reload.discipline_annotation_labels
   end
 end


### PR DESCRIPTION
- Allows projects and workflows to be annotated with scientific disciplines.
- Propagates disciplines set on a project down to workflows under that project (if they do not already have any disciplines set).
- Refactors how default policies/licenses are handled, fetching them with an AJAX call rather than storing a mapping on the page.
- Moves investigation/study select field to the "manage" pages of studies/assays.

