### PR TITLE
Fix handling punctuation in search indexing and queries

### DIFF
--- a/solr/seek/conf/schema.xml
+++ b/solr/seek/conf/schema.xml
@@ -63,11 +63,27 @@
       <analyzer type="index">
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
         <filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true" />
+        <filter class="solr.WordDelimiterGraphFilterFactory"
+                generateWordParts="1"
+                generateNumberParts="1"
+                catenateWords="1"
+                catenateNumbers="1"
+                catenateAll="1"
+                preserveOriginal="1"
+                splitOnCaseChange="0"/>
         <filter class="solr.LowerCaseFilterFactory"/>        
         <filter class="solr.EdgeNGramFilterFactory" minGramSize="2" maxGramSize="50"/>
       </analyzer>
       <analyzer type="query">
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <filter class="solr.WordDelimiterGraphFilterFactory"
+                generateWordParts="1"
+                generateNumberParts="1"
+                catenateWords="1"
+                catenateNumbers="1"
+                catenateAll="1"
+                preserveOriginal="1"
+                splitOnCaseChange="0"/>
         <filter class="solr.LowerCaseFilterFactory"/>        
       </analyzer>
     </fieldType>


### PR DESCRIPTION
introduce WordDelimiterGraphFilterFactory to the search schema, to handle punctuated terms #2485

the filter will create tokens with the punctuation stripped out (i.e concatenated, not treated as a white space delimeter), which preserving the original form

* fix for #2485 and #1823

examples:
https://testing.sysmo-db.org/samples?filter%5Bquery%5D=smith-jones
https://testing.sysmo-db.org/samples?filter%5Bquery%5D=smith%20jones
https://testing.sysmo-db.org/samples?filter%5Bquery%5D=jones
https://testing.sysmo-db.org/samples?filter%5Bquery%5D=upc
https://testing.sysmo-db.org/samples?filter%5Bquery%5D=(upc
https://testing.sysmo-db.org/samples?filter%5Bquery%5D=InChI=1S/C2H6O/c1-2-3/h3H,2H2,1H3

( there is a related PR at https://github.com/FAIRdom/solr-seek-docker/pull/4 - but is exactly the same, so approving this approves both)