### PR TITLE
Disable VCR auto-recording behaviour when running tests in CI

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -273,6 +273,9 @@ VCR.configure do |config|
   config.ignore_request do |request|
     request.uri =~ /sparql-auth/
   end
+
+  # Disable VCR recording when running in CI to detect missing cassettes and avoid making live requests.
+  config.default_cassette_options = { record: ENV['CI'] ? :none : :once }
 end
 
 WebMock.disable_net_connect!(allow_localhost: true) # Need to comment this line out when running VCRs for the first time


### PR DESCRIPTION
Will now fail as demonstrated here:
https://github.com/seek4science/seek/commit/0fe863c51468b1414522ec75e8995fec884e2479

https://github.com/seek4science/seek/actions/runs/19473969781/job/55728734198