### PR TITLE
bioschemas additions 

### DIFF
--- a/lib/seek/bio_schema/dataset.rb
+++ b/lib/seek/bio_schema/dataset.rb
@@ -29,6 +29,10 @@ module Seek
       def is_a_version?
         false
       end
+      def supports_doi?
+        false
+      end
+
     end
   end
 end

--- a/lib/seek/bio_schema/resource_decorators/base_decorator.rb
+++ b/lib/seek/bio_schema/resource_decorators/base_decorator.rb
@@ -8,10 +8,12 @@ module Seek
         include ActionView::Helpers::SanitizeHelper
         include Seek::Util.routes
 
-        attr_reader :resource
+        attr_reader :resource, :parent_resource
 
         def initialize(resource)
           @resource = resource
+          # ensures the parent resource, whether the resource is a version or already the current parent
+          @parent_resource = resource.is_a_version? ? resource.parent : resource
         end
 
         def mappings

--- a/lib/seek/bio_schema/resource_decorators/base_decorator.rb
+++ b/lib/seek/bio_schema/resource_decorators/base_decorator.rb
@@ -86,7 +86,7 @@ module Seek
             end
           end
 
-          # used to define the mapping between the method to be call, and the property
+          # used to define the mapping between the method to be called, and the property
           # for e.g
           #   schema_mappings doi: :identifier
           # calls the method 'doi' on the decorator, and then the value will be used with the schema.org property

--- a/lib/seek/bio_schema/resource_decorators/base_decorator.rb
+++ b/lib/seek/bio_schema/resource_decorators/base_decorator.rb
@@ -73,15 +73,20 @@ module Seek
           private
 
           # to be used to easily define a method that relates to a property and handles a collection.
-          # To be used within the Decorator class to define the method name, and the collection to be used.
+          # To be used within the Decorator class to define the method name (or methods if expressed as an array), and the collection to be used.
           # This results in an array of Hash objects containing the minimal definition JSON. For example
           #   associated_items member: :people
           #   create a method 'member' that returns a collection of Hash objects containing the
           #   minimal definition for each item resulting from calling 'people' on the resource
+          #   returns nil if no methods match, otherwise returns an array even if empty
           def associated_items(**pairs)
-            pairs.each do |method, collection|
+            pairs.each do |method, collections|
               define_method(method) do
-                mini_definitions(send(collection)) if respond_to?(collection)
+                valid_methods = Array(collections).select{ |c| respond_to?(c) }
+                return nil if valid_methods.empty?
+                valid_methods.map do |collection|
+                  mini_definitions(send(collection))
+                end.flatten.compact
               end
             end
           end

--- a/lib/seek/bio_schema/resource_decorators/creative_work.rb
+++ b/lib/seek/bio_schema/resource_decorators/creative_work.rb
@@ -18,7 +18,9 @@ module Seek
                         part_of: :isPartOf,
                         doi: :identifier,
                         previous_version_url: :isBasedOn,
-                        date_published: :datePublished
+                        date_published: :datePublished,
+                        publications: :citation
+
 
 
         def doi
@@ -27,12 +29,10 @@ module Seek
 
         # If a DOI has been minted, use the date of minting as the publication date
         def date_published
-          parent = resource.is_a_version? ? resource.parent : resource
+          return unless parent_resource.supports_doi? && parent_resource.has_doi?
+          return unless AssetDoiLog.was_doi_minted_for?(parent_resource.class.name, parent_resource.id, resource.version)
 
-          return unless parent.supports_doi? && parent.has_doi?
-          return unless AssetDoiLog.was_doi_minted_for?(parent.class.name, parent.id, resource.version)
-
-          AssetDoiLog.minted.where(asset: parent, asset_version: resource.version).order(:created_at).last&.created_at&.iso8601
+          AssetDoiLog.minted.where(asset: parent_resource, asset_version: resource.version).order(:created_at).last&.created_at&.iso8601
         end
 
         def content_type
@@ -61,6 +61,18 @@ module Seek
           return unless respond_to?(:previous_version) && resource.previous_version
 
           resource_url(resource.previous_version)
+        end
+
+        def publications
+          return unless parent_resource.respond_to?(:publications)
+
+          parent_resource.publications.map do |publication|
+            {
+              '@type' => 'ScholarlyArticle',
+              '@id' => publication.rdf_resource.to_s,
+              'name' => publication.title
+            }
+          end
         end
 
       end

--- a/lib/seek/bio_schema/resource_decorators/creative_work.rb
+++ b/lib/seek/bio_schema/resource_decorators/creative_work.rb
@@ -5,8 +5,7 @@ module Seek
       class CreativeWork < Thing
         associated_items producer: :projects,
                          part_of: :collections,
-                         subject_of: :events,
-                         docs_and_sops: %i[documents sops]
+                         subject_of: :events
 
         schema_mappings version: :version,
                         license: :license,
@@ -19,7 +18,6 @@ module Seek
                         part_of: :isPartOf,
                         doi: :identifier,
                         previous_version_url: :isBasedOn,
-                        docs_and_sops: :documentation,
                         date_published: :datePublished
 
 

--- a/lib/seek/bio_schema/resource_decorators/creative_work.rb
+++ b/lib/seek/bio_schema/resource_decorators/creative_work.rb
@@ -21,8 +21,6 @@ module Seek
                         date_published: :datePublished,
                         publications: :citation
 
-
-
         def doi
           "https://doi.org/#{resource.doi}" if resource.try(:doi).present?
         end
@@ -30,9 +28,11 @@ module Seek
         # If a DOI has been minted, use the date of minting as the publication date
         def date_published
           return unless parent_resource.supports_doi? && parent_resource.has_doi?
-          return unless AssetDoiLog.was_doi_minted_for?(parent_resource.class.name, parent_resource.id, resource.version)
 
-          AssetDoiLog.minted.where(asset: parent_resource, asset_version: resource.version).order(:created_at).last&.created_at&.iso8601
+          version = doi_resource_version
+          return unless version
+
+          AssetDoiLog.minted.where(asset: parent_resource, asset_version: version).order(:created_at).last&.created_at&.iso8601
         end
 
         def content_type
@@ -72,6 +72,17 @@ module Seek
               '@id' => publication.rdf_resource.to_s,
               'name' => publication.title
             }
+          end
+        end
+
+        # Resolve the version associated with the DOI/mint log for this decorated resource.
+        # For a versioned resource, use its own version; for a parent resource, use the
+        # latest citable child version that would carry the DOI.
+        def doi_resource_version
+          if resource.is_a_version?
+            resource.version
+          else
+            parent_resource.latest_citable_resource&.version
           end
         end
 

--- a/lib/seek/bio_schema/resource_decorators/creative_work.rb
+++ b/lib/seek/bio_schema/resource_decorators/creative_work.rb
@@ -19,11 +19,22 @@ module Seek
                         part_of: :isPartOf,
                         doi: :identifier,
                         previous_version_url: :isBasedOn,
-                        docs_and_sops: :documentation
+                        docs_and_sops: :documentation,
+                        date_published: :datePublished
 
 
         def doi
           "https://doi.org/#{resource.doi}" if resource.try(:doi).present?
+        end
+
+        # If a DOI has been minted, use the date of minting as the publication date
+        def date_published
+          parent = resource.is_a_version? ? resource.parent : resource
+
+          return unless parent.supports_doi? && parent.has_doi?
+          return unless AssetDoiLog.was_doi_minted_for?(parent.class.name, parent.id, resource.version)
+
+          AssetDoiLog.minted.where(asset: parent, asset_version: resource.version).order(:created_at).last&.created_at&.iso8601
         end
 
         def content_type

--- a/lib/seek/bio_schema/resource_decorators/creative_work.rb
+++ b/lib/seek/bio_schema/resource_decorators/creative_work.rb
@@ -49,7 +49,7 @@ module Seek
 
         def all_creators
           # This should be greatly improved but would rely on SEEK being changed
-          others = other_creators&.split(',')&.collect(&:strip)&.compact || []
+          others = other_creators&.split(',')&.map(&:strip)&.compact || []
           others = others.collect { |name| { "@type": 'Person',"@id": "##{ROCrate::Entity.format_id(name)}", "name": name } }
           all = mini_definitions(assets_creators) + others
           return if all.empty?
@@ -66,7 +66,7 @@ module Seek
         def publications
           return unless parent_resource.respond_to?(:publications)
 
-          parent_resource.publications.map do |publication|
+          parent_resource.publications.select(&:public?).map do |publication|
             {
               '@type' => 'ScholarlyArticle',
               '@id' => publication.rdf_resource.to_s,

--- a/lib/seek/bio_schema/resource_decorators/creative_work.rb
+++ b/lib/seek/bio_schema/resource_decorators/creative_work.rb
@@ -5,7 +5,8 @@ module Seek
       class CreativeWork < Thing
         associated_items producer: :projects,
                          part_of: :collections,
-                         subject_of: :events
+                         subject_of: :events,
+                         docs_and_sops: %i[documents sops]
 
         schema_mappings version: :version,
                         license: :license,
@@ -17,7 +18,9 @@ module Seek
                         subject_of: :subjectOf,
                         part_of: :isPartOf,
                         doi: :identifier,
-                        previous_version_url: :isBasedOn
+                        previous_version_url: :isBasedOn,
+                        docs_and_sops: :documentation
+
 
         def doi
           "https://doi.org/#{resource.doi}" if resource.try(:doi).present?
@@ -44,7 +47,6 @@ module Seek
 
           all
         end
-
 
         def previous_version_url
           return unless respond_to?(:previous_version) && resource.previous_version

--- a/lib/seek/bio_schema/resource_decorators/dataset.rb
+++ b/lib/seek/bio_schema/resource_decorators/dataset.rb
@@ -47,6 +47,7 @@ module Seek
         def keywords
           []
         end
+
       end
     end
   end

--- a/lib/seek/bio_schema/resource_decorators/person.rb
+++ b/lib/seek/bio_schema/resource_decorators/person.rb
@@ -12,7 +12,7 @@ module Seek
                         last_name: :familyName,
                         image: :image,
                         member_of: :memberOf,
-                        orcid: :orcid,
+                        orcid: :identifier,
                         works_for: :worksFor
 
         def conformance

--- a/lib/seek/bio_schema/resource_decorators/workflow.rb
+++ b/lib/seek/bio_schema/resource_decorators/workflow.rb
@@ -10,10 +10,16 @@ module Seek
         schema_mappings programming_language: :programmingLanguage,
                         inputs: :input,
                         outputs: :output,
-                        sd_publisher: :sdPublisher
+                        sd_publisher: :sdPublisher,
+                        maturity: :creativeWorkStatus
+
 
         def contributors
           [contributor]
+        end
+
+        def maturity
+          I18n.t("maturity_level.#{resource.maturity_level}")
         end
 
         def conformance

--- a/lib/seek/bio_schema/resource_decorators/workflow.rb
+++ b/lib/seek/bio_schema/resource_decorators/workflow.rb
@@ -7,12 +7,14 @@ module Seek
 
         FORMALPARAMETER_PROFILE = 'https://bioschemas.org/profiles/FormalParameter/1.0-RELEASE/'.freeze
 
+        associated_items docs_and_sops: %i[documents sops]
+
         schema_mappings programming_language: :programmingLanguage,
                         inputs: :input,
                         outputs: :output,
                         sd_publisher: :sdPublisher,
-                        maturity: :creativeWorkStatus
-
+                        maturity: :creativeWorkStatus,
+                        docs_and_sops: :documentation
 
         def contributors
           [contributor]

--- a/lib/seek/bio_schema/resource_decorators/workflow.rb
+++ b/lib/seek/bio_schema/resource_decorators/workflow.rb
@@ -19,6 +19,8 @@ module Seek
         end
 
         def maturity
+          return nil unless resource.maturity_level.present?
+
           I18n.t("maturity_level.#{resource.maturity_level}")
         end
 

--- a/lib/seek/doi/acts_as_doi_mintable.rb
+++ b/lib/seek/doi/acts_as_doi_mintable.rb
@@ -140,7 +140,7 @@ module Seek
         end
 
         def doi_resource_suffix
-          version if respond_to?(:version) && !version.nil?
+          version if respond_to?(:version)
         end
 
         def create_log

--- a/test/unit/bio_schema/decorator_test.rb
+++ b/test/unit/bio_schema/decorator_test.rb
@@ -22,7 +22,6 @@ class DecoratorTest < ActiveSupport::TestCase
     document = FactoryBot.create(:document, events: [event], license: 'CC-BY-4.0', creators: [FactoryBot.create(:person)], doi: '10.10.10.10/test.1')
     document.add_annotations('yellow, lorry', 'tag', User.first)
     disable_authorization_checks { document.save! }
-    published_date = Time.now + 1.day
     doi_log = travel_to(Time.now + 1.day) do
       AssetDoiLog.create!(asset: document, doi: '10.10.10.10/test.1', asset_version: document.version,
                           action: AssetDoiLog::MINT, user: document.contributor.user)

--- a/test/unit/bio_schema/decorator_test.rb
+++ b/test/unit/bio_schema/decorator_test.rb
@@ -31,7 +31,7 @@ class DecoratorTest < ActiveSupport::TestCase
     end
     document.latest_version.update_column(:doi, '10.10.10.10/test.1')
 
-    decorator = Seek::BioSchema::ResourceDecorators::Document.new(document)
+    decorator = Seek::BioSchema::ResourceDecorators::CreativeWork.new(document)
     identifier = "http://localhost:3000/documents/#{document.id}"
     assert_equal identifier, decorator.identifier
     assert_equal %w[lorry yellow], decorator.keywords.split(',').collect(&:strip).sort
@@ -50,6 +50,28 @@ class DecoratorTest < ActiveSupport::TestCase
 
     properties = decorator.attributes.collect(&:property).collect(&:to_s).sort
     assert_equal %w[@id citation creator dateCreated dateModified datePublished description encodingFormat identifier image isBasedOn isPartOf keywords license name producer subjectOf url version], properties
+  end
+
+  test 'CreativeWork uses the last published version for datePublished' do
+    publication = FactoryBot.create(:publication, policy: FactoryBot.create(:public_policy))
+    sop = FactoryBot.create(:sop, license: 'CC-BY-4.0', creators: [FactoryBot.create(:person)],
+                                  doi: '10.10.10.10/test.1', publications: [publication])
+    doi_log = travel_to(Time.now + 1.day) do
+      AssetDoiLog.create!(asset: sop, doi: '10.10.10.10/test.1', asset_version: sop.version,
+                          action: AssetDoiLog::MINT, user: sop.contributor.user)
+    end
+    sop.latest_version.update_column(:doi, '10.10.10.10/test.1')
+    disable_authorization_checks do
+      sop.save_as_new_version
+      sop.update(description: 'version 2 description', title: 'version 2 title')
+    end
+    assert_equal 2, sop.versions.count
+    assert_nil sop.latest_version.doi
+    decorator = Seek::BioSchema::ResourceDecorators::CreativeWork.new(sop)
+    assert_equal doi_log.created_at.iso8601, decorator.date_published
+
+    decorator = Seek::BioSchema::ResourceDecorators::CreativeWork.new(sop.latest_version)
+    assert_nil decorator.date_published
   end
 
   test 'Dataset pads or truncates description' do

--- a/test/unit/bio_schema/decorator_test.rb
+++ b/test/unit/bio_schema/decorator_test.rb
@@ -19,7 +19,10 @@ class DecoratorTest < ActiveSupport::TestCase
 
   test 'CreativeWork' do
     event = FactoryBot.create(:event, policy: FactoryBot.create(:public_policy))
-    document = FactoryBot.create(:document, events: [event], license: 'CC-BY-4.0', creators: [FactoryBot.create(:person)], doi: '10.10.10.10/test.1')
+    publication = FactoryBot.create(:publication, policy: FactoryBot.create(:public_policy))
+    document = FactoryBot.create(:document, events: [event],
+                                            license: 'CC-BY-4.0', creators: [FactoryBot.create(:person)],
+                                            doi: '10.10.10.10/test.1', publications: [publication])
     document.add_annotations('yellow, lorry', 'tag', User.first)
     disable_authorization_checks { document.save! }
     doi_log = travel_to(Time.now + 1.day) do
@@ -41,9 +44,12 @@ class DecoratorTest < ActiveSupport::TestCase
     assert_equal [{ :@type => ['Project','Organization'], :@id => "http://localhost:3000/projects/#{project.id}", :name => project.title }], decorator.producer
     assert_equal [{ :@type => 'Person', :@id => "http://localhost:3000/people/#{person.id}", :name => person.title }], decorator.all_creators
     assert_equal doi_log.created_at.iso8601, decorator.date_published
+    assert_equal [ { '@type' => 'ScholarlyArticle', '@id' => "http://localhost:3000/publications/#{publication.id}", 'name' => publication.title } ],
+                      decorator.publications
+    
 
     properties = decorator.attributes.collect(&:property).collect(&:to_s).sort
-    assert_equal %w[@id creator dateCreated dateModified datePublished description encodingFormat identifier image isBasedOn isPartOf keywords license name producer subjectOf url version], properties
+    assert_equal %w[@id citation creator dateCreated dateModified datePublished description encodingFormat identifier image isBasedOn isPartOf keywords license name producer subjectOf url version], properties
   end
 
   test 'Dataset pads or truncates description' do

--- a/test/unit/bio_schema/decorator_test.rb
+++ b/test/unit/bio_schema/decorator_test.rb
@@ -22,6 +22,12 @@ class DecoratorTest < ActiveSupport::TestCase
     document = FactoryBot.create(:document, events: [event], license: 'CC-BY-4.0', creators: [FactoryBot.create(:person)], doi: '10.10.10.10/test.1')
     document.add_annotations('yellow, lorry', 'tag', User.first)
     disable_authorization_checks { document.save! }
+    published_date = Time.now + 1.day
+    doi_log = travel_to(Time.now + 1.day) do
+      AssetDoiLog.create!(asset: document, doi: '10.10.10.10/test.1', asset_version: document.version,
+                          action: AssetDoiLog::MINT, user: document.contributor.user)
+    end
+    document.latest_version.update_column(:doi, '10.10.10.10/test.1')
 
     decorator = Seek::BioSchema::ResourceDecorators::Document.new(document)
     identifier = "http://localhost:3000/documents/#{document.id}"
@@ -35,6 +41,7 @@ class DecoratorTest < ActiveSupport::TestCase
     assert_equal [{ :@type => 'Event', :@id => "http://localhost:3000/events/#{event.id}", :name => event.title }], decorator.subject_of
     assert_equal [{ :@type => ['Project','Organization'], :@id => "http://localhost:3000/projects/#{project.id}", :name => project.title }], decorator.producer
     assert_equal [{ :@type => 'Person', :@id => "http://localhost:3000/people/#{person.id}", :name => person.title }], decorator.all_creators
+    assert_equal doi_log.created_at.iso8601, decorator.date_published
 
     properties = decorator.attributes.collect(&:property).collect(&:to_s).sort
     assert_equal %w[@id creator dateCreated dateModified datePublished description encodingFormat identifier image isBasedOn isPartOf keywords license name producer subjectOf url version], properties

--- a/test/unit/bio_schema/decorator_test.rb
+++ b/test/unit/bio_schema/decorator_test.rb
@@ -37,7 +37,7 @@ class DecoratorTest < ActiveSupport::TestCase
     assert_equal [{ :@type => 'Person', :@id => "http://localhost:3000/people/#{person.id}", :name => person.title }], decorator.all_creators
 
     properties = decorator.attributes.collect(&:property).collect(&:to_s).sort
-    assert_equal %w[@id creator dateCreated dateModified description documentation encodingFormat identifier image isBasedOn isPartOf keywords license name producer subjectOf url version], properties
+    assert_equal %w[@id creator dateCreated dateModified datePublished description documentation encodingFormat identifier image isBasedOn isPartOf keywords license name producer subjectOf url version], properties
   end
 
   test 'Dataset pads or truncates description' do

--- a/test/unit/bio_schema/decorator_test.rb
+++ b/test/unit/bio_schema/decorator_test.rb
@@ -37,7 +37,7 @@ class DecoratorTest < ActiveSupport::TestCase
     assert_equal [{ :@type => 'Person', :@id => "http://localhost:3000/people/#{person.id}", :name => person.title }], decorator.all_creators
 
     properties = decorator.attributes.collect(&:property).collect(&:to_s).sort
-    assert_equal %w[@id creator dateCreated dateModified description encodingFormat identifier image isBasedOn isPartOf keywords license name producer subjectOf url version], properties
+    assert_equal %w[@id creator dateCreated dateModified description documentation encodingFormat identifier image isBasedOn isPartOf keywords license name producer subjectOf url version], properties
   end
 
   test 'Dataset pads or truncates description' do

--- a/test/unit/bio_schema/decorator_test.rb
+++ b/test/unit/bio_schema/decorator_test.rb
@@ -37,7 +37,7 @@ class DecoratorTest < ActiveSupport::TestCase
     assert_equal [{ :@type => 'Person', :@id => "http://localhost:3000/people/#{person.id}", :name => person.title }], decorator.all_creators
 
     properties = decorator.attributes.collect(&:property).collect(&:to_s).sort
-    assert_equal %w[@id creator dateCreated dateModified datePublished description documentation encodingFormat identifier image isBasedOn isPartOf keywords license name producer subjectOf url version], properties
+    assert_equal %w[@id creator dateCreated dateModified datePublished description encodingFormat identifier image isBasedOn isPartOf keywords license name producer subjectOf url version], properties
   end
 
   test 'Dataset pads or truncates description' do

--- a/test/unit/bio_schema/schema_ld_generation_test.rb
+++ b/test/unit/bio_schema/schema_ld_generation_test.rb
@@ -470,7 +470,8 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
                                    maturity_level: :released,
                                    documents: [document],
                                    sops: [sop],
-                                   license: 'APSL-2.0', doi: '10.10.10.10/test.1')
+                                   license: 'APSL-2.0',
+                                   doi: '10.10.10.10/test.1')
 
       workflow.assets_creators.create!(creator: @person, pos: 1)
       workflow.assets_creators.create!(creator: creator2, pos: 2)
@@ -485,6 +486,11 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
       disable_authorization_checks { workflow.save! }
       workflow
     end
+    travel_to(@current_time + 1.day) do
+      AssetDoiLog.create!(asset: workflow, doi: '10.10.10.10/test.1', asset_version: workflow.version,
+                          action: AssetDoiLog::MINT, user: @person.user)
+    end
+    workflow.latest_version.update_column(:doi, '10.10.10.10/test.1')
 
     assert_equal [sop], workflow.sops
     assert_equal [document], workflow.documents
@@ -520,6 +526,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
       ],
       'dateCreated' => @current_time.iso8601,
       'dateModified' => @current_time.iso8601,
+      'datePublished' => (@current_time + 1.day).iso8601,
       'encodingFormat' => 'application/x-yaml',
       'sdPublisher' => {
         '@type' => 'Organization',

--- a/test/unit/bio_schema/schema_ld_generation_test.rb
+++ b/test/unit/bio_schema/schema_ld_generation_test.rb
@@ -191,7 +191,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     }
 
     json = JSON.parse(df.to_schema_ld)
-    assert_equal expected, json
+    fine_json_comparison expected, json
     check_version(df.latest_version, expected)
   end
 
@@ -241,7 +241,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     }
 
     json = JSON.parse(df.to_schema_ld)
-    assert_equal expected, json
+    fine_json_comparison expected, json
     check_version(df.latest_version, expected)
   end
 
@@ -290,7 +290,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     }
 
     json = JSON.parse(df.to_schema_ld)
-    assert_equal expected, json
+    fine_json_comparison expected, json
     check_version(df.latest_version, expected)
   end
 
@@ -422,7 +422,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     }
 
     json = JSON.parse(document.to_schema_ld)
-    assert_equal expected, json
+    fine_json_comparison expected, json
     check_version(document.latest_version, expected)
   end
 
@@ -454,19 +454,23 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     }
 
     json = JSON.parse(presentation.to_schema_ld)
-    assert_equal expected, json
+    fine_json_comparison expected, json
     check_version(presentation.latest_version, expected)
   end
 
   test 'workflow' do
     creator2 = FactoryBot.create(:person)
+    sop = FactoryBot.create(:sop, contributor: @person, projects: [@project], policy: FactoryBot.create(:public_policy))
+    document = FactoryBot.create(:document, contributor: @person, projects: [@project], policy: FactoryBot.create(:public_policy))
     workflow = travel_to(@current_time) do
       workflow = FactoryBot.create(:cwl_packed_workflow,
-                         title: 'This workflow',
-                         description: 'This is a test workflow for bioschema generation',
-                         contributor: @person,
-                         maturity_level: :released,
-                         license: 'APSL-2.0', doi: '10.10.10.10/test.1')
+                                   title: 'This workflow',
+                                   description: 'This is a test workflow for bioschema generation',
+                                   contributor: @person,
+                                   maturity_level: :released,
+                                   documents: [document],
+                                   sops: [sop],
+                                   license: 'APSL-2.0', doi: '10.10.10.10/test.1')
 
       workflow.assets_creators.create!(creator: @person, pos: 1)
       workflow.assets_creators.create!(creator: creator2, pos: 2)
@@ -481,6 +485,9 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
       disable_authorization_checks { workflow.save! }
       workflow
     end
+
+    assert_equal [sop], workflow.sops
+    assert_equal [document], workflow.documents
 
     expected_wf_prefix = workflow.title.downcase.gsub(/[^0-9a-z]/i, '_')
 
@@ -506,6 +513,10 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
       'producer' => [
         { '@type' => %w[Project Organization], '@id' => "http://localhost:3000/projects/#{@project.id}",
           'name' => @project.title }
+      ],
+      'documentation' => [
+        { '@type' => 'DigitalDocument', '@id' => "http://localhost:3000/documents/#{document.id}", 'name' => document.title },
+        { '@type' => 'LabProtocol', '@id' => "http://localhost:3000/sops/#{sop.id}", 'name' => sop.title }
       ],
       'dateCreated' => @current_time.iso8601,
       'dateModified' => @current_time.iso8601,
@@ -835,9 +846,9 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     }
 
     json = JSON.parse(df.find_version(1).to_schema_ld)
-    assert_equal v1_expected, json
+    fine_json_comparison v1_expected, json
     json = JSON.parse(df.find_version(2).to_schema_ld)
-    assert_equal v2_expected, json
+    fine_json_comparison v2_expected, json
   end
 
   test 'dataset without data dump' do
@@ -939,7 +950,8 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     }
 
     json = JSON.parse(sop.to_schema_ld)
-    assert_equal expected, json
+    fine_json_comparison expected, json
+    check_version(sop.latest_version, expected)
   end
 
   private

--- a/test/unit/bio_schema/schema_ld_generation_test.rb
+++ b/test/unit/bio_schema/schema_ld_generation_test.rb
@@ -465,6 +465,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
                          title: 'This workflow',
                          description: 'This is a test workflow for bioschema generation',
                          contributor: @person,
+                         maturity_level: :released,
                          license: 'APSL-2.0', doi: '10.10.10.10/test.1')
 
       workflow.assets_creators.create!(creator: @person, pos: 1)
@@ -493,6 +494,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
       'url' => "http://localhost:3000/workflows/#{workflow.id}",
       'keywords' => 'wibble',
       'license' => Seek::License.find('APSL-2.0')&.url,
+      'creativeWorkStatus' => 'Stable',
       'identifier' => 'https://doi.org/10.10.10.10/test.1',
       'creator' => [
         { '@type' => 'Person', '@id' => "http://localhost:3000/people/#{@person.id}", 'name' => @person.name },

--- a/test/unit/bio_schema/schema_ld_generation_test.rb
+++ b/test/unit/bio_schema/schema_ld_generation_test.rb
@@ -133,7 +133,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
         { '@type' => 'ResearchOrganization', '@id' => "http://localhost:3000/institutions/#{institution.id}",
           'name' => institution.title }
       ],
-      'orcid' => 'https://orcid.org/0000-0001-9842-9718'
+      'identifier' => 'https://orcid.org/0000-0001-9842-9718'
     }
 
     json = JSON.parse(@person.to_schema_ld)

--- a/test/unit/bio_schema/schema_ld_generation_test.rb
+++ b/test/unit/bio_schema/schema_ld_generation_test.rb
@@ -151,6 +151,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
 
     assert df.can_download?
     refute df.content_blob.show_as_external_link?
+    publication = df.publications.first
 
     expected = {
       '@context' => Seek::BioSchema::Serializer::SCHEMA_ORG,
@@ -181,6 +182,9 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
           'name' => df.events.first.title }
       ],
       'isPartOf' => [],
+      'citation' => [
+        { '@type' => 'ScholarlyArticle', '@id' => "http://localhost:3000/publications/#{publication.id}", 'name' => publication.title }
+      ],
       'distribution' => {
         '@type' => 'DataDownload',
         'contentSize' => '8.62 KB',
@@ -210,6 +214,8 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     df.reload
     assert_nil df.content_blob
 
+    publication = df.publications.first
+
     expected = {
       '@context' => Seek::BioSchema::Serializer::SCHEMA_ORG,
       '@type' => 'Dataset',
@@ -234,6 +240,9 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
       'dateModified' => @current_time.iso8601,
       'identifier' => 'https://doi.org/10.10.10.10/test.1',
       'isPartOf' => [],
+      'citation' => [
+        { '@type' => 'ScholarlyArticle', '@id' => "http://localhost:3000/publications/#{publication.id}", 'name' => publication.title }
+      ],
       'subjectOf' => [
         { '@type' => 'Event', '@id' => "http://localhost:3000/events/#{df.events.first.id}",
           'name' => df.events.first.title }
@@ -257,6 +266,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
 
     assert df.can_download?
     assert df.content_blob.show_as_external_link?
+    publication = df.publications.first
 
     expected = {
       '@context' => Seek::BioSchema::Serializer::SCHEMA_ORG,
@@ -283,6 +293,9 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
       'encodingFormat' => 'text/html',
       'identifier' => 'https://doi.org/10.10.10.10/test.1',
       'isPartOf' => [],
+      'citation' => [
+        { '@type' => 'ScholarlyArticle', '@id' => "http://localhost:3000/publications/#{publication.id}", 'name' => publication.title }
+      ],
       'subjectOf' => [
         { '@type' => 'Event', '@id' => "http://localhost:3000/events/#{df.events.first.id}",
           'name' => df.events.first.title }
@@ -418,6 +431,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
       ],
       'identifier' => 'https://doi.org/10.10.10.10/test.1',
       'isPartOf' => [],
+      'citation' => [],
       'subjectOf' => []
     }
 
@@ -450,6 +464,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
           '@id' => "http://localhost:3000/projects/#{presentation.projects.first.id}", 'name' => presentation.projects.first.title }
       ],
       'isPartOf' => [],
+      'citation' => [],
       'subjectOf' => []
     }
 
@@ -462,6 +477,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     creator2 = FactoryBot.create(:person)
     sop = FactoryBot.create(:sop, contributor: @person, projects: [@project], policy: FactoryBot.create(:public_policy))
     document = FactoryBot.create(:document, contributor: @person, projects: [@project], policy: FactoryBot.create(:public_policy))
+    publication = FactoryBot.create(:publication, contributor: @person, projects: [@project])
     workflow = travel_to(@current_time) do
       workflow = FactoryBot.create(:cwl_packed_workflow,
                                    title: 'This workflow',
@@ -470,6 +486,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
                                    maturity_level: :released,
                                    documents: [document],
                                    sops: [sop],
+                                   publications: [publication],
                                    license: 'APSL-2.0',
                                    doi: '10.10.10.10/test.1')
 
@@ -523,6 +540,9 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
       'documentation' => [
         { '@type' => 'DigitalDocument', '@id' => "http://localhost:3000/documents/#{document.id}", 'name' => document.title },
         { '@type' => 'LabProtocol', '@id' => "http://localhost:3000/sops/#{sop.id}", 'name' => sop.title }
+      ],
+      'citation' => [
+        { '@type' => 'ScholarlyArticle', '@id' => "http://localhost:3000/publications/#{publication.id}", 'name' => publication.title }
       ],
       'dateCreated' => @current_time.iso8601,
       'dateModified' => @current_time.iso8601,
@@ -612,6 +632,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     end
 
     project = collection.projects.first
+    publication = collection.publications.first
     sel_assets = []
     collection.assets.each do |a|
       next if a.blank?
@@ -649,6 +670,9 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
       'dateCreated' => @current_time.iso8601,
       'dateModified' => @current_time.iso8601,
       'isPartOf' => [],
+      'citation' => [
+        { '@type' => 'ScholarlyArticle', '@id' => "http://localhost:3000/publications/#{publication.id}", 'name' => publication.title }
+      ],
       'hasPart' => [
         { '@type' => 'DigitalDocument', '@id' => "http://localhost:3000/documents/#{doc1.id}",
           'name' => doc1.title.to_s },
@@ -774,6 +798,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
 
     assert df.can_download?
     refute df.content_blob.show_as_external_link?
+    publication = df.publications.first
 
     v1_expected = {
       '@context' => Seek::BioSchema::Serializer::SCHEMA_ORG,
@@ -799,6 +824,9 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
       'encodingFormat' => 'application/pdf',
       'version' => 1,
       'isPartOf' => [],
+      'citation' => [
+        { '@type' => 'ScholarlyArticle', '@id' => "http://localhost:3000/publications/#{publication.id}", 'name' => publication.title }
+      ],
       # 'identifier' => 'https://doi.org/10.10.10.10/test.1', # Should not have a DOI, since it was defined on the parent resource
       'subjectOf' => [
         { '@type' => 'Event', '@id' => "http://localhost:3000/events/#{df.events.first.id}",
@@ -837,6 +865,9 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
       'encodingFormat' => 'image/png',
       'version' => 2,
       'isPartOf' => [],
+      'citation' => [
+        { '@type' => 'ScholarlyArticle', '@id' => "http://localhost:3000/publications/#{publication.id}", 'name' => publication.title }
+      ],
       'identifier' => 'https://doi.org/10.10.10.10/test.2', # This DOI was added to the version itself
       'isBasedOn' => "http://localhost:3000/data_files/#{df.id}?version=1",
       'subjectOf' => [
@@ -936,6 +967,8 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
       sop
     end
 
+    publication = sop.publications.first
+
     expected = {
       '@context' => Seek::BioSchema::Serializer::SCHEMA_ORG,
       '@type' => 'LabProtocol',
@@ -953,6 +986,9 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
       'dateModified' => @current_time.iso8601,
       'encodingFormat' => 'application/pdf',
       'isPartOf' => [{ '@type' => 'Collection', '@id' => "http://localhost:3000/collections/#{collection.id}", 'name' => 'A collection' }],
+      'citation' => [
+        { '@type' => 'ScholarlyArticle', '@id' => "http://localhost:3000/publications/#{publication.id}", 'name' => publication.title }
+      ],
       'computationalTool' => [{ '@type' => %w[SoftwareSourceCode ComputationalWorkflow], '@id' => "http://localhost:3000/workflows/#{sop.workflows.first.id}", 'name' => 'This Workflow' }]
     }
 

--- a/test/unit/bio_schema/schema_ld_generation_test.rb
+++ b/test/unit/bio_schema/schema_ld_generation_test.rb
@@ -477,16 +477,22 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     creator2 = FactoryBot.create(:person)
     sop = FactoryBot.create(:sop, contributor: @person, projects: [@project], policy: FactoryBot.create(:public_policy))
     document = FactoryBot.create(:document, contributor: @person, projects: [@project], policy: FactoryBot.create(:public_policy))
-    publication = FactoryBot.create(:publication, contributor: @person, projects: [@project])
+    publication = FactoryBot.create(:publication, contributor: @person, projects: [@project], policy: FactoryBot.create(:public_policy))
+
+    # some private ones that shouldn't show up
+    private_sop = FactoryBot.create(:sop, contributor: @person, projects: [@project], policy: FactoryBot.create(:private_policy))
+    private_document = FactoryBot.create(:document, contributor: @person, projects: [@project], policy: FactoryBot.create(:private_policy))
+    private_publication = FactoryBot.create(:publication, contributor: @person, projects: [@project], policy: FactoryBot.create(:private_policy))
+
     workflow = travel_to(@current_time) do
       workflow = FactoryBot.create(:cwl_packed_workflow,
                                    title: 'This workflow',
                                    description: 'This is a test workflow for bioschema generation',
                                    contributor: @person,
                                    maturity_level: :released,
-                                   documents: [document],
-                                   sops: [sop],
-                                   publications: [publication],
+                                   documents: [document, private_document],
+                                   sops: [sop, private_sop],
+                                   publications: [publication, private_publication],
                                    license: 'APSL-2.0',
                                    doi: '10.10.10.10/test.1')
 
@@ -509,8 +515,9 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     end
     workflow.latest_version.update_column(:doi, '10.10.10.10/test.1')
 
-    assert_equal [sop], workflow.sops
-    assert_equal [document], workflow.documents
+    assert_equal [sop, private_sop].sort, workflow.sops.sort
+    assert_equal [document, private_document].sort, workflow.documents.sort
+    assert_equal [publication, private_publication].sort, workflow.publications.sort
 
     expected_wf_prefix = workflow.title.downcase.gsub(/[^0-9a-z]/i, '_')
 


### PR DESCRIPTION
* fix for #2546

* Add citation (from associated Publications) and datePublished (from DOI mint logs) to CreativeWork JSON-LD.
* Extend Workflow JSON-LD with creativeWorkStatus (maturity) and documentation (Documents + SOPs).
* Update Person JSON-LD to emit ORCID under identifier (instead of orcid) and update tests accordingly.

skipped `contributor` for now, as the schema.org has a different meaning and is for secondary contributors