### PR TITLE
2249 spreadsheet name is too generic and confusing

### DIFF
--- a/app/controllers/single_pages_controller.rb
+++ b/app/controllers/single_pages_controller.rb
@@ -78,11 +78,11 @@ class SinglePagesController < ApplicationController
               "#{@assay&.id} - #{@assay&.title} table.xlsx"
             else
               @sample_type.title&.concat(".xlsx")
-            end.sanitize
+            end
 
     notice_message << '</ul>'
     flash[:notice] = notice_message.html_safe
-    render xlsx: 'download_samples_excel', filename: spreadsheet_name, disposition: 'inline'
+    render xlsx: 'download_samples_excel', filename: helpers.sanitized_text(spreadsheet_name), disposition: 'inline'
   rescue StandardError => e
     flash[:error] = e.message
     respond_to do |format|

--- a/test/functional/single_pages_controller_test.rb
+++ b/test/functional/single_pages_controller_test.rb
@@ -491,7 +491,7 @@ class SinglePagesControllerTest < ActionController::TestCase
       :id_label, :person, :project, :study, :source_sample_type, :sources
     )
 
-    study.update_column(:title, '<script>alert("This should be removed!")</script>My sample type')
+    study.update_column(:title, '<script>alert("Script tags should be removed!")</script> My sample type')
 
     source_ids = sources.map { |s| { id_label => s.id } }
     sample_type_id = source_sample_type.id
@@ -516,7 +516,10 @@ class SinglePagesControllerTest < ActionController::TestCase
     get :download_samples_excel, params: { uuid: cache_uuid }
     response_cd = response.headers["Content-Disposition"]
     assert_response :ok
-    assert response_cd.include?("filename=\"#{study.id} - My sample type sources table.xlsx\"")
+    expected_file_name = "My sample type sources table.xlsx"
+    assert response_cd.include?(expected_file_name)
+    assert %w[<script> </script>].none? { |tag| response_cd.include?(tag) }
+
 
   end
 


### PR DESCRIPTION
- Change spreadsheet name to study / assay title instead of the Sample  Type title.
- closes #2249  