### PR TITLE
Place observation unit in the asset order after study

### DIFF
--- a/config/initializers/seek_main.rb
+++ b/config/initializers/seek_main.rb
@@ -20,7 +20,7 @@ Rails.configuration.after_initialize do
 
 
   SEEK::Application.configure do
-    ASSET_ORDER = ['Person', 'Programme', 'Project', 'Institution', 'Investigation', 'Study', 'Assay', 'Strain', 'DataFile', 'Model', 'Sop', 'Publication', 'Presentation','SavedSearch', 'Organism', 'HumanDisease', 'Event']
+    ASSET_ORDER = ['Person', 'Programme', 'Project', 'Institution', 'Investigation', 'Study', 'ObservationUnit', 'Assay', 'Strain', 'DataFile', 'Model', 'Sop', 'Publication', 'Presentation','SavedSearch', 'Organism', 'HumanDisease', 'Event']
 
     begin
       Seek::Config.propagate_all


### PR DESCRIPTION
Just an ordering for the asset overview so that observation unit is now in the list as it was missing making it appear after study.