### PR TITLE
use a select2 tokenSeparator to handle commas when typing or pasting a comma separated list of authors

### DIFF
--- a/app/assets/javascripts/objects_input.js
+++ b/app/assets/javascripts/objects_input.js
@@ -35,6 +35,10 @@ var ObjectsInput = {
                 opts.data = $j(this).data('typeahead-local-values');
             }
 
+            if ($j(this).data('token-separators')) {
+                opts.tokenSeparators = $j(this).data('token-separators');
+            }
+
             const template = $j(this).data('typeahead-template') || 'typeahead/hint';
             opts.templateResult = HandlebarsTemplates[template];
             opts.escapeMarkup = ObjectsInput.doNothing;

--- a/app/helpers/bootstrap_helper.rb
+++ b/app/helpers/bootstrap_helper.rb
@@ -127,6 +127,7 @@ module BootstrapHelper
     options['data-allow-new-items'] = options.delete(:allow_new) if options[:allow_new]
     options['data-placeholder'] = options.delete(:placeholder) if options[:placeholder]
     options['data-allow-clear'] = options.delete(:allow_clear) if options[:allow_clear]
+    options['data-token-separators'] = options.delete(:token_separators) if options[:token_separators]
     options[:include_blank] = ''
     options[:multiple] = true unless options.key?(:multiple)
     options[:name] = "#{element_name}#{options[:multiple] ? '[]': ''}" unless options.key?(:name)

--- a/app/helpers/publications_helper.rb
+++ b/app/helpers/publications_helper.rb
@@ -58,6 +58,7 @@ module PublicationsHelper
       typeahead: typeahead,
       limit: limit,
       allow_new: allow_new,
+      token_separators: [','],
       class: 'form-control',
       'data-role': 'seek-objectsinput'
     }


### PR DESCRIPTION
Adds the option to define the `tokenSeparators` for select2 as a new option. ( see https://select2.org/tagging#automatic-tokenization-into-tags )

Helpful when copying and pasting in a list of comma separated authors from a citation, it automatically creates individual tags for each author, instead of one tag. Also allows a comma to be typed to close a tag.

* updates #2330