### PR TITLE
Fix wrong variable passed when notifying of DOI exception

### DIFF
--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -471,7 +471,7 @@ end
         @error = 'The DOI resolved to an unsupported resource type.'
       rescue RuntimeError => e
         @error = 'There was a problem contacting the DOI query service. Please add the publication manually instead.'
-        Seek::Errors::ExceptionForwarder.send_notification(exception, data: {message: "Problem fetching DOI #{doi} : #{e.message}"})
+        Seek::Errors::ExceptionForwarder.send_notification(e, data: {message: "Problem fetching DOI #{doi} : #{e.message}"})
       end
     else
       @error = 'Please enter either a DOI or a PubMed ID for the publication.'


### PR DESCRIPTION
Tiny fix, but prevents a new method missing exception being thrown instead of reporting the exception raised.