### PR TITLE
Fix the object datatype being correctly registered when inserting to triple store

### DIFF
--- a/lib/seek/rdf/rdf_generation.rb
+++ b/lib/seek/rdf/rdf_generation.rb
@@ -134,7 +134,8 @@ module Seek
           'sioc' => RDF::Vocab::SIOC.to_uri.to_s,
           'mixs' => 'https://w3id.org/mixs/',
           'uniprot' => 'http://purl.uniprot.org/core/',
-          'fairbd' => 'http://fairbydesign.nl/ontology/'
+          'fairbd' => 'http://fairbydesign.nl/ontology/',
+          'xsd' => 'http://www.w3.org/2001/XMLSchema#'
         }
       end
 

--- a/lib/seek/rdf/rdf_repository.rb
+++ b/lib/seek/rdf/rdf_repository.rb
@@ -137,7 +137,7 @@ module Seek
       def send_statement_to_repository(statement, graph_uri)
         Rails.logger.debug("sending statement #{statement} to graph #{graph_uri}")
         graph = RDF::URI.new graph_uri
-        q = query.insert([statement.subject, statement.predicate, statement.object]).graph(graph)
+        q = query.insert_data([statement.subject, statement.predicate, statement.object]).graph(graph)
         Rails.logger.debug("Insert statement SPARQL: #{q}")
         result = insert(q)
         Rails.logger.debug(result)

--- a/test/integration/rdf_triple_store_test.rb
+++ b/test/integration/rdf_triple_store_test.rb
@@ -49,6 +49,12 @@ class RdfTripleStoreTest < ActionDispatch::IntegrationTest
     result = @repository.select(q)
     assert_equal 1, result.count
     assert_equal 'Test for RDF storage', result[0][:o].value
+    assert_equal 'http://www.w3.org/2001/XMLSchema#string', result[0][:o].datatype
+
+    q = @repository.query.select.where([@subject, RDF::URI.new('http://purl.org/dc/terms/created'), :o]).from(@private_graph)
+    result = @repository.select(q)
+    assert_equal 1, result.count
+    assert_equal 'http://www.w3.org/2001/XMLSchema#dateTime', result[0][:o].datatype
   end
 
   test 'remove public from store' do


### PR DESCRIPTION
by using `insert_data` instead of just `insert`, then the data type of the object value is correctly appended in the INSERT query.

i.e.

```
INSERT DATA INTO GRAPH <seek-testing:private> { <http://localhost:3000/projects/1044> <http://purl.org/dc/terms/modified> 
"2025-06-26T15:59:15.398Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> . }
``` 
instead of 
```
INSERT DATA INTO GRAPH <seek-testing:private> { <http://localhost:3000/projects/1044> <http://purl.org/dc/terms/modified> 
"2025-06-26T15:59:15.398Z" . }
```

also updated test and also include `xsd:http://www.w3.org/2001/XMLSchema#` as a namespace prefix for cleaner looking rdf / turtle

* Fix for #2204 