### PR TITLE
2238 select all broken in dynamic table

### DIFF
--- a/app/assets/javascripts/single_page/dynamic_table.js.erb
+++ b/app/assets/javascripts/single_page/dynamic_table.js.erb
@@ -186,6 +186,10 @@ const handleSelect = (e) => {
           targets: options.readonly ? [0, ...multi_link_idx] : [1],
           visible: false,
           searchable: false
+        },
+        {
+          targets: options.readonly ? [] : [0],
+          orderable: false
         }
       ];
       const editor = this.editor;


### PR DESCRIPTION
- Fixes the `selectAll` rows after updating the DataTablesJS dependency.
- Resolves #2238 