### PR TITLE
RO-Crate spec adherence fixes

### DIFF
--- a/app/models/concerns/workflow_extraction.rb
+++ b/app/models/concerns/workflow_extraction.rb
@@ -133,6 +133,8 @@ module WorkflowExtraction
       remotes.each do |path, url|
         crate.add_external_file(url)
       end
+
+      crate['datePublished'] = git_version.commit_object&.time
     else
       unless crate.main_workflow
         crate.main_workflow = ROCrate::Workflow.new(crate, content_blob.filepath, content_blob.original_filename, contentSize: content_blob.file_size)
@@ -156,6 +158,7 @@ module WorkflowExtraction
     merge_entities(crate, self)
 
     crate['isBasedOn'] = source_link_url if source_link_url && !crate['isBasedOn']
+    crate['datePublished'] = Time.now unless crate['datePublished']
     crate['sdDatePublished'] = Time.now unless crate['sdDatePublished']
     crate['creativeWorkStatus'] = I18n.t("maturity_level.#{maturity_level}") if maturity_level
 

--- a/lib/overrides/ro_crate/workflow_crate.rb
+++ b/lib/overrides/ro_crate/workflow_crate.rb
@@ -11,13 +11,13 @@ module ROCrate
     properties(%w[mainEntity mentions about])
 
     def initialize(*args)
-      super.tap do
-        conforms = self['conformsTo']
-        if conforms.is_a?(Array)
-          self['conformsTo'] << PROFILE_REF
-        else
-          self['conformsTo'] = [{ '@id' => ::ROCrate::Metadata::SPEC }, PROFILE_REF]
-        end
+      super
+
+      conforms = metadata['conformsTo']
+      if conforms.is_a?(Array)
+        metadata['conformsTo'] << PROFILE_REF
+      else
+        metadata['conformsTo'] = [{ '@id' => ::ROCrate::Metadata::SPEC }, PROFILE_REF]
       end
     end
 

--- a/test/integration/workflow_versioning_test.rb
+++ b/test/integration/workflow_versioning_test.rb
@@ -141,7 +141,7 @@ class WorkflowVersioningTest < ActionDispatch::IntegrationTest
 
     assert_equal 2, workflow.reload.versions.count
     assert_equal 732, workflow.find_version(1).content_blob.file_size
-    assert_equal 12271, workflow.find_version(2).content_blob.file_size
+    assert_equal 12263, workflow.find_version(2).content_blob.file_size
   end
 
   test 'new workflow version upload copes with workflow class change' do

--- a/test/unit/ro_crate/workflow_crate_test.rb
+++ b/test/unit/ro_crate/workflow_crate_test.rb
@@ -4,7 +4,7 @@ class WorkflowCrateTest < ActiveSupport::TestCase
   test 'conformsTo' do
     crate = ROCrate::WorkflowCrate.new
 
-    ids = crate['conformsTo'].map { |x| x['@id'] }
+    ids = crate.metadata['conformsTo'].map { |x| x['@id'] }
     assert_includes ids, 'https://w3id.org/ro/crate/1.1'
     assert_includes ids, 'https://w3id.org/workflowhub/workflow-ro-crate/1.0'
   end

--- a/test/unit/workflow_test.rb
+++ b/test/unit/workflow_test.rb
@@ -970,4 +970,15 @@ class WorkflowTest < ActiveSupport::TestCase
 
     assert_equal ['Physics and Astronomy'], workflow.reload.discipline_annotation_labels
   end
+
+  test 'sets datePublished in RO-Crate metadata' do
+    time = Time.zone.local(2024, 9, 15, 12, 0, 0)
+    travel_to(time) do
+      assert_equal time, FactoryBot.create(:cwl_workflow).ro_crate['datePublished'],
+                   'Should set datePublished to current time'
+    end
+
+    assert_equal '2021-03-31 15:01:47 UTC', FactoryBot.create(:remote_git_workflow).ro_crate['datePublished'].utc.to_s,
+                 'Should set datePublished to time of git commit'
+  end
 end


### PR DESCRIPTION
- Ensure they have `datePublished` (uses date of latest commit or current time)
- Put `conformsTo` on metadata entity instead of root entity.

Fixes #2013