### PR TITLE
Reset tooltips on every draw of the dynamic table

### DIFF
--- a/app/assets/javascripts/single_page/dynamic_table.js.erb
+++ b/app/assets/javascripts/single_page/dynamic_table.js.erb
@@ -248,9 +248,10 @@ const handleSelect = (e) => {
           },
           draw () {
             ObjectsInput.init();
-            
-            $j('[data-toggle="tooltip"]').tooltip('destroy');
-            $j('[data-toggle="tooltip"]').tooltip({
+
+            const tooltips = $j('[data-toggle="tooltip"]')
+            tooltips.tooltip('destroy');
+            tooltips.tooltip({
               container: 'body',
               placement: 'top'
             });

--- a/app/assets/javascripts/single_page/dynamic_table.js.erb
+++ b/app/assets/javascripts/single_page/dynamic_table.js.erb
@@ -248,6 +248,12 @@ const handleSelect = (e) => {
           },
           draw () {
             ObjectsInput.init();
+            
+            $j('[data-toggle="tooltip"]').tooltip('destroy');
+            $j('[data-toggle="tooltip"]').tooltip({
+              container: 'body',
+              placement: 'top'
+            });
           },
         },
         ajax: options.ajax
@@ -294,11 +300,8 @@ const handleSelect = (e) => {
           }
           $j(x)
             .attr("title", columns[i].description)
-            .attr("data-toggle", "tooltip")
-            .attr("data-placement", "top")
-            .attr("data-container", "body");
+            .attr("data-toggle", "tooltip");
         });
-      $j('[data-toggle="tooltip"]').tooltip();
       highlightTitleCol(this.table);
     },
     pasteFromClipboard: function () {


### PR DESCRIPTION
Tooltip id restored when hovering the header cell in the dynamic table.
<img width="784" height="202" alt="image" src="https://github.com/user-attachments/assets/98cbadee-6bb3-4b47-9309-604f12d8dfdd" />

Closes #2324 