### PR TITLE
Clean up FAIR Data Station Uploads

### DIFF
--- a/app/jobs/regular_maintenance_job.rb
+++ b/app/jobs/regular_maintenance_job.rb
@@ -13,6 +13,7 @@ class RegularMaintenanceJob < ApplicationJob
   USER_GRACE_PERIOD = 1.week.freeze
   MAX_ACTIVATION_EMAILS = 3
   RESEND_ACTIVATION_EMAIL_DELAY = 4.hours.freeze
+  FAILED_FAIR_DATA_STATION_IMPORTS_PERIOD = 4.weeks.freeze
 
   def perform
     remove_dangling_content_blobs
@@ -20,6 +21,7 @@ class RegularMaintenanceJob < ApplicationJob
     clean_git_repositories
     resend_activation_emails
     remove_unregistered_users
+    clean_failed_fair_data_station_imports
   end
 
   private
@@ -70,6 +72,14 @@ class RegularMaintenanceJob < ApplicationJob
         Rails.logger.info("User with invalid person - #{user.id}")
       end
     end
+  end
+
+  # cleans up failed fair data station imports, that are older than 4 weeks old
+  def clean_failed_fair_data_station_imports
+    FairDataStationUpload.for_import_task_status(Task::STATUS_FAILED)
+                          .where('fair_data_station_uploads.created_at < ?', FAILED_FAIR_DATA_STATION_IMPORTS_PERIOD.ago)
+                         .destroy_all
+
   end
 
 end

--- a/app/models/fair_data_station_upload.rb
+++ b/app/models/fair_data_station_upload.rb
@@ -1,8 +1,11 @@
 class FairDataStationUpload < ApplicationRecord
+  include Seek::ActsAsAsset::ContentBlobs::ClassMethods
+  include Seek::ActsAsAsset::ContentBlobs::InstanceMethods
+
   belongs_to :investigation
   belongs_to :content_blob, validate: true
   belongs_to :project
-  belongs_to :policy, validate: true
+  belongs_to :policy, validate: true, dependent: :destroy
   belongs_to :contributor, class_name: 'Person'
   enum :purpose, %i[import update], suffix: true
 

--- a/app/models/fair_data_station_upload.rb
+++ b/app/models/fair_data_station_upload.rb
@@ -23,21 +23,19 @@ class FairDataStationUpload < ApplicationRecord
   }
 
   scope :show_status, -> { where show_status: true }
+  scope :for_import_task_status, ->(statuses) { import_purpose.joins(:import_task).where(tasks: {status: statuses})}
+  scope :for_update_task_status, ->(statuses) { update_purpose.joins(:update_task).where(tasks: {status: statuses})}
 
   def self.matching_imports_in_progress(project, external_id)
-    FairDataStationUpload.import_purpose
-                         .joins(:import_task)
+    FairDataStationUpload.for_import_task_status([Task::STATUS_QUEUED, Task::STATUS_ACTIVE, Task::STATUS_WAITING])
                          .where(investigation_external_identifier: external_id,
-                                project: project,
-                                tasks: { status: [Task::STATUS_QUEUED, Task::STATUS_ACTIVE, Task::STATUS_WAITING] })
+                                project: project)
   end
 
   def self.matching_updates_in_progress(investigation, external_id)
-    FairDataStationUpload.update_purpose
-                         .joins(:update_task)
+    FairDataStationUpload.for_update_task_status([Task::STATUS_QUEUED, Task::STATUS_ACTIVE, Task::STATUS_WAITING])
                          .where(investigation_external_identifier: external_id,
-                                investigation: investigation,
-                                tasks: { status: [Task::STATUS_QUEUED, Task::STATUS_ACTIVE, Task::STATUS_WAITING] })
+                                investigation: investigation)
   end
 
   private

--- a/app/models/investigation.rb
+++ b/app/models/investigation.rb
@@ -21,6 +21,8 @@ class Investigation < ApplicationRecord
   has_many :observation_units, through: :studies
   has_many :observations_unit_data_files, -> { distinct }, through: :observation_units, source: :data_files
   has_many :observations_unit_samples, -> { distinct }, through: :observation_units, source: :samples
+
+  has_many :fair_data_station_uploads, dependent: :destroy
   def state_allows_delete?(*args)
     studies.empty? && super
   end


### PR DESCRIPTION
Delete associated `FairDataStationUploads ` when an Investigation is deleted - setting up the appropriate `dependent: :destroy` to also delete the policy and mark the associated content blob for deletion.

Decided against doing the same for Project, as the Investigation could be associated to multiple projects - and for the Project to be deleted the associated items need to be moved or deleted, making it unnecessary. However, the maintenance task will clean up failed imports after 4 weeks (after which time it can be investigated). 

* fix for #2227 