### PR TITLE
Fix deleted avatar crash

### DIFF
--- a/app/helpers/avatars_helper.rb
+++ b/app/helpers/avatars_helper.rb
@@ -34,10 +34,14 @@ module AvatarsHelper
 
   def avatar_according_to_user_upload(alternative, item, size, css_class = 'framed')
     if item.avatar_selected?
-      image_tag avatar_url(item, item.avatar, size), alt: alternative, class: css_class
-    else
-      default_avatar(item.class.name, size, alternative, '', css_class)
+      if item.avatars.include?(item.avatar)
+        return image_tag avatar_url(item, item.avatar, size), alt: alternative, class: css_class
+      else
+        raise 'Avatar does not belong to instance' unless Rails.env.production?
+      end
     end
+
+    default_avatar(item.class.name, size, alternative, '', css_class)
   end
 
   def avatar_alternative_and_tooltip_text(alt, show_tooltip, title)
@@ -53,11 +57,7 @@ module AvatarsHelper
   def avatar_url(owner, avatar, size = nil)
     #serve_from_public = Rails.configuration.assets.enabled
     if Rails.env.production?
-      if owner.avatars.include?(avatar)
-        avatar.public_asset_url(size)
-      else
-        raise 'Avatar does not belong to instance'
-      end
+      avatar.public_asset_url(size)
     else
       basic_url = polymorphic_path([owner, avatar])
       append_size_parameter(basic_url, size)

--- a/app/models/avatar.rb
+++ b/app/models/avatar.rb
@@ -21,29 +21,14 @@ class Avatar < ApplicationRecord
   belongs_to :owner,
              polymorphic: true
 
-  has_many :people,
-           foreign_key: :avatar_id,
-           dependent: :nullify
-
-  has_many :projects,
-           foreign_key: :avatar_id,
-           dependent: :nullify
-
-  has_many :institutions,
-           foreign_key: :avatar_id,
-           dependent: :nullify
-
-  has_many :programmes,
-           foreign_key: :avatar_id,
-           dependent: :nullify
-
   after_create :select_avatar
+  after_destroy_commit :nullify_foreign_key
 
   def select!
     if selected?
       false
     else
-      owner.update_attribute :avatar_id, id
+      owner.update_attribute(:avatar_id, id)
       true
     end
   end
@@ -80,5 +65,9 @@ class Avatar < ApplicationRecord
 
   def select_avatar
     select! unless owner.nil? || owner.avatar_selected?
+  end
+
+  def nullify_foreign_key
+    owner.update_column(:avatar_id, nil) if owner&.persisted?
   end
 end

--- a/app/models/avatar.rb
+++ b/app/models/avatar.rb
@@ -22,7 +22,7 @@ class Avatar < ApplicationRecord
              polymorphic: true
 
   after_create :select_avatar
-  after_destroy_commit :nullify_foreign_key
+  after_destroy_commit :deselect_avatar
 
   def select!
     if selected?
@@ -67,7 +67,7 @@ class Avatar < ApplicationRecord
     select! unless owner.nil? || owner.avatar_selected?
   end
 
-  def nullify_foreign_key
+  def deselect_avatar
     owner.update_column(:avatar_id, nil) if owner&.persisted?
   end
 end

--- a/app/models/concerns/has_custom_avatar.rb
+++ b/app/models/concerns/has_custom_avatar.rb
@@ -10,7 +10,7 @@ module HasCustomAvatar
   # "false" returned by this helper method won't mean that no avatars are uploaded for this yellow page model;
   # it rather means that no avatar (other than default placeholder) was selected for the yellow page model
   def avatar_selected?
-    !avatar_id.nil?
+    avatar.present?
   end
 
   def defines_own_avatar?

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -16,6 +16,12 @@ FactoryBot.define do
       end
     end
   end
+
+  trait :with_avatar do
+    after(:create) do |resource|
+      resource.avatars = [FactoryBot.create(:avatar, owner: resource)]
+    end
+  end
 end
 
 FactoryBot.class_eval do

--- a/test/factories/workflows.rb
+++ b/test/factories/workflows.rb
@@ -55,7 +55,7 @@ FactoryBot.define do
   
   factory(:user_added_workflow_class_with_logo, class: WorkflowClass) do
     sequence(:title) { |n| "User-added Type with Logo #{n}" }
-    avatar
+    with_avatar
     contributor { FactoryBot.create(:person) }
   end
   

--- a/test/functional/collections_controller_test.rb
+++ b/test/functional/collections_controller_test.rb
@@ -518,17 +518,14 @@ class CollectionsControllerTest < ActionController::TestCase
 
   test 'can get index featuring collection with avatar' do
     Collection.delete_all
-    collection = FactoryBot.create(:public_collection)
-    disable_authorization_checks do
-      FactoryBot.build(:avatar, owner: collection).save!
-    end
+    collection = FactoryBot.create(:public_collection, :with_avatar)
     avatar = collection.reload.avatar
     assert avatar
 
     get :index
 
     assert_response :success
-    assert_select 'img[src=?]', avatar.public_asset_url(60)
+    assert_select 'img[src=?]', Seek::Util.routes.polymorphic_path([collection, avatar], size: '60x60')
   end
 
   test 'can get index featuring collection with missing avatar' do

--- a/test/functional/collections_controller_test.rb
+++ b/test/functional/collections_controller_test.rb
@@ -516,6 +516,33 @@ class CollectionsControllerTest < ActionController::TestCase
     end
   end
 
+  test 'can get index featuring collection with avatar' do
+    Collection.delete_all
+    collection = FactoryBot.create(:public_collection)
+    disable_authorization_checks do
+      FactoryBot.build(:avatar, owner: collection).save!
+    end
+    avatar = collection.reload.avatar
+    assert avatar
+
+    get :index
+
+    assert_response :success
+    assert_select 'img[src=?]', avatar.public_asset_url(60)
+  end
+
+  test 'can get index featuring collection with missing avatar' do
+    Collection.delete_all
+    collection = FactoryBot.create(:public_collection, avatar_id: (Avatar.maximum(:id) || 0) + 10)
+    assert collection.reload.avatar_id
+    refute collection.avatar
+
+    get :index
+
+    assert_response :success
+    assert_select 'img[src=?]', '/assets/avatars/avatar-collection.png'
+  end
+
   private
 
   def valid_collection

--- a/test/unit/collection_test.rb
+++ b/test/unit/collection_test.rb
@@ -196,10 +196,7 @@ class CollectionTest < ActiveSupport::TestCase
   end
 
   test 'selected avatar id is nullified when avatar deleted' do
-    collection = FactoryBot.create(:public_collection)
-    disable_authorization_checks do
-      FactoryBot.build(:avatar, owner: collection).save!
-    end
+    collection = FactoryBot.create(:public_collection, :with_avatar)
     avatar = collection.reload.avatar
     assert avatar
     assert collection.avatar_selected?

--- a/test/unit/collection_test.rb
+++ b/test/unit/collection_test.rb
@@ -194,4 +194,44 @@ class CollectionTest < ActiveSupport::TestCase
       assert_includes collection.reload.assets, asset
     end
   end
+
+  test 'selected avatar id is nullified when avatar deleted' do
+    collection = FactoryBot.create(:public_collection)
+    disable_authorization_checks do
+      FactoryBot.build(:avatar, owner: collection).save!
+    end
+    avatar = collection.reload.avatar
+    assert avatar
+    assert collection.avatar_selected?
+
+    assert_difference('Avatar.count', -1) do
+      avatar.destroy!
+    end
+
+    assert_nil collection.reload.avatar_id
+    assert_nil collection.avatar
+    refute collection.avatar_selected?
+  end
+
+  test 'avatars cleaned up when collection destroyed' do
+    collection = FactoryBot.create(:public_collection)
+    a1 = a2 = nil
+    disable_authorization_checks do
+      a1 = FactoryBot.create(:avatar, owner: collection)
+      a2 = FactoryBot.create(:avatar, owner: collection)
+    end
+    avatar = collection.reload.avatar
+    assert_equal a1, avatar
+    assert collection.avatar_selected?
+
+    assert_difference('Collection.count', -1) do
+      assert_difference('Avatar.count', -2) do
+        disable_authorization_checks { collection.destroy! }
+      end
+    end
+
+    refute Collection.exists?(collection.id)
+    refute Avatar.exists?(a1.id)
+    refute Avatar.exists?(a2.id)
+  end
 end

--- a/test/unit/helpers/avatar_helper_test.rb
+++ b/test/unit/helpers/avatar_helper_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class AvatarHelperTest < ActionView::TestCase
+  include ImagesHelper
+  include AvatarsHelper
+
+  test 'renders default avatar if no avatar selected' do
+    collection = FactoryBot.create(:public_collection)
+    refute collection.avatar
+
+    assert_equal '/images/avatars/avatar-collection.png',
+                 img_src(avatar_according_to_user_upload('...', collection, 60))
+  end
+
+  test 'renders selected avatar if avatar selected' do
+    collection = FactoryBot.create(:public_collection)
+    disable_authorization_checks do
+      FactoryBot.build(:avatar, owner: collection).save!
+    end
+    assert collection.reload.avatar
+
+    assert_equal "/collections/#{collection.id}/avatars/#{collection.avatar.id}?size=60x60",
+                 img_src(avatar_according_to_user_upload('...', collection, 60))
+  end
+
+  test 'renders default avatar if avatar from another item selected' do
+    collection = FactoryBot.create(:public_collection)
+    person = collection.contributor
+    disable_authorization_checks do
+      FactoryBot.build(:avatar, owner: person).save!
+    end
+    assert person.reload.avatar
+    collection.update_column(:avatar_id, person.avatar_id)
+    assert_equal person.avatar, collection.reload.avatar
+
+    # Only raises in dev/test - will show default avatar in production.
+    assert_raises(RuntimeError, 'Avatar does not belong to instance') do
+      assert_equal '/images/avatars/avatar-collection.png',
+                   img_src(avatar_according_to_user_upload('...', collection, 60))
+    end
+  end
+
+  def img_src(tag)
+    tag.match(/src="([^"]+)"/)&.captures&.first
+  end
+end

--- a/test/unit/helpers/avatar_helper_test.rb
+++ b/test/unit/helpers/avatar_helper_test.rb
@@ -13,23 +13,17 @@ class AvatarHelperTest < ActionView::TestCase
   end
 
   test 'renders selected avatar if avatar selected' do
-    collection = FactoryBot.create(:public_collection)
-    disable_authorization_checks do
-      FactoryBot.build(:avatar, owner: collection).save!
-    end
-    assert collection.reload.avatar
+    collection = FactoryBot.create(:public_collection, :with_avatar)
+    assert collection.avatar
 
     assert_equal "/collections/#{collection.id}/avatars/#{collection.avatar.id}?size=60x60",
                  img_src(avatar_according_to_user_upload('...', collection, 60))
   end
 
   test 'renders default avatar if avatar from another item selected' do
-    collection = FactoryBot.create(:public_collection)
-    person = collection.contributor
-    disable_authorization_checks do
-      FactoryBot.build(:avatar, owner: person).save!
-    end
-    assert person.reload.avatar
+    person = FactoryBot.create(:person, :with_avatar)
+    collection = FactoryBot.create(:public_collection, contributor: person)
+    assert person.avatar
     collection.update_column(:avatar_id, person.avatar_id)
     assert_equal person.avatar, collection.reload.avatar
 

--- a/test/unit/person_test.rb
+++ b/test/unit/person_test.rb
@@ -1414,4 +1414,22 @@ class PersonTest < ActiveSupport::TestCase
     assert_equal [project, project2, project3], person.projects.sort_by(&:id)
     assert_equal [project,project2], person.administered_projects.sort_by(&:id)
   end
+
+  test 'selected avatar id is nullified when avatar deleted' do
+    person = FactoryBot.create(:person)
+    disable_authorization_checks do
+      FactoryBot.build(:avatar, owner: person).save!
+    end
+    avatar = person.reload.avatar
+    assert avatar
+    assert person.avatar_selected?
+
+    assert_difference('Avatar.count', -1) do
+      avatar.destroy!
+    end
+
+    assert_nil person.reload.avatar_id
+    assert_nil person.avatar
+    refute person.avatar_selected?
+  end
 end


### PR DESCRIPTION
- Return default avatar instead of raising exception if selected avatar does not belong to the model
- Ensure deleted avatar is deselected on `owner`, regardless of the type