### PR TITLE
2240 automatically fill in sample type title and description

### DIFF
--- a/app/assets/javascripts/templates.js
+++ b/app/assets/javascripts/templates.js
@@ -203,11 +203,7 @@ function updateIsaTagSelect(template_level, attribute_row) {
 
 const applyTemplate = () => {
   const id = $j("#source_select").find(":selected").val();
-  const data = templates.find((t) => t.template_id == id);
-  const codeMirror = $j(Templates.context.description_elem || "#template-description").nextAll(
-    ".CodeMirror"
-  )[0].CodeMirror;
-  if (data.description) codeMirror.getDoc().setValue(data.description);
+  const data = templates.find((t) => t.template_id === id);
   const suffix = Templates.context.suffix || "";
   const attribute_table = "#attribute-table" + suffix;
   const attribute_row = "#new-attribute-row" + suffix;

--- a/app/assets/javascripts/templates.js
+++ b/app/assets/javascripts/templates.js
@@ -155,10 +155,10 @@ function loadFilterSelectors(data) {
       const filters =  $j("[data-key]")
         .map((i, elem) => ({ key: elem.getAttribute("data-key"), value: elem.value }))
         .toArray()
-        .filter((f) => f.value != "not selected");
+        .filter((f) => f.value !== "not selected");
       let filtered = templates;
       filters.forEach(({ key, value }) => {
-        filtered = filtered.filter((x) => x[key] == value);
+        filtered = filtered.filter((x) => x[key] === value);
       });
       loadTemplates(filtered || templates);
     });
@@ -203,7 +203,7 @@ function updateIsaTagSelect(template_level, attribute_row) {
 
 const applyTemplate = () => {
   const id = $j("#source_select").find(":selected").val();
-  const data = templates.find((t) => t.template_id === id);
+  const data = templates.find((t) => t.template_id.toString() === id);
   const suffix = Templates.context.suffix || "";
   const attribute_table = "#attribute-table" + suffix;
   const attribute_row = "#new-attribute-row" + suffix;

--- a/app/controllers/isa_assays_controller.rb
+++ b/app/controllers/isa_assays_controller.rb
@@ -49,7 +49,16 @@ class ISAAssaysController < ApplicationController
 
   def create
     update_sharing_policies @isa_assay.assay
-    @isa_assay.sample_type.policy = @isa_assay.assay.policy unless @isa_assay.assay.is_assay_stream?
+    unless @isa_assay.assay.is_assay_stream?
+      level = if @isa_assay.sample_type.level
+                @isa_assay.sample_type.level&.split(' - ').map(&:capitalize).join(' - ')
+              else
+                'Custom'
+              end
+      @isa_assay.sample_type.policy = @isa_assay.assay.policy
+      @isa_assay.sample_type.title = "#{@isa_assay.assay.title} - '#{level}' Sample Type" if @isa_assay.sample_type.title.blank?
+      @isa_assay.sample_type.description = "'#{level}' Sample Type linked to Assay '#{@isa_assay.assay.title}'." if @isa_assay.sample_type.description.blank?
+    end
     if @isa_assay.save
       flash[:notice] = "The #{t('isa_assay')} was successfully created.<br/>".html_safe
       respond_to do |format|

--- a/app/controllers/isa_studies_controller.rb
+++ b/app/controllers/isa_studies_controller.rb
@@ -19,6 +19,10 @@ class ISAStudiesController < ApplicationController
     @isa_study.sample_collection.policy = @isa_study.study.policy
     @isa_study.source.contributor = User.current_user.person
     @isa_study.sample_collection.contributor = User.current_user.person
+    @isa_study.source.title = "#{@isa_study.study.title} - Source Sample Type"
+    @isa_study.source.description = "Source Sample Type linked to Study #{@isa_study.study.title}"
+    @isa_study.sample_collection.title = "#{@isa_study.study.title} - Sample Collection Sample Type"
+    @isa_study.sample_collection.description = "Sample Collection Sample Type linked to Study #{@isa_study.study.title}."
     @isa_study.study.sample_types = [ @isa_study.source, @isa_study.sample_collection ]
 
     if @isa_study.save

--- a/app/controllers/isa_studies_controller.rb
+++ b/app/controllers/isa_studies_controller.rb
@@ -19,10 +19,10 @@ class ISAStudiesController < ApplicationController
     @isa_study.sample_collection.policy = @isa_study.study.policy
     @isa_study.source.contributor = User.current_user.person
     @isa_study.sample_collection.contributor = User.current_user.person
-    @isa_study.source.title = "#{@isa_study.study.title} - Source Sample Type"
-    @isa_study.source.description = "Source Sample Type linked to Study #{@isa_study.study.title}"
-    @isa_study.sample_collection.title = "#{@isa_study.study.title} - Sample Collection Sample Type"
-    @isa_study.sample_collection.description = "Sample Collection Sample Type linked to Study #{@isa_study.study.title}."
+    @isa_study.source.title = "#{@isa_study.study.title} - Source Sample Type" if @isa_study.source.title.blank?
+    @isa_study.source.description = "Source Sample Type linked to Study '#{@isa_study.study.title}'." if @isa_study.source.description.blank?
+    @isa_study.sample_collection.title = "#{@isa_study.study.title} - Sample Collection Sample Type" if @isa_study.sample_collection.title.blank?
+    @isa_study.sample_collection.description = "Sample Collection Sample Type linked to Study '#{@isa_study.study.title}'." if @isa_study.sample_collection.description.blank?
     @isa_study.study.sample_types = [ @isa_study.source, @isa_study.sample_collection ]
 
     if @isa_study.save

--- a/app/views/isa_studies/_sample_types_form.html.erb
+++ b/app/views/isa_studies/_sample_types_form.html.erb
@@ -13,16 +13,6 @@
     <% end %>
 	<% end %>
 
-  <div class="form-group">
-      <label>Title</label><%= required_span %>
-      <%= field.text_field :title, class: 'form-control', placeholder: 'Sample type name' %>
-  </div>
-
-  <div class="form-group">
-    <label>Description</label>
-    <%= field.text_area :description, class: "form-control rich-text-edit", rows: 5 -%>
-  </div>
-
   <%= field.hidden_field :template_id, { id: "isa_study#{id_suffix}template_parent_id" } %>
 
   <div class="tab-content">

--- a/test/functional/isa_assays_controller_test.rb
+++ b/test/functional/isa_assays_controller_test.rb
@@ -48,7 +48,7 @@ class ISAAssaysControllerTest < ActionController::TestCase
                                                       assay_class_id: AssayClass.experimental.id,
                                                       position: 0, policy_attributes: },
                                              input_sample_type_id: sample_collection_sample_type.id,
-                                             sample_type: material_assay_sample_type_attributes(projects.first, sample_collection_sample_type.id)
+                                             sample_type: create_material_assay_sample_type_attributes(projects.first, sample_collection_sample_type.id)
         } }
       end
     end
@@ -193,7 +193,7 @@ class ISAAssaysControllerTest < ActionController::TestCase
 
     isa_assay_attributes = { assay: assay_attributes.merge(emt_attributes),
                              input_sample_type_id: sample_collection_sample_type.id,
-                             sample_type: material_assay_sample_type_attributes(projects.first, sample_collection_sample_type.id)
+                             sample_type: create_material_assay_sample_type_attributes(projects.first, sample_collection_sample_type.id)
     }
 
     assert_difference 'Assay.count', 1 do
@@ -302,7 +302,7 @@ class ISAAssaysControllerTest < ActionController::TestCase
 
     intermediate_isa_assay_attributes1 = { assay: intermediate_assay_attributes1,
                                            input_sample_type_id: study.sample_types.second.id,
-                                           sample_type: material_assay_sample_type_attributes(projects.first, study.sample_types.second.id) }
+                                           sample_type: create_material_assay_sample_type_attributes(projects.first, study.sample_types.second.id) }
 
     assert_difference "Assay.count", 1 do
       assert_difference "SampleType.count", 1 do
@@ -603,7 +603,7 @@ class ISAAssaysControllerTest < ActionController::TestCase
     assay_attributes = assay.as_json.reject { |_, v| v.blank? }
 
     login_as person.user
-    post :create, params: { isa_assay: { assay: assay_attributes, sample_type: material_assay_sample_type_attributes(project, study.sample_types.second.id), source_assay_id: assay_stream.id, input_sample_type_id: study.sample_types.second.id }, policy_attributes: assay_policy_attributes }
+    post :create, params: { isa_assay: { assay: assay_attributes, sample_type: create_material_assay_sample_type_attributes(project, study.sample_types.second.id), source_assay_id: assay_stream.id, input_sample_type_id: study.sample_types.second.id }, policy_attributes: assay_policy_attributes }
     @isa_assay = assigns(:isa_assay)
     assert_redirected_to single_page_path(id: @isa_assay.assay.projects.first, item_type: 'assay', item_id: @isa_assay.assay)
 
@@ -757,11 +757,81 @@ class ISAAssaysControllerTest < ActionController::TestCase
     assert_equal first_assay_sample_type.previous_linked_sample_type, study.sample_types.second
   end
 
+  test 'should auto-populate the sample type title and description' do
+    person = FactoryBot.create(:person)
+    login_as(person)
+    projects = person.projects
+    investigation = FactoryBot.create(:investigation, is_isa_json_compliant: true, contributor: person)
+    study = FactoryBot.create(:isa_json_compliant_study, investigation:, contributor: person)
+    assay_stream = FactoryBot.create(:assay_stream, contributor: person, study:)
+    material_assay_template = FactoryBot.create(:isa_assay_material_template)
+    data_file_assay_template = FactoryBot.create(:isa_assay_data_file_template)
+
+    policy_attributes = { access_type: Policy::ACCESSIBLE,
+                          permissions_attributes: project_permissions([projects.first], Policy::ACCESSIBLE) }
+
+    # Create an assay with material outputs
+    material_assay_sample_type_attributes = create_material_assay_sample_type_attributes(projects.first, study.sample_types.second.id, material_assay_template.id)
+    material_assay_sample_type_attributes.delete(:title)
+
+    material_assay_attributes = { title: 'Material Assay',
+                                  study_id: study.id,
+                                  assay_class_id: AssayClass.experimental.id,
+                                  creator_ids: [person.id],
+                                  policy_attributes:,
+                                  assay_stream_id: assay_stream.id }
+
+    material_isa_assay_attributes = { assay: material_assay_attributes,
+                             input_sample_type_id: study.sample_types.second.id,
+                             sample_type: material_assay_sample_type_attributes }
+
+    assert_difference('Assay.count', 1) do
+      assert_difference('SampleType.count', 1) do
+        post :create, params: { isa_assay: material_isa_assay_attributes }
+      end
+    end
+
+    assert_response :redirect
+    material_isa_assay = assigns(:isa_assay)
+
+    assert_equal material_isa_assay.sample_type.title, "#{material_isa_assay.assay.title} - 'Assay - Material' Sample Type"
+    assert_equal material_isa_assay.sample_type.description, "'Assay - Material' Sample Type linked to Assay '#{material_isa_assay.assay.title}'."
+
+    # Create an assay with data file outputs
+    data_file_assay_sample_type_attributes = create_data_file_assay_sample_type_attributes(projects.first, material_isa_assay.sample_type.id, data_file_assay_template.id)
+    data_file_assay_sample_type_attributes.delete(:title)
+
+    data_file_assay_attributes = { title: 'Material Assay',
+                                  study_id: study.id,
+                                  assay_class_id: AssayClass.experimental.id,
+                                  creator_ids: [person.id],
+                                  policy_attributes:,
+                                  assay_stream_id: assay_stream.id }
+
+    data_file_isa_assay_attributes = { assay: data_file_assay_attributes,
+                             input_sample_type_id: study.sample_types.second.id,
+                             sample_type: data_file_assay_sample_type_attributes }
+
+    assert_difference('Assay.count', 1) do
+      assert_difference('SampleType.count', 1) do
+        post :create, params: { isa_assay: data_file_isa_assay_attributes }
+      end
+    end
+
+    assert_response :redirect
+    data_file_isa_assay = assigns(:isa_assay)
+
+    assert_equal data_file_isa_assay.sample_type.title, "#{data_file_isa_assay.assay.title} - 'Assay - Data file' Sample Type"
+    assert_equal data_file_isa_assay.sample_type.description, "'Assay - Data file' Sample Type linked to Assay '#{data_file_isa_assay.assay.title}'."
+
+  end
+
   private
 
-  def material_assay_sample_type_attributes(project, linked_sample_type_id='self')
-    { title: "Intermediate Assay Sample type 1",
+  def create_material_assay_sample_type_attributes(project, linked_sample_type_id='self', parent_template_id=nil, counter=1)
+    { title: "Intermediate Assay Sample type #{counter}",
       project_ids: [project.id],
+      template_id: parent_template_id,
       sample_attributes_attributes: {
         '0': {
           pos: '1', title: 'a string', required: '1', is_title: '1',
@@ -787,4 +857,35 @@ class ISAAssaysControllerTest < ActionController::TestCase
       }
     }
   end
+
+  def create_data_file_assay_sample_type_attributes(project, linked_sample_type_id='self', parent_template_id=nil, counter=1)
+    { title: "Data File Assay Sample type #{counter}",
+      project_ids: [project.id],
+      template_id: parent_template_id,
+      sample_attributes_attributes: {
+        '0': {
+          pos: '1', title: 'Data File name', required: '1', is_title: '1',
+          sample_attribute_type_id: FactoryBot.create(:string_sample_attribute_type).id, _destroy: '0',
+          isa_tag_id: FactoryBot.create(:data_file_isa_tag).id
+        },
+        '1': {
+          pos: '2', title: 'Protocol', required: '1', is_title: '0',
+          sample_attribute_type_id: FactoryBot.create(:string_sample_attribute_type).id,
+          isa_tag_id: FactoryBot.create(:protocol_isa_tag).id, _destroy: '0'
+        },
+        '2': {
+          pos: '3', title: 'Input sample', required: '1',
+          sample_attribute_type_id: FactoryBot.create(:sample_multi_sample_attribute_type).id,
+          linked_sample_type_id: linked_sample_type_id, _destroy: '0'
+        },
+        '3': {
+          pos: '4', title: 'Some Data File comment', required: '1',
+          sample_attribute_type_id: FactoryBot.create(:string_sample_attribute_type).id,
+          _destroy: '0',
+          isa_tag_id: FactoryBot.create(:data_file_comment_isa_tag).id
+        }
+      }
+    }
+  end
+
 end


### PR DESCRIPTION
- Automatically populates the sample type's title and description if not provided. Implemented for Sample types linked to ISA-studies and ISA-assays.
- Resolves #2240 