### PR TITLE
Fix LinkingSamplesUpdateJob failures

### DIFF
--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -211,7 +211,7 @@ class Sample < ApplicationRecord
   end
 
   def queue_linking_samples_update_job
-    LinkingSamplesUpdateJob.new(self).queue_job
+    LinkingSamplesUpdateJob.new(self).queue_job if title_previously_changed?
   end
 
   def update_sample_resource_links

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -145,23 +145,22 @@ class Sample < ApplicationRecord
   end
 
   def refresh_linking_samples
-    sample_type_hash = {}
-    linking_samples.each do |s|
-      sample_type_hash = update_sample_type_hash(sample_type_hash, s.sample_type)
-      positions = sample_type_hash[s.sample_type.id]
-      metadata = s.data
-      positions.each do |p|
-        item_linked_samples = Array(metadata.values[p - 1])
-        item_linked_samples.each do |sample|
-          sample['title'] = title if sample['id'] == id
-        end
-        metadata.values[p - 1] = item_linked_samples
+    linking_samples.group_by(&:sample_type).each do |sample_type, _linking_samples|
+      potential_linking_attributes = sample_type.sample_attributes.select do |sa|
+        sa.seek_sample_multi? || sa.seek_sample?
+      end
 
-        # only update if changed, to prevent triggered jobs that could potentially create an infinate loop
-        if s.json_metadata != metadata.to_json
-          s.json_metadata = metadata.to_json
-          s.save
+      _linking_samples.each do |linking_sample|
+        changed = false
+        potential_linking_attributes.each do |attr|
+          Array(linking_sample.get_attribute_value(attr)).each do |linked_sample_data|
+            next unless linked_sample_data['id'] == id
+            next if linked_sample_data['title'] == title
+            linked_sample_data['title'] = title
+            changed = true
+          end
         end
+        linking_sample.update_column(:json_metadata, linking_sample.data.to_json) if changed
       end
     end
   end
@@ -225,16 +224,6 @@ class Sample < ApplicationRecord
 
   def attribute_class
     SampleAttribute
-  end
-
-  def update_sample_type_hash(sample_type_hash, sample_type)
-    if sample_type_hash[sample_type.id].nil?
-      # Select all attributes of type seek_sample_multi or seek_sample
-      sample_type_hash[sample_type.id] = sample_type.sample_attributes.select do |sa|
-        sa.seek_sample_multi? || sa.seek_sample?
-      end.map(&:pos)
-    end
-    sample_type_hash
   end
 
   # checks and validates whether new linked samples have view permission, but ignores existing ones

--- a/test/unit/jobs/linking_samples_update_job_test.rb
+++ b/test/unit/jobs/linking_samples_update_job_test.rb
@@ -7,45 +7,43 @@ class LinkingSamplesUpdateJobTest < ActiveSupport::TestCase
   end
 
   test 'perform' do
-    sample = Sample.first
-    sample.set_attribute_value('full name', 'Ali Mohammadi')
-    disable_authorization_checks { sample.save! }
+    @main_sample.set_attribute_value('full name', 'Ali Mohammadi')
+    disable_authorization_checks { @main_sample.save! }
 
-    LinkingSamplesUpdateJob.perform_now(sample)
+    LinkingSamplesUpdateJob.perform_now(@main_sample)
 
-    sample.linking_samples.each do |s|
+    @main_sample.linking_samples.each do |s|
       assert_equal 'Ali Mohammadi', s.get_attribute_value(:patient)[0][:title]
     end
   end
 
-  test 'only trigger further jobs if the metadata changes' do
-    sample = Sample.first
-    sample.set_attribute_value('full name', 'Ali Mohammadi')
-    disable_authorization_checks { sample.save! }
-    assert_enqueued_jobs 2, only: LinkingSamplesUpdateJob do
-      LinkingSamplesUpdateJob.perform_now(sample)
-    end
-
-    sample.set_attribute_value('full name', 'Ali Mohammadi')
-    disable_authorization_checks { sample.save! }
-    assert_enqueued_jobs 0, only: LinkingSamplesUpdateJob do
-      LinkingSamplesUpdateJob.perform_now(sample)
-    end
-
-    sample.set_attribute_value('full name', 'Fred Flintstone')
-    disable_authorization_checks { sample.save! }
-    assert_enqueued_jobs 2, only: LinkingSamplesUpdateJob do
-      LinkingSamplesUpdateJob.perform_now(sample)
+  test 'triggers job on title change' do
+    @main_sample.set_attribute_value('full name', 'Ali Mohammadi')
+    assert_enqueued_with(job: LinkingSamplesUpdateJob, args: [@main_sample]) do
+      disable_authorization_checks { @main_sample.save! }
     end
   end
 
+  test 'does not trigger job on other change' do
+    @main_sample.set_attribute_value('age', 66)
+    assert_enqueued_jobs 0, only: LinkingSamplesUpdateJob do
+      disable_authorization_checks { @main_sample.save! }
+    end
+  end
+
+  test 'does not recursively trigger jobs' do
+    @main_sample.set_attribute_value('full name', 'Ali Mohammadi')
+    disable_authorization_checks { @main_sample.save! }
+    assert_enqueued_jobs 0, only: LinkingSamplesUpdateJob do
+      LinkingSamplesUpdateJob.perform_now(@main_sample)
+    end
+  end
 
   def create_linked_samples
-
     project = @person.projects.first
 
-    main_sample = FactoryBot.create(:patient_sample)
-    sample_type = main_sample.sample_type
+    @main_sample = FactoryBot.create(:patient_sample)
+    sample_type = @main_sample.sample_type
 
     another_sample_type = FactoryBot.create(:multi_linked_sample_type, project_ids: [project.id])
     another_sample_type.sample_attributes.last.linked_sample_type = sample_type
@@ -54,10 +52,10 @@ class LinkingSamplesUpdateJobTest < ActiveSupport::TestCase
     another_sample_type.save!
     disable_authorization_checks do
       Sample.create!(sample_type: another_sample_type, project_ids: [project.id],
-                     data: { title: 'linked_sample1', patient: [main_sample.id], age: 42 })
+                     data: { title: 'linked_sample1', patient: [@main_sample.id], age: 42 })
 
       s2 = Sample.create!(sample_type: another_sample_type, project_ids: [project.id],
-                     data: { title: 'linked_sample2', patient: [main_sample.id], age: 43 })
+                     data: { title: 'linked_sample2', patient: [@main_sample.id], age: 43 })
       # Muddle the order of the properties in the JSON metadata
       s2.update_column(:json_metadata, JSON.parse(s2.json_metadata).slice('patient', 'age', 'title').to_json)
     end


### PR DESCRIPTION
Fixes #1889

Also prevents needless jobs being created when no updates are required.