### PR TITLE
option to block local file updates

### DIFF
--- a/app/assets/javascripts/templates/upload/remote_file.hbs
+++ b/app/assets/javascripts/templates/upload/remote_file.hbs
@@ -3,7 +3,6 @@
     {{text}}
     <a href="#" class="remove-file"><span class="remove_icon"></span></a>
 
-    <input type="hidden" name="content_blobs[][data]" value=""/>
     <input type="hidden" name="content_blobs[][data_url]" value="{{dataURL}}"/>
     <input type="hidden" name="content_blobs[][make_local_copy]" value="{{makeALocalCopy}}"/>
 </li>

--- a/app/assets/javascripts/upload.js
+++ b/app/assets/javascripts/upload.js
@@ -14,6 +14,10 @@ $j(document).ready(function () {
 
         // Tabs
         var activateTab = function (id) {
+            // only continue if the tab to activate exists
+            if ($j('[data-role="seek-upload-field-tab"][data-tab-target="' + id + '"]').length == 0) {
+                return;
+            }
             $j('[data-role="seek-upload-field-tab"]', field).closest('li').removeClass('active');
             $j('[data-role="seek-upload-field-tab"][data-tab-target="' + id + '"]', field).closest('li').addClass('active');
             $j('[data-role="seek-upload-field-tab-pane"]', field).removeClass('active');

--- a/app/assets/javascripts/upload.js
+++ b/app/assets/javascripts/upload.js
@@ -153,7 +153,7 @@ $j(document).ready(function () {
                 if (lastTestedUrl !== input.val()) { // Prevent double query, 1 from keypress and 1 from text box losing focus.
                     submitUrl();
                 }
-            }, 100);
+            }, 700);
             return true;
         });
 

--- a/app/assets/javascripts/upload.js
+++ b/app/assets/javascripts/upload.js
@@ -15,7 +15,7 @@ $j(document).ready(function () {
         // Tabs
         var activateTab = function (id) {
             // only continue if the tab to activate exists
-            if ($j('[data-role="seek-upload-field-tab"][data-tab-target="' + id + '"]').length == 0) {
+            if ($j('[data-role="seek-upload-field-tab"][data-tab-target="' + id + '"]', field).length === 0) {
                 return;
             }
             $j('[data-role="seek-upload-field-tab"]', field).closest('li').removeClass('active');

--- a/app/assets/javascripts/upload.js
+++ b/app/assets/javascripts/upload.js
@@ -73,6 +73,7 @@ $j(document).ready(function () {
                 filenameInput.val('');
                 $j('[data-role="seek-url-checker-msg-success"]', field).hide();
                 $j('[data-role="seek-url-checker-msg-too-big"]', field).hide();
+                $j('[data-role="seek-url-checker-msg-blocked-uploads"]', field).hide();
                 $j('[role="seek-url-checker-remind-to-add-file"]',field).hide();
                 pending.append(HandlebarsTemplates['upload/remote_file'](remoteFile));
             }
@@ -89,20 +90,22 @@ $j(document).ready(function () {
 
     // Code for checking URL and showing preview
     $j('[data-role="seek-url-checker"]').each(function () {
-        var checker = $j(this);
-        var field = checker.parents('[data-role="seek-upload-field"]');
-        var input = $j('input', checker);
-        var btn = $j('a.btn', checker);
-        var url = checker.data('path');
-        var result = field.find('[data-role="seek-url-checker-result"]');
-        var copyDialog = $j('[data-role="seek-url-checker-msg-success"]', field);
-        var tooBig = $j('[data-role="seek-url-checker-msg-too-big"]', field);
-        var addReminder = $j('[role="seek-url-checker-remind-to-add-file"]',field);
+        const checker = $j(this);
+        const field = checker.parents('[data-role="seek-upload-field"]');
+        const input = $j('input', checker);
+        const btn = $j('a.btn', checker);
+        const url = checker.data('path');
+        const result = field.find('[data-role="seek-url-checker-result"]');
+        const copyDialog = $j('[data-role="seek-url-checker-msg-success"]', field);
+        const tooBigDialog = $j('[data-role="seek-url-checker-msg-too-big"]', field);
+        const blockedUploadsDialog = $j('[data-role="seek-url-checker-msg-blocked-uploads"]', field);
+        const addReminder = $j('[role="seek-url-checker-remind-to-add-file"]',field);
 
         var submitUrl = function () {
             result.html('').spinner('add');
             copyDialog.hide();
-            tooBig.hide();
+            tooBigDialog.hide();
+            blockedUploadsDialog.hide();
             $j.ajax({
                 url: url,
                 method: 'POST',
@@ -118,8 +121,11 @@ $j(document).ready(function () {
                     if (info.allow_copy) {
                         copyDialog.show();
                         addReminder.show();
+                    }
+                    else if (info.blocked_file_uploads) {
+                        blockedUploadsDialog.show();
                     } else {
-                        tooBig.show();
+                        tooBigDialog.show();
                     }
                 }
                 lastTestedUrl = input.val();

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -601,6 +601,11 @@ span.required, label.required::after {
   margin: 0.5em 1em;
 }
 
+.remote-content-preview-result img.preview {
+    max-width: 30em;
+    max-height: 30em;
+}
+
 li.upload-field-tab {
   cursor: pointer;
 }

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -338,6 +338,7 @@ class AdminController < ApplicationController
     Seek::Config.auth_lookup_update_batch_size = params[:auth_lookup_update_batch_size]
 
     Seek::Config.allow_private_address_access = string_to_boolean params[:allow_private_address_access]
+    Seek::Config.block_file_uploads = string_to_boolean params[:block_file_uploads]
     Seek::Config.cache_remote_files = string_to_boolean params[:cache_remote_files]
     Seek::Config.max_cachable_size = params[:max_cachable_size]
     Seek::Config.hard_max_cachable_size = params[:hard_max_cachable_size]

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -338,6 +338,7 @@ class AdminController < ApplicationController
     Seek::Config.auth_lookup_update_batch_size = params[:auth_lookup_update_batch_size]
 
     Seek::Config.allow_private_address_access = string_to_boolean params[:allow_private_address_access]
+    Seek::Config.show_as_external_link_enabled = string_to_boolean params[:show_as_external_link_enabled]
     Seek::Config.block_file_uploads = string_to_boolean params[:block_file_uploads]
     Seek::Config.cache_remote_files = string_to_boolean params[:cache_remote_files]
     Seek::Config.max_cachable_size = params[:max_cachable_size]

--- a/app/controllers/content_blobs_controller.rb
+++ b/app/controllers/content_blobs_controller.rb
@@ -12,6 +12,10 @@ class ContentBlobsController < ApplicationController
   api_actions :show, :update, :download
 
   def update
+    if Seek::Config.block_file_uploads
+      raise Seek::UploadHandling::DataUpload::UploadBlockedException, 'Data upload is not allowed.'
+    end
+
     if @content_blob.no_content?
       @content_blob.tmp_io_object = get_request_payload
       @content_blob.save
@@ -235,6 +239,12 @@ class ContentBlobsController < ApplicationController
       params.values.detect { |v| v.is_a?(ActionDispatch::Http::UploadedFile) }
     else
       request.body
+    end
+  end
+  # overrides from DataUpload module
+  def handle_upload_blocked_exception(exception)
+    respond_to do |format|
+      format.all { render plain: exception.message, status: :forbidden }
     end
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -391,14 +391,14 @@ class ProjectsController < ApplicationController
 
     unless file.has_key?('dmp')
       flash[:error] = 'Invalid file format, missing top-level "dmp" tag'
-      redirect_back fallback_location: import_projects_path
+      redirect_back fallback_location: guided_import_projects_path
       return
     end
     dmp = file['dmp']
 
     unless dmp.has_key?('project')
       flash[:error] = 'Invalid file format, missing project properties'
-      redirect_back fallback_location: import_projects_path
+      redirect_back fallback_location: guided_import_projects_path
       return
     end
     project_data = dmp['project'][0]

--- a/app/controllers/sample_types_controller.rb
+++ b/app/controllers/sample_types_controller.rb
@@ -227,7 +227,7 @@ class SampleTypesController < ApplicationController
     build_sample_type
     @sample_type.uploaded_template = true
 
-    handle_upload_data
+    handle_upload_data(false, true)
     @sample_type.content_blob.save! # Need's to be saved so the spreadsheet can be read from disk
     @sample_type.build_attributes_from_template
   end

--- a/app/helpers/assets_helper.rb
+++ b/app/helpers/assets_helper.rb
@@ -370,4 +370,16 @@ module AssetsHelper
     tooltip_txt = "#{item_type.humanize}: \"#{item.title}\"#{by_text}"
     list_item_with_icon(item_type.underscore, item, item.title, truncate_to, tooltip_txt, 34)
   end
+
+  def upload_box_text(asset_name, action_text, hide_remote, hide_local)
+    raise 'cannot hide both remote and local options' if hide_remote && hide_local
+    action_text ||= "register #{asset_name.indefinite_article} #{asset_name}"
+    if hide_remote
+      "You can #{action_text} by selecting a file."
+    elsif hide_local
+      "You can register #{asset_name.indefinite_article} #{asset_name} by registering a URL to a remote file or web page."
+    else
+      "You can register #{asset_name.indefinite_article} #{asset_name} by either directly uploading a file#{' or zipped folder' if asset_name == 'Data file'}, or registering a URL to a remote file or web page."
+    end
+  end
 end

--- a/app/helpers/assets_helper.rb
+++ b/app/helpers/assets_helper.rb
@@ -372,9 +372,10 @@ module AssetsHelper
   end
 
   def upload_box_text(asset_name, action_text, hide_remote, hide_local)
-    raise 'cannot hide both remote and local options' if hide_remote && hide_local
-    action_text ||= "register #{asset_name.indefinite_article} #{asset_name}"
-    if hide_remote
+    if hide_remote && hide_local
+      'Both uploading a file or registering a URL to a remote file or web page are currently unavailable.'
+    elsif hide_remote
+      action_text ||= "register #{asset_name.indefinite_article} #{asset_name}"
       "You can #{action_text} by selecting a file."
     elsif hide_local
       "You can register #{asset_name.indefinite_article} #{asset_name} by registering a URL to a remote file or web page."

--- a/app/helpers/studies_helper.rb
+++ b/app/helpers/studies_helper.rb
@@ -24,6 +24,8 @@ module StudiesHelper
   end
 
   def show_batch_miappe_button?
+    return false if Seek::Config.block_file_uploads
+
     ExtendedMetadataType.where(supported_type: 'Study', title: ExtendedMetadataType::MIAPPE_TITLE, enabled: true).any?
   end
 

--- a/app/models/content_blob.rb
+++ b/app/models/content_blob.rb
@@ -56,6 +56,8 @@ class ContentBlob < ApplicationRecord
 
   acts_as_fleximage_extension
 
+  has_task :remote_content_fetch
+
   # This overrides the method from acts_as_fleximage so that the original image is read from the default SEEK filestore
   #  rather than the special `image_directory` specified above. Resized images will still go in there, though.
   def file_path
@@ -177,10 +179,10 @@ class ContentBlob < ApplicationRecord
   end
 
   def cachable?
-    Seek::Config.cache_remote_files &&
-      !is_webpage? &&
-      file_size &&
-      file_size < Seek::Config.max_cachable_size
+    return false if Seek::Config.block_file_uploads
+    return false unless Seek::Config.cache_remote_files
+
+    !is_webpage? && file_size && file_size < Seek::Config.max_cachable_size
   end
 
   def search_terms
@@ -247,8 +249,6 @@ class ContentBlob < ApplicationRecord
     self.class.valid_url?(url)
   end
 
-  has_task :remote_content_fetch
-
   def content_path(opts = {})
     opts.reverse_merge!(action: 'download')
     Seek::Util.routes.polymorphic_path([asset, self], opts)
@@ -309,7 +309,10 @@ class ContentBlob < ApplicationRecord
   end
 
   def create_retrieval_job
-    if Seek::Config.cache_remote_files && !file_exists? && !url.blank? && (make_local_copy || cachable?) && remote_content_handler
+    return if Seek::Config.block_file_uploads
+    return unless Seek::Config.cache_remote_files
+
+    if  !file_exists? && !url.blank? && (make_local_copy || cachable?) && remote_content_handler
       RemoteContentFetchingJob.perform_later(self)
     end
   end

--- a/app/views/admin/settings.html.erb
+++ b/app/views/admin/settings.html.erb
@@ -25,6 +25,9 @@
                            'Session store timeout', 'The length of time, in MINUTES, that the server session store is active until it expires. (Requires a restart after changing)') %>
 
   <h2>File handling settings</h2>
+  <%= admin_checkbox_setting(:show_as_external_link_enabled, 1, Seek::Config.show_as_external_link_enabled,
+                             "Always show external links", "Items registered as a URL will always show the external link. When disabled, items are downloaded through SEEK as a proxy.") %>
+
   <%= admin_checkbox_setting(:block_file_uploads, 1, Seek::Config.block_file_uploads,
                              "Prevent file uploads", "If this setting is enabled, SEEK will block the ability to upload files for assets, and registering a URL will only be possible.
                              Caching of remote files will also be prevented, even if enabled.", onchange: toggle_appear_javascript('remote-cache-settings-block', reverse: true)) %>

--- a/app/views/admin/settings.html.erb
+++ b/app/views/admin/settings.html.erb
@@ -23,17 +23,25 @@
 
     <%= admin_text_setting(:session_store_timeout, Seek::Config.session_store_timeout.to_i / 60,
                            'Session store timeout', 'The length of time, in MINUTES, that the server session store is active until it expires. (Requires a restart after changing)') %>
+
+  <h2>File handling settings</h2>
+  <%= admin_checkbox_setting(:block_file_uploads, 1, Seek::Config.block_file_uploads,
+                             "Prevent file uploads", "If this setting is enabled, SEEK will block the ability to upload files for assets, and registering a URL will only be possible.
+                             Caching of remote files will also be prevented, even if enabled.", onchange: toggle_appear_javascript('remote-cache-settings-block', reverse: true)) %>
+  <div id='remote-cache-settings-block' style="<%= show_or_hide_block !Seek::Config.block_file_uploads -%>">
     <%= admin_checkbox_setting(:cache_remote_files, 1, Seek::Config.cache_remote_files,
-                               "Cache remote files", "If this setting is enabled, SEEK will attempt to download remote content from the provided URL and store the content in the filestore.",
-                               onchange: toggle_appear_javascript('cache_remote_block')) %>
-    <div id="cache_remote_block" class="additional_settings" style="<%= show_or_hide_block Seek::Config.cache_remote_files -%>">
-      <%= admin_text_setting(:max_cachable_size, Seek::Config.max_cachable_size,
-                             'Maximum file size', 'The size limit (in bytes) below which SEEK will automatically cache remote files. Remote files larger than this limit will be ignored unless the user explicitly requests.',
-                             :onkeypress => "javascript: return onlyNumbers(event);") %>
-      <%= admin_text_setting(:hard_max_cachable_size, Seek::Config.hard_max_cachable_size,
-                             'Hard maximum file size', 'The hard remote file size limit (in bytes). SEEK will not download files over this size regardless of user preference.',
-                             :onkeypress => "javascript: return onlyNumbers(event);") %>
-    </div>
+                                 "Cache remote files", "If this setting is enabled, SEEK will attempt to download remote content from the provided URL and store the content in the filestore.",
+                                 onchange: toggle_appear_javascript('cache_remote_block')) %>
+      <div id="cache_remote_block" class="additional_settings" style="<%= show_or_hide_block Seek::Config.cache_remote_files -%>">
+        <%= admin_text_setting(:max_cachable_size, Seek::Config.max_cachable_size,
+                               'Maximum file size', 'The size limit (in bytes) below which SEEK will automatically cache remote files. Remote files larger than this limit will be ignored unless the user explicitly requests.',
+                               :onkeypress => "javascript: return onlyNumbers(event);") %>
+        <%= admin_text_setting(:hard_max_cachable_size, Seek::Config.hard_max_cachable_size,
+                               'Hard maximum file size', 'The hard remote file size limit (in bytes). SEEK will not download files over this size regardless of user preference.',
+                               :onkeypress => "javascript: return onlyNumbers(event);") %>
+      </div>
+  </div>
+  <h2>Sandbox settings</h2>
 
     <%= admin_text_setting(:sandbox_instance_url, Seek::Config.sandbox_instance_url,
                            'Sandbox instance URL', "A URL of an instance of SEEK to be used for testing/development. Users will be directed here if they attempt to create a #{t('project')} or #{t('programme')} with a name including \"test\".") %>

--- a/app/views/admin/settings.html.erb
+++ b/app/views/admin/settings.html.erb
@@ -29,8 +29,9 @@
                              "Always show external links", "Items registered as a URL will always show the external link. When disabled, items are downloaded through SEEK as a proxy.") %>
 
   <%= admin_checkbox_setting(:block_file_uploads, 1, Seek::Config.block_file_uploads,
-                             "Prevent file uploads", "If this setting is enabled, SEEK will block the ability to upload files for assets, and registering a URL will only be possible.
-                             Caching of remote files will also be prevented, even if enabled.", onchange: toggle_appear_javascript('remote-cache-settings-block', reverse: true)) %>
+                             "Prevent asset file uploads", "If this setting is enabled, SEEK will block the ability to upload files for assets, and registering a URL will only be possible.
+                             Caching of remote files will also be prevented, even if enabled. The purpose is to enforce a much smaller filestore footprint.
+                             <strong>This only affects the main asset files, other auxiliary files such as avatars, model images, RO-Crates and template files for configuration can still be uploaded. This setting shouldn't be enabled in conjunction with Workflows being enabled</strong>'.", onchange: toggle_appear_javascript('remote-cache-settings-block', reverse: true)) %>
   <div id='remote-cache-settings-block' style="<%= show_or_hide_block !Seek::Config.block_file_uploads -%>">
     <%= admin_checkbox_setting(:cache_remote_files, 1, Seek::Config.cache_remote_files,
                                  "Cache remote files", "If this setting is enabled, SEEK will attempt to download remote content from the provided URL and store the content in the filestore.",

--- a/app/views/assets/_upload.html.erb
+++ b/app/views/assets/_upload.html.erb
@@ -43,7 +43,7 @@
     <% end %>
 
     <% unless hide_remote %>
-      <div role="tabpanel" class="tab-pane" data-role="seek-upload-field-tab-pane" data-tab-id="remote-url">
+      <div role="tabpanel" class="tab-pane <%= hide_local ? 'active' : '' %>" data-role="seek-upload-field-tab-pane" data-tab-id="remote-url">
         <div class="form-group">
           <div class="row">
             <div class="col-sm-8">

--- a/app/views/assets/_upload.html.erb
+++ b/app/views/assets/_upload.html.erb
@@ -106,7 +106,7 @@
             <%= button_link_to 'Add', 'new', '#', 'data-role' => 'seek-upload-field-add-remote' %>
           </div>
           <%= content_tag :script,
-                          existing_objects.map { |o| { text: "#{o.url.blank? ? o.original_filename : o.url} (original)", id: o.id } }.to_json.html_safe,
+                          json_escape(existing_objects.map { |o| { text: "#{o.url.blank? ? o.original_filename : o.url} (original)", id: o.id } }.to_json),
                           type: 'application/json',
                           'data-role' => 'seek-upload-field-existing' %>
         <% end %>

--- a/app/views/assets/_upload.html.erb
+++ b/app/views/assets/_upload.html.erb
@@ -6,6 +6,7 @@
   existing_objects ||= []
   file_field_opts ||= {}
   hide_remote ||= false
+  hide_local ||= false
 
   url_from_params = nil
   original_filename_from_params = nil
@@ -20,86 +21,93 @@
 
 <div role="tabpanel" data-role="seek-upload-field">
   <ul class="nav nav-tabs" role="tablist">
-    <li role="presentation" class="upload-field-tab active">
-      <a data-role="seek-upload-field-tab" data-tab-target="local-file" role="tab" data-toggle="tab">Local file</a>
-    </li>
+    <% unless hide_local %>
+      <li role="presentation" class="upload-field-tab active">
+        <a data-role="seek-upload-field-tab" data-tab-target="local-file" role="tab" data-toggle="tab">Local file</a>
+      </li>
+    <% end %>
     <% unless hide_remote %>
-      <li role="presentation" class="upload-field-tab">
+      <li role="presentation" class="upload-field-tab <%= hide_local ? 'active' : '' %>">
         <a data-role="seek-upload-field-tab" data-tab-target="remote-url" role="tab" data-toggle="tab">Remote URL</a>
       </li>
     <% end %>
   </ul>
 
   <div class="tab-content">
-    <div role="tabpanel" class="tab-pane active" data-role="seek-upload-field-tab-pane" data-tab-id="local-file">
-      <div class="form-group">
-        <%= file_field_tag "#{field_name}[data]", file_field_opts.merge({ "data-batch-upload" => batch, autocomplete: batch ? 'off' : 'on' }) -%>
+    <% unless hide_local %>
+      <div role="tabpanel" class="tab-pane active" data-role="seek-upload-field-tab-pane" data-tab-id="local-file">
+        <div class="form-group">
+          <%= file_field_tag "#{field_name}[data]", file_field_opts.merge({ "data-batch-upload" => batch, autocomplete: batch ? 'off' : 'on' }) -%>
+        </div>
       </div>
-    </div>
+    <% end %>
 
-    <div role="tabpanel" class="tab-pane" data-role="seek-upload-field-tab-pane" data-tab-id="remote-url">
-      <div class="form-group">
-        <div class="row">
-          <div class="col-sm-8">
-            <div class="input-group" data-role="seek-url-checker" data-path="<%= path_for_examine_url -%>">
-              <%= text_field_tag "#{field_name}[data_url]", url_from_params, class: 'form-control' -%>
-              <span class="input-group-btn">
-                <%= button_link_to 'Test', 'test', '#' %>
-              </span>
+    <% unless hide_remote %>
+      <div role="tabpanel" class="tab-pane" data-role="seek-upload-field-tab-pane" data-tab-id="remote-url">
+        <div class="form-group">
+          <div class="row">
+            <div class="col-sm-8">
+              <div class="input-group" data-role="seek-url-checker" data-path="<%= path_for_examine_url -%>">
+                <%= text_field_tag "#{field_name}[data_url]", url_from_params, class: 'form-control' -%>
+                <span class="input-group-btn">
+                  <%= button_link_to 'Test', 'test', '#' %>
+                </span>
+              </div>
             </div>
           </div>
         </div>
-      </div>
 
-      <div data-role="seek-url-checker-result"></div>
+        <div data-role="seek-url-checker-result"></div>
 
-      <%= hidden_field_tag "#{field_name}[original_filename]", original_filename_from_params, 'data-role' => 'seek-upload-field-filename' %>
+        <%= hidden_field_tag "#{field_name}[original_filename]", original_filename_from_params, 'data-role' => 'seek-upload-field-filename' %>
 
-      <div class="alert alert-info" role="alert" style="display: none;" data-role="seek-url-checker-msg-too-big">
-        This file exceeds <%= Seek::Config.instance_name %>'s remote file size limit of
-        <strong><%= number_to_human_size(Seek::Config.hard_max_cachable_size) -%></strong>
-        and so only a link to the file will be stored.
-      </div>
-
-      <div style="display: none;" data-role="seek-url-checker-msg-success">
-        <p>
-          You can either upload this file to <%= Seek::Config.instance_name %> using this URL, or you can register a link to the file.
-        </p>
-
-        <p>
-          By selecting the option below, a copy of the file will be made. This is recommended, and is equivalent to uploading
-          a file from your disk. It also means that should the data behind the URL become unavailable, the data is still
-          available from <%= Seek::Config.instance_name %>.
-          However, you should be sure that the copyright on the file allows you to do this.
-        </p>
-
-        <p>
-          If you do not select the option below <%= Seek::Config.instance_name %> will store only the URL and a copy will not be stored on <%= Seek::Config.instance_name %>. You should do this if the file
-          is large or you always want <%= Seek::Config.instance_name %> to deliver the latest version.
-        </p>
-
-        <div class="checkbox">
-          <label>
-            <%= check_box_tag "#{field_name}[make_local_copy]", "1", false, 'data-role' => 'seek-upload-field-make-copy' %>
-            <strong>Fetch a copy</strong>
-          </label>
+        <div class="alert alert-info" role="alert" style="display: none;" data-role="seek-url-checker-msg-too-big">
+          This file exceeds <%= Seek::Config.instance_name %>'s remote file size limit of
+          <strong><%= number_to_human_size(Seek::Config.hard_max_cachable_size) -%></strong>
+          and so only a link to the file will be stored.
         </div>
-      </div>
 
-      <% if batch %>
-        <div class="form-group">
+        <div style="display: none;" data-role="seek-url-checker-msg-success">
+          <p>
+            You can either upload this file to <%= Seek::Config.instance_name %> using this URL, or you can register a link to the file.
+          </p>
 
-          <div>
-            <div class='alert alert-warning' role='seek-url-checker-remind-to-add-file' style='display:none'>
-              Please click on "<b>Add</b>" button to confirm adding this Remote URL to <%= Seek::Config.instance_name %> !</div></div>
+          <p>
+            By selecting the option below, a copy of the file will be made. This is recommended, and is equivalent to uploading
+            a file from your disk. It also means that should the data behind the URL become unavailable, the data is still
+            available from <%= Seek::Config.instance_name %>.
+            However, you should be sure that the copyright on the file allows you to do this.
+          </p>
+
+          <p>
+            If you do not select the option below <%= Seek::Config.instance_name %> will store only the URL and a copy will not be stored on <%= Seek::Config.instance_name %>. You should do this if the file
+            is large or you always want <%= Seek::Config.instance_name %> to deliver the latest version.
+          </p>
+
+          <div class="checkbox">
+            <label>
+              <%= check_box_tag "#{field_name}[make_local_copy]", "1", false, 'data-role' => 'seek-upload-field-make-copy' %>
+              <strong>Fetch a copy</strong>
+            </label>
+          </div>
+        </div>
+
+        <% if batch %>
+          <div class="form-group">
+
+            <div>
+              <div class='alert alert-warning' role='seek-url-checker-remind-to-add-file' style='display:none'>
+                Please click on "<b>Add</b>" button to confirm adding this Remote URL to <%= Seek::Config.instance_name %> !</div></div>
             <%= button_link_to 'Add', 'new', '#', 'data-role' => 'seek-upload-field-add-remote' %>
-        </div>
-        <%= content_tag :script,
-                        existing_objects.map { |o| { text: "#{o.url.blank? ? o.original_filename : o.url} (original)", id: o.id } }.to_json.html_safe,
-                        type: 'application/json',
-                        'data-role' => 'seek-upload-field-existing' %>
-      <% end %>
-    </div>
+          </div>
+          <%= content_tag :script,
+                          existing_objects.map { |o| { text: "#{o.url.blank? ? o.original_filename : o.url} (original)", id: o.id } }.to_json.html_safe,
+                          type: 'application/json',
+                          'data-role' => 'seek-upload-field-existing' %>
+        <% end %>
+      </div>
+    <% end %>
+
   </div>
 
   <ul data-role="seek-upload-field-pending-files" class="pending-files"></ul>

--- a/app/views/assets/_upload.html.erb
+++ b/app/views/assets/_upload.html.erb
@@ -67,6 +67,10 @@
           and so only a link to the file will be stored.
         </div>
 
+        <div style="display: none;" data-role="seek-url-checker-msg-blocked-uploads">
+          Copies are unavailable as file uploads are disabled, and so only a link to the file will be stored.
+        </div>
+
         <div style="display: none;" data-role="seek-url-checker-msg-success">
           <p>
             You can either upload this file to <%= Seek::Config.instance_name %> using this URL, or you can register a link to the file.
@@ -90,6 +94,7 @@
               <strong>Fetch a copy</strong>
             </label>
           </div>
+
         </div>
 
         <% if batch %>

--- a/app/views/assets/_upload.html.erb
+++ b/app/views/assets/_upload.html.erb
@@ -106,7 +106,7 @@
             <%= button_link_to 'Add', 'new', '#', 'data-role' => 'seek-upload-field-add-remote' %>
           </div>
           <%= content_tag :script,
-                          json_escape(existing_objects.map { |o| { text: "#{o.url.blank? ? o.original_filename : o.url} (original)", id: o.id } }.to_json),
+                          raw(json_escape(existing_objects.map { |o| { text: "#{o.url.blank? ? o.original_filename : o.url} (original)", id: o.id } }.to_json)),
                           type: 'application/json',
                           'data-role' => 'seek-upload-field-existing' %>
         <% end %>

--- a/app/views/assets/_upload_box.html.erb
+++ b/app/views/assets/_upload_box.html.erb
@@ -6,6 +6,7 @@
   action_text ||= "register #{asset_name.indefinite_article} #{asset_name}"
   extra_content ||= nil
   hide_remote ||= false
+  hide_local = Seek::Config.block_file_uploads if hide_local.nil?
 %>
 <%= panel(title, id: id) do %>
   <div>
@@ -21,9 +22,10 @@
   </div>
 
   <% if !resource.nil? && Seek::Util.is_multi_file_asset_type?(resource.class) %>
-    <%= render partial: 'assets/upload', locals: { existing_objects: resource.content_blobs, batch: true, hide_remote: hide_remote } -%>
+    <%= render partial: 'assets/upload', locals: { existing_objects: resource.content_blobs, batch: true,
+                                                   hide_remote: hide_remote, hide_local: hide_local } -%>
   <% else %>
-    <%= render partial: 'assets/upload', locals: { hide_remote: hide_remote } -%>
+    <%= render partial: 'assets/upload', locals: { hide_remote: hide_remote, hide_local: hide_local } -%>
   <% end %>
 
   <%= extra_content if extra_content %>

--- a/app/views/assets/_upload_box.html.erb
+++ b/app/views/assets/_upload_box.html.erb
@@ -11,12 +11,8 @@
 <%= panel(title, id: id) do %>
   <div>
     <p>
-      <% unless hide_remote %>
-        You can register a <%= asset_name -%> by either directly uploading a file<%= ' or zipped folder' if asset_name == 'Data file' %>,
-      	or registering a URL to a remote file or web page.
-      <% else %>
-        You can <%= action_text -%> by selecting a file.
-      <% end %>
+      <%= upload_box_text(asset_name, action_text, hide_remote, hide_local) %>
+
 
     </p>
   </div>

--- a/app/views/assets/_upload_box.html.erb
+++ b/app/views/assets/_upload_box.html.erb
@@ -6,7 +6,7 @@
   action_text ||= "register #{asset_name.indefinite_article} #{asset_name}"
   extra_content ||= nil
   hide_remote ||= false
-  hide_local = Seek::Config.block_file_uploads if hide_local.nil?
+  hide_local = Seek::Config.block_file_uploads unless local_assigns.key?(:hide_local)
 %>
 <%= panel(title, id: id) do %>
   <div>

--- a/app/views/content_blobs/examine_url/_file_metadata.html.erb
+++ b/app/views/content_blobs/examine_url/_file_metadata.html.erb
@@ -14,5 +14,5 @@
 </ul>
 
 <%= content_tag :script,
-                @info.merge(allow_copy: (@info[:file_size].blank? || (@info[:file_size] <= Seek::Config.hard_max_cachable_size))).to_json.html_safe,
+                @info.to_json.html_safe,
                 type: 'application/json' %>

--- a/app/views/content_blobs/examine_url/_file_metadata.html.erb
+++ b/app/views/content_blobs/examine_url/_file_metadata.html.erb
@@ -14,5 +14,5 @@
 </ul>
 
 <%= content_tag :script,
-                @info.to_json.html_safe,
+                ERB::Util.json_escape(@info.to_json),
                 type: 'application/json' %>

--- a/app/views/content_blobs/examine_url/_file_metadata.html.erb
+++ b/app/views/content_blobs/examine_url/_file_metadata.html.erb
@@ -14,5 +14,5 @@
 </ul>
 
 <%= content_tag :script,
-                ERB::Util.json_escape(@info.to_json),
+                raw(ERB::Util.json_escape(@info.to_json)),
                 type: 'application/json' %>

--- a/app/views/studies/batch_uploader.html.erb
+++ b/app/views/studies/batch_uploader.html.erb
@@ -23,4 +23,7 @@
       </div>
     </div>
   <% end %>
+<% else %>
+  <h1>Batch MIAPPE upload unavailable</h1>
+  <p>Batch MIAPPE uploads are currently disabled or file uploads are blocked for this instance.</p>
 <% end %>

--- a/app/views/studies/batch_uploader.html.erb
+++ b/app/views/studies/batch_uploader.html.erb
@@ -1,27 +1,26 @@
-<%
-  return unless show_batch_miappe_button?
-%>
+<% if show_batch_miappe_button? %>
 
-<% @page_title ||= "New #{t('data_file')}" %>
-<h1><%= @page_title %></h1>
+  <% @page_title ||= "New #{t('data_file')}" %>
+  <h1><%= @page_title %></h1>
 
-<%= form_tag({:action => :preview_content}, :multipart => true) do -%>
-  <%= forward_params(:data_file) %>
+  <%= form_tag({:action => :preview_content}, :multipart => true) do -%>
+    <%= forward_params(:data_file) %>
 
 
 
-  <div class="asset_form">
-    <%= error_messages_for :data_file -%>
+    <div class="asset_form">
+      <%= error_messages_for :data_file -%>
 
-    <%= render :partial=>"assets/upload_box",:locals=>{:resource=>@data_file} -%>
+      <%= render :partial=>"assets/upload_box",:locals=>{:resource=>@data_file} -%>
 
-    <div>
-      <%= create_button id:"study_file_submit_btn",
-                        onclick:"return validateResourceFields('data_file');",
-                        class:'btn btn-primary',
-                        button_text:'Upload',
-                        'data-upload-file-text' => 'Upload' %>
-      or <%= cancel_button(studies_path) -%>
+      <div>
+        <%= create_button id:"study_file_submit_btn",
+                          onclick:"return validateResourceFields('data_file');",
+                          class:'btn btn-primary',
+                          button_text:'Upload',
+                          'data-upload-file-text' => 'Upload' %>
+        or <%= cancel_button(studies_path) -%>
+      </div>
     </div>
-  </div>
-<% end -%>
+  <% end %>
+<% end %>

--- a/app/views/studies/batch_uploader.html.erb
+++ b/app/views/studies/batch_uploader.html.erb
@@ -1,3 +1,7 @@
+<%
+  return unless show_batch_miappe_button?
+%>
+
 <% @page_title ||= "New #{t('data_file')}" %>
 <h1><%= @page_title %></h1>
 

--- a/config/initializers/seek_configuration.rb
+++ b/config/initializers/seek_configuration.rb
@@ -201,6 +201,7 @@ def load_seek_config_defaults!
   Seek::Config.default :zenodo_oauth_url, 'https://zenodo.org/oauth'
 
   Seek::Config.default :allow_private_address_access, false
+  Seek::Config.default :block_file_uploads, false
   Seek::Config.default :cache_remote_files, true
   Seek::Config.default :max_cachable_size, 20 * 1024 * 1024
   Seek::Config.default :hard_max_cachable_size, 100 * 1024 * 1024

--- a/config/initializers/seek_testing.rb
+++ b/config/initializers/seek_testing.rb
@@ -88,7 +88,7 @@ def load_seek_testing_defaults!
       Settings.defaults[:zenodo_api_url] = "https://sandbox.zenodo.org/api"
       Settings.defaults[:zenodo_oauth_url] = "https://sandbox.zenodo.org/oauth"
 
-      Settings.defaults[:block_file_uploads] = false
+      Settings.defaults[:block_file_uploads] = true
       Settings.defaults[:cache_remote_files] = true
       Settings.defaults[:max_cachable_size] = 2000
       Settings.defaults[:hard_max_cachable_size] = 50000

--- a/config/initializers/seek_testing.rb
+++ b/config/initializers/seek_testing.rb
@@ -88,7 +88,7 @@ def load_seek_testing_defaults!
       Settings.defaults[:zenodo_api_url] = "https://sandbox.zenodo.org/api"
       Settings.defaults[:zenodo_oauth_url] = "https://sandbox.zenodo.org/oauth"
 
-      Settings.defaults[:block_file_uploads] = true
+      Settings.defaults[:block_file_uploads] = false
       Settings.defaults[:cache_remote_files] = true
       Settings.defaults[:max_cachable_size] = 2000
       Settings.defaults[:hard_max_cachable_size] = 50000

--- a/config/initializers/seek_testing.rb
+++ b/config/initializers/seek_testing.rb
@@ -88,6 +88,7 @@ def load_seek_testing_defaults!
       Settings.defaults[:zenodo_api_url] = "https://sandbox.zenodo.org/api"
       Settings.defaults[:zenodo_oauth_url] = "https://sandbox.zenodo.org/oauth"
 
+      Settings.defaults[:block_file_uploads] = false
       Settings.defaults[:cache_remote_files] = true
       Settings.defaults[:max_cachable_size] = 2000
       Settings.defaults[:hard_max_cachable_size] = 50000

--- a/lib/seek/assets_common.rb
+++ b/lib/seek/assets_common.rb
@@ -11,7 +11,6 @@ module Seek
 
     included do
       after_action :fair_signposting, only: [:show], if: -> { Seek::Config.fair_signposting_enabled }
-
       user_content_actions :download
     end
 

--- a/lib/seek/assets_standard_controller_actions.rb
+++ b/lib/seek/assets_standard_controller_actions.rb
@@ -2,6 +2,8 @@ module Seek
   # The standard basic actions for assets - currently show, new, create, edit, destroy. THe intention is to support all methods for all asset types.
   # DataFile is currently not fully supported due to biosample complications which are intended to be revisited.
   module AssetsStandardControllerActions
+    extend ActiveSupport::Concern
+
     include Seek::DestroyHandling
     include Seek::UploadHandling::DataUpload
 

--- a/lib/seek/config_setting_attributes.yml
+++ b/lib/seek/config_setting_attributes.yml
@@ -98,7 +98,6 @@ profile_select_by_default:
 recaptcha_public_key:
 recaptcha_private_key:
 support_email_address:
-show_as_external_link_enabled:
 doi_minting_enabled:
 datacite_username:
 datacite_password:
@@ -119,6 +118,7 @@ zenodo_client_id:
 zenodo_client_secret:
 programme_user_creation_enabled:
 programmes_open_for_projects_enabled:
+show_as_external_link_enabled:
 block_file_uploads:
 cache_remote_files:
 orcid_required:

--- a/lib/seek/config_setting_attributes.yml
+++ b/lib/seek/config_setting_attributes.yml
@@ -119,6 +119,7 @@ zenodo_client_id:
 zenodo_client_secret:
 programme_user_creation_enabled:
 programmes_open_for_projects_enabled:
+block_file_uploads:
 cache_remote_files:
 orcid_required:
 max_cachable_size:

--- a/lib/seek/upload_handling/data_upload.rb
+++ b/lib/seek/upload_handling/data_upload.rb
@@ -14,7 +14,7 @@ module Seek
       end
 
       def handle_upload_data(new_version = false, always_allow_uploads = false)
-        blob_params = params[:content_blobs]
+        blob_params = params[:content_blobs] || []
         unless always_allow_uploads
           check_for_blocked_uploads(blob_params)
           prevent_local_copy_for_blocked_uploads(blob_params)
@@ -23,8 +23,7 @@ module Seek
         allow_empty_content_blob = model_image_present? || json_api_request?
 
         unless allow_empty_content_blob || retained_content_blob_ids.present?
-          if !blob_params || blob_params.empty? || blob_params.none? { |p| check_for_data_or_url(p) }
-
+          if blob_params.empty? || blob_params.none? { |p| check_for_data_or_url(p) }
             flash.now[:error] ||= 'Please select a file to upload or provide a URL to the data.'
             return false
           end

--- a/lib/seek/upload_handling/data_upload.rb
+++ b/lib/seek/upload_handling/data_upload.rb
@@ -12,10 +12,12 @@ module Seek
         rescue_from UploadBlockedException, with: :handle_upload_blocked_exception
       end
 
-      def handle_upload_data(new_version = false)
+      def handle_upload_data(new_version = false, always_allow_uploads = false)
         blob_params = params[:content_blobs]
-        check_for_blocked_uploads(blob_params)
-        prevent_local_copy_for_blocked_uploads(blob_params)
+        unless always_allow_uploads
+          check_for_blocked_uploads(blob_params)
+          prevent_local_copy_for_blocked_uploads(blob_params)
+        end
 
         allow_empty_content_blob = model_image_present? || json_api_request?
 

--- a/lib/seek/upload_handling/data_upload.rb
+++ b/lib/seek/upload_handling/data_upload.rb
@@ -1,10 +1,16 @@
 module Seek
   module UploadHandling
     module DataUpload
+      extend ActiveSupport::Concern
+
       include Seek::UploadHandling::ParameterHandling
       include Seek::UploadHandling::ContentInspection
 
-      class Seek::UploadHandling::DataUpload::UploadBlockedException < StandardError; end
+      class UploadBlockedException < StandardError; end
+
+      included do
+        rescue_from Seek::UploadHandling::DataUpload::UploadBlockedException, with: :handle_upload_blocked_exception
+      end
 
       def handle_upload_data(new_version = false)
         blob_params = params[:content_blobs]
@@ -221,7 +227,7 @@ module Seek
         action_name == 'create'
       end
 
-      # raises UploadBlockedException if data upload params are present for any blob params
+      # raises UploadBlockedException if data upload params are present for any blob params whilst Seek::Config.block_file_uploads is true
       def check_for_blocked_uploads(blob_params)
         return unless Seek::Config.block_file_uploads
 
@@ -229,6 +235,16 @@ module Seek
           if check_for_data_upload_params(params)
             raise UploadBlockedException, 'Data upload is not allowed. Please provide a URL to the data instead.'
           end
+        end
+      end
+
+      def handle_upload_blocked_exception
+        respond_to do |format|
+          format.html do
+            flash.now[:error] = 'Data upload is not allowed. Please provide a URL to the data instead.'
+            render action: :new
+          end
+          format.json { render json: { error: 'Data upload is not allowed. Please provide a URL to the data instead.' }, status: 403 }
         end
       end
 

--- a/lib/seek/upload_handling/data_upload.rb
+++ b/lib/seek/upload_handling/data_upload.rb
@@ -242,7 +242,7 @@ module Seek
         respond_to do |format|
           format.html do
             flash.now[:error] = 'Data upload is not allowed. Please provide a URL to the data instead.'
-            render action: :new
+            redirect_to polymorphic_path(controller_name)
           end
           format.json { render json: { error: 'Data upload is not allowed. Please provide a URL to the data instead.' }, status: 403 }
         end

--- a/lib/seek/upload_handling/data_upload.rb
+++ b/lib/seek/upload_handling/data_upload.rb
@@ -9,6 +9,7 @@ module Seek
       class UploadBlockedException < StandardError; end
 
       included do
+        # this concern is for controllers only, otherwise the following line will throw an exception
         rescue_from UploadBlockedException, with: :handle_upload_blocked_exception
       end
 

--- a/lib/seek/upload_handling/data_upload.rb
+++ b/lib/seek/upload_handling/data_upload.rb
@@ -238,13 +238,13 @@ module Seek
         end
       end
 
-      def handle_upload_blocked_exception
+      def handle_upload_blocked_exception(exception)
         respond_to do |format|
           format.html do
             flash.now[:error] = 'Data upload is not allowed. Please provide a URL to the data instead.'
             redirect_to polymorphic_path(controller_name)
           end
-          format.json { render json: { error: 'Data upload is not allowed. Please provide a URL to the data instead.' }, status: 403 }
+          format.json { render json: { error: exception.message }, status: :forbidden }
         end
       end
 

--- a/lib/seek/upload_handling/data_upload.rb
+++ b/lib/seek/upload_handling/data_upload.rb
@@ -15,6 +15,7 @@ module Seek
       def handle_upload_data(new_version = false)
         blob_params = params[:content_blobs]
         check_for_blocked_uploads(blob_params)
+        prevent_local_copy_for_blocked_uploads(blob_params)
 
         allow_empty_content_blob = model_image_present? || json_api_request?
 
@@ -227,6 +228,15 @@ module Seek
         action_name == 'create'
       end
 
+      # forces params to prevent local copies to be made from urls if Seek::Config.block_file_uploads is true
+      def prevent_local_copy_for_blocked_uploads(blob_params)
+        return unless Seek::Config.block_file_uploads
+
+        blob_params.each do |params|
+          params[:make_local_copy] = '0'
+        end
+      end
+
       # raises UploadBlockedException if data upload params are present for any blob params whilst Seek::Config.block_file_uploads is true
       def check_for_blocked_uploads(blob_params)
         return unless Seek::Config.block_file_uploads
@@ -241,7 +251,7 @@ module Seek
       def handle_upload_blocked_exception(exception)
         respond_to do |format|
           format.html do
-            flash.now[:error] = 'Data upload is not allowed. Please provide a URL to the data instead.'
+            flash.now[:error] = exception.message
             redirect_to polymorphic_path(controller_name)
           end
           format.json { render json: { error: exception.message }, status: :forbidden }

--- a/lib/seek/upload_handling/data_upload.rb
+++ b/lib/seek/upload_handling/data_upload.rb
@@ -9,7 +9,7 @@ module Seek
       class UploadBlockedException < StandardError; end
 
       included do
-        rescue_from Seek::UploadHandling::DataUpload::UploadBlockedException, with: :handle_upload_blocked_exception
+        rescue_from UploadBlockedException, with: :handle_upload_blocked_exception
       end
 
       def handle_upload_data(new_version = false)

--- a/lib/seek/upload_handling/data_upload.rb
+++ b/lib/seek/upload_handling/data_upload.rb
@@ -4,8 +4,11 @@ module Seek
       include Seek::UploadHandling::ParameterHandling
       include Seek::UploadHandling::ContentInspection
 
+      class Seek::UploadHandling::DataUpload::UploadBlockedException < StandardError; end
+
       def handle_upload_data(new_version = false)
         blob_params = params[:content_blobs]
+        check_for_blocked_uploads(blob_params)
 
         allow_empty_content_blob = model_image_present? || json_api_request?
 
@@ -217,6 +220,19 @@ module Seek
       def render_new?
         action_name == 'create'
       end
+
+      # raises UploadBlockedException if data upload params are present for any blob params
+      def check_for_blocked_uploads(blob_params)
+        return unless Seek::Config.block_file_uploads
+
+        blob_params.each do |params|
+          if check_for_data_upload_params(params)
+            raise UploadBlockedException, 'Data upload is not allowed. Please provide a URL to the data instead.'
+          end
+        end
+      end
+
     end
+
   end
 end

--- a/lib/seek/upload_handling/data_upload.rb
+++ b/lib/seek/upload_handling/data_upload.rb
@@ -253,7 +253,7 @@ module Seek
       def handle_upload_blocked_exception(exception)
         respond_to do |format|
           format.html do
-            flash.now[:error] = exception.message
+            flash[:error] = exception.message
             redirect_to polymorphic_path(controller_name)
           end
           format.json { render json: { error: exception.message }, status: :forbidden }

--- a/lib/seek/upload_handling/examine_url.rb
+++ b/lib/seek/upload_handling/examine_url.rb
@@ -48,7 +48,7 @@ module Seek
 
       def allow_copy?(info)
         allow_copy = !Seek::Config.block_file_uploads
-        allow_copy = allow_copy & (info[:file_size].blank? || (info[:file_size] <= Seek::Config.hard_max_cachable_size))
+        allow_copy = allow_copy && (info[:file_size].blank? || (info[:file_size] <= Seek::Config.hard_max_cachable_size))
         info.merge!(allow_copy: allow_copy)
         info.merge!(blocked_file_uploads: Seek::Config.block_file_uploads)
         info

--- a/lib/seek/upload_handling/examine_url.rb
+++ b/lib/seek/upload_handling/examine_url.rb
@@ -14,6 +14,7 @@ module Seek
           handler = @content_blob.remote_content_handler
           if handler
             @info = handler.info
+            @info = allow_copy?(@info)
             if @info[:code]
               if @info[:code] == 200
                 handle_good_http_response(handler)
@@ -44,6 +45,14 @@ module Seek
       end
 
       private
+
+      def allow_copy?(info)
+        allow_copy = !Seek::Config.block_file_uploads
+        allow_copy = allow_copy & (info[:file_size].blank? || (info[:file_size] <= Seek::Config.hard_max_cachable_size))
+        info.merge!(allow_copy: allow_copy)
+        info.merge!(blocked_file_uploads: Seek::Config.block_file_uploads)
+        info
+      end
 
       def handle_good_http_response(handler)
         if handler.is_a?(Seek::DownloadHandling::GithubHTTPHandler)

--- a/lib/seek/upload_handling/examine_url.rb
+++ b/lib/seek/upload_handling/examine_url.rb
@@ -26,7 +26,7 @@ module Seek
             @type = 'warning'
             @warning_msg = "Unhandled URL scheme: #{uri.scheme}. The given URL will be presented as a clickable link."
           end
-        rescue URI::InvalidURIError
+        rescue URI::InvalidURIError, ArgumentError
           @type = 'override'
           @error_msg = 'The URL appears to be invalid.'
         rescue OpenSSL::OpenSSLError

--- a/lib/seek/upload_handling/parameter_handling.rb
+++ b/lib/seek/upload_handling/parameter_handling.rb
@@ -24,7 +24,7 @@ module Seek
       end
 
       def check_for_data_or_url(blob_param)
-        if blob_param[:data].blank? && blob_param[:data_url].blank?  && blob_param[:base64_data].blank?
+        if blob_param[:data].blank? && blob_param[:data_url].blank? && blob_param[:base64_data].blank?
           if blob_param.include?(:data_url)
             flash.now[:error] = 'Please select a file to upload or provide a URL to the data.'
           elsif blob_param.include?(:data_url)
@@ -47,6 +47,13 @@ module Seek
         else
           true
         end
+      end
+
+      # returns true if the `data` or `base64_data` parameter is present, regardless of whether it is blank or not
+      def check_for_data_upload_params(blob_params)
+        return true if blob_params.include?(:data) || blob_params.include?(:base64_data)
+
+        false
       end
 
       def check_for_base64_data(blob_params)

--- a/test/functional/content_blobs_controller_test.rb
+++ b/test/functional/content_blobs_controller_test.rb
@@ -224,6 +224,15 @@ class ContentBlobsControllerTest < ActionController::TestCase
     assert assigns(:error_msg)
   end
 
+  test 'examine url no host' do
+    get :examine_url, xhr: true, params: { data_url: 'http://' }
+    assert_response 400
+    assert @response.body.include?('The URL appears to be invalid')
+    assert @response.body.include?('I understand the risks and want to override URL validation')
+    assert_equal 'override', assigns(:type)
+    assert assigns(:error_msg)
+  end
+
   test 'examine url unrecognized scheme' do
     get :examine_url, xhr: true, params: { data_url: 'fish://tuna:1525125151' }
     assert_response :success

--- a/test/functional/content_blobs_controller_test.rb
+++ b/test/functional/content_blobs_controller_test.rb
@@ -56,8 +56,23 @@ class ContentBlobsControllerTest < ActionController::TestCase
     get :examine_url, xhr: true, params: { data_url: 'http://mockedlocation.com/a-piccy.png' }
     assert_response :success
     assert_equal 200, assigns(:info)[:code]
+    assert assigns(:info)[:allow_copy]
+    refute assigns(:info)[:blocked_file_uploads]
     assert !@response.body.include?('Webpage Link')
     assert_equal 'file', assigns(:type)
+  end
+
+  test 'examine url to file blocked file uploads' do
+    with_config_value(:block_file_uploads, true) do
+      stub_request(:head, 'http://mockedlocation.com/a-piccy.png').to_return(status: 200, headers: { 'Content-Type' => 'image/png' })
+      get :examine_url, xhr: true, params: { data_url: 'http://mockedlocation.com/a-piccy.png' }
+      assert_response :success
+      assert_equal 200, assigns(:info)[:code]
+      refute assigns(:info)[:allow_copy]
+      assert assigns(:info)[:blocked_file_uploads]
+      assert !@response.body.include?('Webpage Link')
+      assert_equal 'file', assigns(:type)
+    end
   end
 
   test 'examine url to webpage' do
@@ -66,6 +81,8 @@ class ContentBlobsControllerTest < ActionController::TestCase
     get :examine_url, xhr: true, params: { data_url: 'http://somewhere.com' }
     assert_response :success
     assert_equal 200, assigns(:info)[:code]
+    assert assigns(:info)[:allow_copy]
+    refute assigns(:info)[:blocked_file_uploads]
     assert @response.body.include?('Webpage Link')
     assert_equal 'webpage', assigns(:type)
   end

--- a/test/functional/data_files_controller_test.rb
+++ b/test/functional/data_files_controller_test.rb
@@ -1887,6 +1887,38 @@ class DataFilesControllerTest < ActionController::TestCase
     assert blob.remote_content_fetch_task&.pending?
   end
 
+  test 'should create cache job for small file if uploads are blocked' do
+    mock_http
+    params = { data_file: {
+      title: 'Small File',
+      project_ids: [projects(:sysmo_project).id]
+    },
+               content_blobs: [{
+                                 data_url: 'http://mockedlocation.com/small.txt',
+                                 make_local_copy: '0'
+                               }],
+               policy_attributes: valid_sharing }
+
+    with_config_value(:block_file_uploads, true) do
+      assert_no_enqueued_jobs(only: RemoteContentFetchingJob) do
+        assert_difference('DataFile.count') do
+          assert_difference('ContentBlob.count') do
+            post :create, params: params
+          end
+        end
+      end
+
+      assert_redirected_to data_file_path(assigns(:data_file))
+      blob = assigns(:data_file).content_blob
+      refute blob.cachable?
+      refute blob.url.blank?
+      assert_equal 'small.txt', blob.original_filename
+      assert_equal 'text/plain', blob.content_type
+      assert_equal 100, blob.file_size
+      refute blob.remote_content_fetch_task&.pending?
+    end
+  end
+
   test 'should not create cache job if setting disabled' do
     mock_http
     params = { data_file: {

--- a/test/functional/data_files_controller_test.rb
+++ b/test/functional/data_files_controller_test.rb
@@ -1887,7 +1887,7 @@ class DataFilesControllerTest < ActionController::TestCase
     assert blob.remote_content_fetch_task&.pending?
   end
 
-  test 'should create cache job for small file if uploads are blocked' do
+  test 'should not create cache job for file if uploads are blocked' do
     mock_http
     params = { data_file: {
       title: 'Small File',

--- a/test/functional/documents_controller_test.rb
+++ b/test/functional/documents_controller_test.rb
@@ -88,6 +88,45 @@ class DocumentsControllerTest < ActionController::TestCase
     assert_redirected_to document_path(assigns(:document))
   end
 
+  test 'should not create document with blocked file uploads' do
+    with_config_value(:block_file_uploads, true) do
+      person = FactoryBot.create(:person)
+      login_as(person)
+
+      assert_no_difference('ActivityLog.count') do
+        assert_no_difference('Document.count') do
+          assert_no_difference('Document::Version.count') do
+            assert_no_difference('ContentBlob.count') do
+              post :create, params: { document: { title: 'Document', project_ids: [person.projects.first.id]}, content_blobs: [valid_content_blob], policy_attributes: valid_sharing }
+            end
+          end
+        end
+      end
+      assert_equal 'Data upload is not allowed. Please provide a URL to the data instead.', flash[:error]
+      assert_redirected_to documents_path
+    end
+  end
+
+  test 'should create document from url with blocked file uploads' do
+    stub_request(:head, 'http://fish.com').to_return(status: 200, body: '',
+                                                     headers: { content_type: 'text/html', content_length: '555' })
+    with_config_value(:block_file_uploads, true) do
+      person = FactoryBot.create(:person)
+      login_as(person)
+
+      assert_difference('ActivityLog.count') do
+        assert_difference('Document.count') do
+          assert_difference('Document::Version.count') do
+            assert_difference('ContentBlob.count') do
+              post :create, params: { document: { title: 'Document', project_ids: [person.projects.first.id]}, content_blobs: [valid_url_content_blob], policy_attributes: valid_sharing }
+            end
+          end
+        end
+      end
+      assert_redirected_to document_path(assigns(:document))
+    end
+  end
+
   test 'should create document version' do
     document = FactoryBot.create(:document)
     login_as(document.contributor)
@@ -106,6 +145,50 @@ class DocumentsControllerTest < ActionController::TestCase
     assert_equal 2, assigns(:document).version
     assert_equal 2, assigns(:document).versions.count
     assert_equal 'new version!', assigns(:document).latest_version.revision_comments
+  end
+
+  test 'should not create document version with blocked file uploads' do
+    with_config_value(:block_file_uploads, true) do
+      document = FactoryBot.create(:document)
+      login_as(document.contributor)
+
+      assert_no_difference('ActivityLog.count') do
+        assert_no_difference('Document.count') do
+          assert_no_difference('Document::Version.count') do
+            assert_no_difference('ContentBlob.count') do
+              post :create_version, params: { id: document.id, content_blobs: [{ data: fixture_file_upload('little_file.txt') }], revision_comments: 'new version!' }
+            end
+          end
+        end
+      end
+      assert_equal 'Data upload is not allowed. Please provide a URL to the data instead.', flash[:error]
+      assert_redirected_to documents_path
+    end
+  end
+
+  test 'should create document version from url with blocked file uploads' do
+    stub_request(:head, 'http://fish.com').to_return(status: 200, body: '',
+                                                     headers: { content_type: 'text/html', content_length: '555' })
+    with_config_value(:block_file_uploads, true) do
+      document = FactoryBot.create(:document)
+      login_as(document.contributor)
+
+      assert_difference('ActivityLog.count') do
+        assert_no_difference('Document.count') do
+          assert_difference('Document::Version.count') do
+            assert_difference('ContentBlob.count') do
+              post :create_version, params: { id: document.id, content_blobs: [valid_url_content_blob], revision_comments: 'new version!' }
+            end
+          end
+        end
+      end
+
+      assert_redirected_to document_path(assigns(:document))
+      assert_equal 2, assigns(:document).version
+      assert_equal 2, assigns(:document).versions.count
+      assert_equal 'new version!', assigns(:document).latest_version.revision_comments
+    end
+
   end
 
   test 'create, update and show a document with extended metadata' do
@@ -1539,5 +1622,9 @@ class DocumentsControllerTest < ActionController::TestCase
 
   def valid_content_blob
     { data: fixture_file_upload('a_pdf_file.pdf'), data_url: '' }
+  end
+
+  def valid_url_content_blob
+    { data_url: 'http://fish.com' }
   end
 end

--- a/test/functional/documents_controller_test.rb
+++ b/test/functional/documents_controller_test.rb
@@ -209,7 +209,7 @@ class DocumentsControllerTest < ActionController::TestCase
         assert_select '.tab-content' do
           assert_select 'div[data-tab-id=?]', 'local-file', count: 0
           assert_select 'input[type=file]', count: 0
-          assert_select 'div[data-tab-id=?]', 'remote-url', count: 1
+          assert_select 'div[data-tab-id=?].active', 'remote-url', count: 1
           assert_select 'input[name="content_blobs[][data_url]"]', count: 1
         end
       end

--- a/test/functional/documents_controller_test.rb
+++ b/test/functional/documents_controller_test.rb
@@ -208,19 +208,51 @@ class DocumentsControllerTest < ActionController::TestCase
       get :new
 
       assert_response :success
-
-      assert_select 'div[role=?]', 'tabpanel' do
-        assert_select 'ul[role=?]', 'tablist' do
-          assert_select 'a[data-tab-target=?]', 'local-file', count: 0
-          assert_select 'li.upload-field-tab.active' do
-            assert_select 'a[data-tab-target=?]', 'remote-url', count: 1
+      assert_select '.panel-body' do
+        expected = 'You can register a Document by registering a URL to a remote file or web page.'
+        assert_select 'p', text: expected
+        assert_select 'div[role=?]', 'tabpanel' do
+          assert_select 'ul[role=?]', 'tablist' do
+            assert_select 'a[data-tab-target=?]', 'local-file', count: 0
+            assert_select 'li.upload-field-tab.active' do
+              assert_select 'a[data-tab-target=?]', 'remote-url', count: 1
+            end
+          end
+          assert_select '.tab-content' do
+            assert_select 'div[data-tab-id=?]', 'local-file', count: 0
+            assert_select 'input[type=file]', count: 0
+            assert_select 'div[data-tab-id=?].active', 'remote-url', count: 1
+            assert_select 'input[name="content_blobs[][data_url]"]', count: 1
           end
         end
-        assert_select '.tab-content' do
-          assert_select 'div[data-tab-id=?]', 'local-file', count: 0
-          assert_select 'input[type=file]', count: 0
-          assert_select 'div[data-tab-id=?].active', 'remote-url', count: 1
-          assert_select 'input[name="content_blobs[][data_url]"]', count: 1
+      end
+    end
+  end
+
+  test 'local upload option available without blocked file uploads' do
+    with_config_value(:block_file_uploads, false) do
+      person = FactoryBot.create(:person)
+      login_as(person)
+
+      get :new
+
+      assert_response :success
+      assert_select '.panel-body' do
+        expected='You can register a Document by either directly uploading a file, or registering a URL to a remote file or web page.'
+        assert_select 'p', text: expected
+        assert_select 'div[role=?]', 'tabpanel' do
+          assert_select 'ul[role=?]', 'tablist' do
+            assert_select 'a[data-tab-target=?]', 'local-file', count: 1
+            assert_select 'li.upload-field-tab' do
+              assert_select 'a[data-tab-target=?]', 'remote-url', count: 1
+            end
+          end
+          assert_select '.tab-content' do
+            assert_select 'div[data-tab-id=?]', 'local-file', count: 1
+            assert_select 'input[type=file]', count: 1
+            assert_select 'div[data-tab-id=?]', 'remote-url', count: 1
+            assert_select 'input[name="content_blobs[][data_url]"]', count: 1
+          end
         end
       end
     end

--- a/test/functional/documents_controller_test.rb
+++ b/test/functional/documents_controller_test.rb
@@ -188,7 +188,33 @@ class DocumentsControllerTest < ActionController::TestCase
       assert_equal 2, assigns(:document).versions.count
       assert_equal 'new version!', assigns(:document).latest_version.revision_comments
     end
+  end
 
+  test 'local upload option removed with blocked file uploads' do
+    with_config_value(:block_file_uploads, true) do
+      person = FactoryBot.create(:person)
+      login_as(person)
+
+      get :new
+
+      assert_response :success
+
+      assert_select 'div[role=?]', 'tabpanel' do
+        assert_select 'ul[role=?]', 'tablist' do
+          assert_select 'a[data-tab-target=?]', 'local-file', count: 0
+          assert_select 'li.upload-field-tab.active' do
+            assert_select 'a[data-tab-target=?]', 'remote-url', count: 1
+          end
+        end
+        assert_select '.tab-content' do
+          assert_select 'div[data-tab-id=?]', 'local-file', count: 0
+          assert_select 'input[type=file]', count: 0
+          assert_select 'div[data-tab-id=?]', 'remote-url', count: 1
+          assert_select 'input[name="content_blobs[][data_url]"]', count: 1
+        end
+      end
+
+    end
   end
 
   test 'create, update and show a document with extended metadata' do

--- a/test/functional/documents_controller_test.rb
+++ b/test/functional/documents_controller_test.rb
@@ -213,7 +213,17 @@ class DocumentsControllerTest < ActionController::TestCase
           assert_select 'input[name="content_blobs[][data_url]"]', count: 1
         end
       end
+    end
+  end
 
+  test 'make local copy not available with blocked file uploads' do
+    with_config_value(:block_file_uploads, true) do
+      person = FactoryBot.create(:person)
+      login_as(person)
+
+      get :new
+      assert_select 'input#content_blobs__make_local_copy', count: 1
+      assert_select 'input#content_blobs__make_local_copy[checked]', count: 0
     end
   end
 

--- a/test/functional/documents_controller_test.rb
+++ b/test/functional/documents_controller_test.rb
@@ -79,7 +79,8 @@ class DocumentsControllerTest < ActionController::TestCase
       assert_difference('Document.count') do
         assert_difference('Document::Version.count') do
           assert_difference('ContentBlob.count') do
-            post :create, params: { document: { title: 'Document', project_ids: [person.projects.first.id]}, content_blobs: [valid_content_blob], policy_attributes: valid_sharing }
+            post :create, params: { document: { title: 'Document', project_ids: [person.projects.first.id]},
+                                    content_blobs: [valid_content_blob], policy_attributes: valid_sharing }
           end
         end
       end
@@ -114,16 +115,25 @@ class DocumentsControllerTest < ActionController::TestCase
       person = FactoryBot.create(:person)
       login_as(person)
 
+      blob = valid_url_content_blob
+
+      # ensure these are ignored and forced to not make a copy
+      blob[:make_local_copy] = '1'
+
       assert_difference('ActivityLog.count') do
         assert_difference('Document.count') do
           assert_difference('Document::Version.count') do
             assert_difference('ContentBlob.count') do
-              post :create, params: { document: { title: 'Document', project_ids: [person.projects.first.id]}, content_blobs: [valid_url_content_blob], policy_attributes: valid_sharing }
+              post :create, params: { document: { title: 'Document', project_ids: [person.projects.first.id]}, content_blobs: [blob], policy_attributes: valid_sharing }
             end
           end
         end
       end
-      assert_redirected_to document_path(assigns(:document))
+      document = assigns(:document)
+      assert_redirected_to document_path(document)
+
+      # these are always the case if uploads are blocked
+      refute document.content_blob.make_local_copy?
     end
   end
 
@@ -213,17 +223,6 @@ class DocumentsControllerTest < ActionController::TestCase
           assert_select 'input[name="content_blobs[][data_url]"]', count: 1
         end
       end
-    end
-  end
-
-  test 'make local copy not available with blocked file uploads' do
-    with_config_value(:block_file_uploads, true) do
-      person = FactoryBot.create(:person)
-      login_as(person)
-
-      get :new
-      assert_select 'input#content_blobs__make_local_copy', count: 1
-      assert_select 'input#content_blobs__make_local_copy[checked]', count: 0
     end
   end
 

--- a/test/functional/models_controller_test.rb
+++ b/test/functional/models_controller_test.rb
@@ -362,9 +362,31 @@ class ModelsControllerTest < ActionController::TestCase
     login_as(:model_owner)
     assert_difference('Model.count') do
       assert_difference('ModelImage.count') do
-        post :create, params: { model: valid_model, content_blobs: [{ data: file_for_upload }], policy_attributes: valid_sharing, model_image: { image_file: fixture_file_upload('file_picture.png', 'image/png') } }
+        post :create, params: { model: valid_model, content_blobs: [{ data: file_for_upload }],
+                                policy_attributes: valid_sharing,
+                                model_image: { image_file: fixture_file_upload('file_picture.png', 'image/png') } }
 
         assert_redirected_to model_path(assigns(:model))
+      end
+    end
+
+    model = assigns(:model)
+    assert_equal 'file_picture.png', model.model_image.original_filename
+    assert_equal 'image/png', model.model_image.content_type
+  end
+
+  test 'should create model with image even with blocked file uploads' do
+    stub_request(:head, 'http://somehwere/model.sbml').to_return(status: 200, headers: { 'Content-Type' => 'text/xml' })
+    with_config_value(:block_file_uploads, true) do
+      login_as(:model_owner)
+      assert_difference('Model.count') do
+        assert_difference('ModelImage.count') do
+          post :create, params: { model: valid_model, content_blobs: [{ data_url: 'http://somehwere/model.sbml' }],
+                                  policy_attributes: valid_sharing,
+                                  model_image: { image_file: fixture_file_upload('file_picture.png', 'image/png') } }
+
+          assert_redirected_to model_path(assigns(:model))
+        end
       end
     end
 

--- a/test/functional/sample_types_controller_test.rb
+++ b/test/functional/sample_types_controller_test.rb
@@ -440,7 +440,46 @@ class SampleTypesControllerTest < ActionController::TestCase
                params: { sample_type: { title: 'Hello!', project_ids: @project_ids, tags: ['fish','golf'] },
                          content_blobs: [blob],
                          policy_attributes: policy_attributes }
+          assert_redirected_to edit_sample_type_path(assigns(:sample_type))
+        end
+      end
+    end
 
+    sample_type = assigns(:sample_type)
+    assert_redirected_to edit_sample_type_path(sample_type)
+    assert_empty sample_type.errors
+    assert sample_type.uploaded_template?
+
+    policy = sample_type.policy
+    assert_equal Policy::VISIBLE, policy.access_type
+    assert_equal 1, policy.permissions.count
+    assert_equal Policy::MANAGING, policy.permissions.first.access_type
+    assert_equal @project, policy.permissions.first.contributor
+
+    assert_equal %w[fish golf], sample_type.tags.sort
+
+    assert_equal sample_type, ActivityLog.last.activity_loggable
+    assert_equal 'create', ActivityLog.last.action
+  end
+
+  test 'create from template even with file uploads blocked' do
+    blob = { data: template_for_upload }
+
+    policy_attributes = projects_policy(Policy::VISIBLE, [@project], Policy::MANAGING)
+
+    with_config_value(:block_file_uploads, true) do
+      assert_difference('ActivityLog.count', 1) do
+        assert_difference('SampleType.count', 1) do
+          assert_difference('ContentBlob.count', 1) do
+            assert_nothing_raised do
+              post :create_from_template,
+                   params: { sample_type: { title: 'Hello!', project_ids: @project_ids, tags: ['fish','golf'] },
+                             content_blobs: [blob],
+                             policy_attributes: policy_attributes }
+              refute_nil assigns(:sample_type)
+              assert_redirected_to edit_sample_type_path(assigns(:sample_type))
+            end
+          end
         end
       end
     end

--- a/test/functional/sops_controller_test.rb
+++ b/test/functional/sops_controller_test.rb
@@ -189,11 +189,13 @@ class SopsControllerTest < ActionController::TestCase
         post :create, params: { sop: sop_details, content_blobs: [blob], policy_attributes: valid_sharing }
       end
     end
-    assert_redirected_to sop_path(assigns(:sop))
-    assert_equal users(:quentin).person, assigns(:sop).contributor
-    assert !assigns(:sop).content_blob.url.blank?
-    assert_equal 'sysmo-db-logo-grad2.png', assigns(:sop).content_blob.original_filename
-    assert_equal 'image/png', assigns(:sop).content_blob.content_type
+    sop = assigns(:sop)
+    assert_redirected_to sop_path(sop)
+    assert_equal users(:quentin).person, sop.contributor
+    refute sop.content_blob.url.blank?
+    assert_equal 'sysmo-db-logo-grad2.png', sop.content_blob.original_filename
+    assert_equal 'image/png', sop.content_blob.content_type
+    assert sop.content_blob.make_local_copy?
   end
 
   test 'should show sop' do

--- a/test/integration/api/content_blob_api_test.rb
+++ b/test/integration/api/content_blob_api_test.rb
@@ -51,6 +51,24 @@ class ContentBlobApiTest < ActionDispatch::IntegrationTest
 
   end
 
+  test 'update content blob data fails with blocked file uploads' do
+    with_config_value(:block_file_uploads, true) do
+      sop = FactoryBot.create(:sop, policy: FactoryBot.create(:public_policy),
+                              contributor: @current_user.person,
+                              content_blob: FactoryBot.create(:content_blob, data: nil))
+      blob = sop.content_blob
+      assert blob.no_content?
+      new_data = 'X'*123
+
+      assert sop.can_edit?
+      put polymorphic_url([sop, blob]), params: new_data, headers: {'Content-Type': 'application/octet-stream'}
+      assert_response :forbidden
+      assert_equal 'Data upload is not allowed.', response.body
+      blob.reload
+      assert blob.no_content?
+    end
+  end
+
   private
 
   def collection_url

--- a/test/unit/content_blob_test.rb
+++ b/test/unit/content_blob_test.rb
@@ -712,6 +712,16 @@ class ContentBlobTest < ActiveSupport::TestCase
     refute blob.file_exists?
   end
 
+  test "won't follow redirect and fetch local file" do
+    stub_request(:get, 'http://www.abc.com').to_return(headers: { location: 'file:///etc/passwd' }, status: 302)
+    blob = FactoryBot.create(:url_content_blob)
+    refute blob.file_exists?
+    assert_raise Addressable::URI::InvalidURIError do
+      blob.retrieve
+    end
+    refute blob.file_exists?
+  end
+
   test 'raises exception on bad response code when downloading remote content' do
     stub_request(:head, 'http://www.abc.com').to_return(
       headers: { content_length: 500, content_type: 'text/plain' }, status: 200

--- a/test/unit/content_blob_test.rb
+++ b/test/unit/content_blob_test.rb
@@ -937,6 +937,19 @@ class ContentBlobTest < ActiveSupport::TestCase
     end
   end
 
+  test 'does not enqueue remote content fetching job if file uploads blocked' do
+    content_blob = FactoryBot.build(:url_content_blob, make_local_copy: true)
+    refute content_blob.remote_content_fetch_task.pending?
+    with_config_value(:block_file_uploads, true) do
+      assert_no_difference('Task.count') do
+        assert_no_enqueued_jobs(only: RemoteContentFetchingJob) do
+          content_blob.save!
+          refute content_blob.remote_content_fetch_task.pending?
+        end
+      end
+    end
+  end
+
   test 'does not enqueue remote content fetching job for local content blob' do
     content_blob = FactoryBot.build(:content_blob)
     assert_no_difference('Task.count') do
@@ -957,5 +970,15 @@ class ContentBlobTest < ActiveSupport::TestCase
     assert FactoryBot.create(:image_content_blob).is_image_convertable?
     refute FactoryBot.create(:svg_content_blob).is_image_convertable?
     refute FactoryBot.create(:pdf_content_blob).is_image_convertable?
+  end
+
+  test 'not cachable if file uploads blocked' do
+    blob = FactoryBot.build(:url_content_blob, make_local_copy: true, file_size: 12)
+    with_config_value(:block_file_uploads, false) do
+      assert blob.cachable?
+    end
+    with_config_value(:block_file_uploads, true) do
+      refute blob.cachable?
+    end
   end
 end

--- a/test/unit/content_blob_test.rb
+++ b/test/unit/content_blob_test.rb
@@ -939,7 +939,6 @@ class ContentBlobTest < ActiveSupport::TestCase
 
   test 'does not enqueue remote content fetching job if file uploads blocked' do
     content_blob = FactoryBot.build(:url_content_blob, make_local_copy: true)
-    refute content_blob.remote_content_fetch_task.pending?
     with_config_value(:block_file_uploads, true) do
       assert_no_difference('Task.count') do
         assert_no_enqueued_jobs(only: RemoteContentFetchingJob) do

--- a/test/unit/helpers/assets_helper_test.rb
+++ b/test/unit/helpers/assets_helper_test.rb
@@ -211,9 +211,8 @@ class AssetsHelperTest < ActionView::TestCase
                  upload_box_text('Assay', nil, false, false)
     assert_equal 'You can register a Data file by either directly uploading a file or zipped folder, or registering a URL to a remote file or web page.',
                  upload_box_text('Data file', nil, false, false)
-    assert_raise StandardError, match:/cannot hide both remote and local options/i do
-      upload_box_text('Data file', nil, true, true)
-    end
+    assert_equal 'Both uploading a file or registering a URL to a remote file or web page are currently unavailable.',
+                 upload_box_text('Data file', nil, true, true)
   end
 
   private

--- a/test/unit/helpers/assets_helper_test.rb
+++ b/test/unit/helpers/assets_helper_test.rb
@@ -198,6 +198,24 @@ class AssetsHelperTest < ActionView::TestCase
     end
   end
 
+  test 'upload_box_text' do
+    assert_equal 'You can register a Data file by selecting a file.',
+                 upload_box_text('DataFile', 'register a Data file', true, false)
+    assert_equal 'You can register an Assay by selecting a file.',
+                 upload_box_text('Assay', nil, true, false)
+    assert_equal 'You can register a Data file by registering a URL to a remote file or web page.',
+                 upload_box_text('Data file', nil, false, true)
+    assert_equal 'You can register an Assay by registering a URL to a remote file or web page.',
+                 upload_box_text('Assay', nil, false, true)
+    assert_equal 'You can register an Assay by either directly uploading a file, or registering a URL to a remote file or web page.',
+                 upload_box_text('Assay', nil, false, false)
+    assert_equal 'You can register a Data file by either directly uploading a file or zipped folder, or registering a URL to a remote file or web page.',
+                 upload_box_text('Data file', nil, false, false)
+    assert_raise StandardError, match:/cannot hide both remote and local options/i do
+      upload_box_text('Data file', nil, true, true)
+    end
+  end
+
   private
 
   def update_lookup_tables

--- a/test/unit/helpers/studies_helper_test.rb
+++ b/test/unit/helpers/studies_helper_test.rb
@@ -1,6 +1,7 @@
 require 'test_helper'
 
 class StudiesHelperTest < ActionView::TestCase
+
   test 'show_batch_miappe_button' do
     refute show_batch_miappe_button?
 
@@ -11,6 +12,11 @@ class StudiesHelperTest < ActionView::TestCase
     refute show_batch_miappe_button?
 
     type = FactoryBot.create(:study_extended_metadata_type_for_MIAPPE, title: 'MIAPPE metadata v1.1')
+    assert show_batch_miappe_button?
+
+    with_config_value(:block_file_uploads, true) do
+      refute show_batch_miappe_button?
+    end
     assert show_batch_miappe_button?
 
     type.update_column(:enabled, false)

--- a/test/unit/upload_handling_test.rb
+++ b/test/unit/upload_handling_test.rb
@@ -6,7 +6,6 @@ require 'seek/upload_handling/examine_url'
 class UploadHandingTest < ActiveSupport::TestCase
 
   include Seek::UploadHandling::DataUpload
-  include Seek::UploadHandling::DataUpload
   include Seek::UrlValidation
 
   test 'valid scheme?' do
@@ -225,6 +224,31 @@ class UploadHandingTest < ActiveSupport::TestCase
     refute check_for_empty_data_if_present(data: [empty_content, file_with_content])
   end
 
+  test 'check for data upload params' do
+    assert check_for_data_upload_params(data: '', data_url: 'http://fish')
+    assert check_for_data_upload_params(data: '')
+    assert check_for_data_upload_params(data: 'sdf')
+    assert check_for_data_upload_params(base64_data: '', data_url: 'http://fish')
+    assert check_for_data_upload_params(base64_data: '')
+    assert check_for_data_upload_params(base64_data: 'sdf')
+    refute check_for_data_upload_params(data_url: 'http://fish')
+  end
+
+  test 'exception in handle upload if upload data present and blocked' do
+    with_config_value(:block_file_uploads, true) do
+      @params = { content_blobs: [{ data_url: 'http://fish.com', data: fixture_file_upload('empty_file', 'text/plain') }] }
+      assert_raises(Seek::UploadHandling::DataUpload::UploadBlockedException, match: /Data upload is not allowed\. Please provide a URL to the data instead/) do
+        handle_upload_data
+      end
+      @params = { content_blobs: [{ data_url: 'http://fish.com', base64_data: fixture_file_upload('empty_file', 'text/plain') }] }
+      assert_raises(Seek::UploadHandling::DataUpload::UploadBlockedException, match: /Data upload is not allowed\. Please provide a URL to the data instead/) do
+        handle_upload_data
+      end
+    end
+
+
+  end
+
   # allows some methods to be tested the rely on flash.now[:error]
   def flash
     ActionDispatch::Flash::FlashHash.new
@@ -247,4 +271,5 @@ class UploadHandingTest < ActiveSupport::TestCase
   def check_url_response_code(url)
     Seek::DownloadHandling::HTTPHandler.new(url, fallback_to_get: false).info[:code]
   end
+
 end

--- a/test/unit/upload_handling_test.rb
+++ b/test/unit/upload_handling_test.rb
@@ -5,6 +5,7 @@ require 'seek/upload_handling/examine_url'
 
 class UploadHandingTest < ActiveSupport::TestCase
 
+  include ActiveSupport::Rescuable
   include Seek::UploadHandling::DataUpload
   include Seek::UrlValidation
 


### PR DESCRIPTION
* fix for #2286 

Also allows controlling if a link is shown, or downloaded via SEEK. The setting already existed but needed adding to the admin page.

Doesn't eliminate all uploads, still allowed are avatars, model image, project DMP, Fair data station rdf, sample templates.