### PR TITLE
change the tests to use mysql 8.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
       mysql:
-        image: mysql:5.7
+        image: mysql:8.4
         env:
           MYSQL_USER: seek
           MYSQL_PASSWORD: test


### PR DESCRIPTION
I noticed whilst doing something else that it was still on 5.7. 8.4 seems more appropriate since this is what we are targetting