### PR TITLE
Update workflow context to point to bioschemas and add dct namespace636 compact computational workflow

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -817,7 +817,7 @@ GEM
     rmagick (6.1.1)
       observer (~> 0.1)
       pkg-config (~> 1.4)
-    ro-crate (0.6.0)
+    ro-crate (0.7.0)
       addressable (>= 2.7, < 3)
       rubyzip (>= 2.3, < 4)
     rouge (4.5.1)

--- a/lib/seek/bio_schema/resource_decorators/base_decorator.rb
+++ b/lib/seek/bio_schema/resource_decorators/base_decorator.rb
@@ -26,7 +26,10 @@ module Seek
 
         # The @context to be used for the JSON-LD
         def context
-          Seek::BioSchema::Serializer::SCHEMA_ORG
+          {
+            '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+            dct: Seek::BioSchema::Serializer::DCT
+          }
         end
 
         # The schema.org @type .

--- a/lib/seek/bio_schema/resource_decorators/base_decorator.rb
+++ b/lib/seek/bio_schema/resource_decorators/base_decorator.rb
@@ -26,10 +26,12 @@ module Seek
 
         # The @context to be used for the JSON-LD
         def context
-          {
+          ctx = {
             '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
             dct: Seek::BioSchema::Serializer::DCT
           }
+          ctx.merge!(additional_contexts) if respond_to?(:additional_contexts)
+          ctx
         end
 
         def mini_context
@@ -93,12 +95,12 @@ module Seek
               end
             end
 
-            define_method(:context) do
+            define_method(:additional_contexts) do
               ctx = {}
               pairs.each_value do |collection|
                 ctx.merge!(mini_contexts(send(collection))) if respond_to?(collection)
               end
-              ctx.merge!(super())
+              ctx
             end
           end
 

--- a/lib/seek/bio_schema/resource_decorators/base_decorator.rb
+++ b/lib/seek/bio_schema/resource_decorators/base_decorator.rb
@@ -87,10 +87,11 @@ module Seek
           #   returns nil if no methods match, otherwise returns an array even if empty
           # Also adds to the additional_context the context for each item in the associated resources
           def associated_items(**pairs)
-            pairs.each do |method, collection|
+            pairs.each do |method, collections|
               define_method(method) do
                 valid_methods = Array(collections).select{ |c| respond_to?(c) }
                 return nil if valid_methods.empty?
+
                 valid_methods.map do |collection|
                   @additional_context.merge!(additional_contexts(send(collection)))
                   mini_definitions(send(collection))

--- a/lib/seek/bio_schema/resource_decorators/base_decorator.rb
+++ b/lib/seek/bio_schema/resource_decorators/base_decorator.rb
@@ -93,8 +93,9 @@ module Seek
                 return nil if valid_methods.empty?
 
                 valid_methods.map do |collection|
-                  @additional_context.merge!(additional_contexts(send(collection)))
-                  mini_definitions(send(collection))
+                  items = send(collection)
+                  @additional_context.merge!(additional_contexts(items))
+                  mini_definitions(items)
                 end.flatten.compact
               end
             end

--- a/lib/seek/bio_schema/resource_decorators/event.rb
+++ b/lib/seek/bio_schema/resource_decorators/event.rb
@@ -4,6 +4,9 @@ module Seek
       # Decorator that provides extensions for a Event
       class Event < Thing
         EVENT_PROFILE = 'https://bioschemas.org/profiles/Event/0.3-DRAFT'.freeze
+        HOST_INSTITUTION_PROPERTY = 'https://bioschemas.org/properties/hostInstitution'.freeze
+        CONTACT_PROPERTY = 'https://bioschemas.org/properties/contact'.freeze
+        EVENT_TYPE_PROPERTY = 'https://bioschemas.org/properties/eventType'.freeze
 
         associated_items contact: :contributors,
                          host_institution: :projects,
@@ -18,6 +21,14 @@ module Seek
                         all_assets: :about,
                         created_at: :dateCreated,
                         updated_at: :dateModified
+
+        def context
+          super.merge(
+            contact: CONTACT_PROPERTY,
+            eventType: EVENT_TYPE_PROPERTY,
+            hostInstitution: HOST_INSTITUTION_PROPERTY
+          )
+        end
 
         def conformance
           EVENT_PROFILE

--- a/lib/seek/bio_schema/resource_decorators/event.rb
+++ b/lib/seek/bio_schema/resource_decorators/event.rb
@@ -4,9 +4,9 @@ module Seek
       # Decorator that provides extensions for a Event
       class Event < Thing
         EVENT_PROFILE = 'https://bioschemas.org/profiles/Event/0.3-DRAFT'.freeze
-        HOST_INSTITUTION_PROPERTY = 'https://bioschemas.org/properties/hostInstitution'.freeze
-        CONTACT_PROPERTY = 'https://bioschemas.org/properties/contact'.freeze
-        EVENT_TYPE_PROPERTY = 'https://bioschemas.org/properties/eventType'.freeze
+        HOST_INSTITUTION_PROPERTY = 'https://bioschemas.org/terms/hostInstitution'.freeze
+        CONTACT_PROPERTY = 'https://bioschemas.org/terms/contact'.freeze
+        EVENT_TYPE_PROPERTY = 'https://bioschemas.org/terms/eventType'.freeze
 
         associated_items contact: :contributors,
                          host_institution: :projects,

--- a/lib/seek/bio_schema/resource_decorators/organism.rb
+++ b/lib/seek/bio_schema/resource_decorators/organism.rb
@@ -1,7 +1,7 @@
 module Seek
   module BioSchema
     module ResourceDecorators
-      # Decorator that provides extensions for a Organism
+      # Decorator that provides extensions for an Organism
       class Organism < Thing
         schema_mappings synonyms: :alternateName,
                         ncbi_uri: :sameAs

--- a/lib/seek/bio_schema/resource_decorators/person.rb
+++ b/lib/seek/bio_schema/resource_decorators/person.rb
@@ -12,7 +12,7 @@ module Seek
                         last_name: :familyName,
                         image: :image,
                         member_of: :memberOf,
-                        orcid: :orcid,
+                        orcid: :identifier,
                         works_for: :worksFor
 
         def conformance

--- a/lib/seek/bio_schema/resource_decorators/person.rb
+++ b/lib/seek/bio_schema/resource_decorators/person.rb
@@ -3,8 +3,6 @@ module Seek
     module ResourceDecorators
       # Decorator that provides extensions for a Person
       class Person < Thing
-        PERSON_PROFILE = 'https://bioschemas.org/profiles/Person/0.3-DRAFT'.freeze
-
         associated_items member_of: :projects,
                          works_for: :institutions
 
@@ -14,10 +12,6 @@ module Seek
                         member_of: :memberOf,
                         orcid: :identifier,
                         works_for: :worksFor
-
-        def conformance
-          PERSON_PROFILE
-        end
 
         def url
           web_page.blank? ? identifier : web_page

--- a/lib/seek/bio_schema/resource_decorators/sample.rb
+++ b/lib/seek/bio_schema/resource_decorators/sample.rb
@@ -6,6 +6,11 @@ module Seek
         schema_mappings properties: :additionalProperty
 
         SAMPLE_PROFILE = 'https://bioschemas.org/profiles/Sample/0.2-RELEASE-2018_11_10/'.freeze
+        SAMPLE_TYPE = 'https://bioschemas.org/types/Sample/0.2-DRAFT-2018_11_09'.freeze
+
+        def context
+          super.merge(Sample: SAMPLE_TYPE)
+        end
 
         def schema_type
           'Sample'
@@ -31,7 +36,7 @@ module Seek
             'value' => value.to_s
           }
           if attribute.pid
-            data['propertyId'] = attribute.pid
+            data['propertyID'] = attribute.pid
           end
           resolved = attribute.resolve(value)
           data['identifier'] = resolved if resolved

--- a/lib/seek/bio_schema/resource_decorators/sop.rb
+++ b/lib/seek/bio_schema/resource_decorators/sop.rb
@@ -4,6 +4,7 @@ module Seek
       # Decorator that provides extensions for a Sop
       class Sop < CreativeWork
         LAB_PROTOCOL_TYPE = 'https://bioschemas.org/types/LabProtocol/0.5-DRAFT'.freeze
+        COMPUTATIONAL_TOOL_PROPERTY = 'https://bioschemas.org/terms/computationalTool'.freeze
 
         associated_items computational_tool: :workflows
         schema_mappings computational_tool: :computationalTool
@@ -11,12 +12,8 @@ module Seek
         def context
           super.merge(
             LabProtocol: LAB_PROTOCOL_TYPE,
-            computationalTool: "#{LAB_PROTOCOL_TYPE}#computationalTool"
+            computationalTool: COMPUTATIONAL_TOOL_PROPERTY
           )
-        end
-
-        def mini_context
-          super.merge(LabProtocol: LAB_PROTOCOL_TYPE)
         end
 
         def schema_type

--- a/lib/seek/bio_schema/resource_decorators/sop.rb
+++ b/lib/seek/bio_schema/resource_decorators/sop.rb
@@ -3,9 +3,21 @@ module Seek
     module ResourceDecorators
       # Decorator that provides extensions for a Sop
       class Sop < CreativeWork
+        LAB_PROTOCOL_TYPE = 'https://bioschemas.org/types/LabProtocol/0.5-DRAFT'.freeze
 
         associated_items computational_tool: :workflows
         schema_mappings computational_tool: :computationalTool
+
+        def context
+          super.merge(
+            LabProtocol: LAB_PROTOCOL_TYPE,
+            computationalTool: "#{LAB_PROTOCOL_TYPE}#computationalTool"
+          )
+        end
+
+        def mini_context
+          super.merge(LabProtocol: LAB_PROTOCOL_TYPE)
+        end
 
         def schema_type
           'LabProtocol'

--- a/lib/seek/bio_schema/resource_decorators/workflow.rb
+++ b/lib/seek/bio_schema/resource_decorators/workflow.rb
@@ -8,7 +8,6 @@ module Seek
         FORMALPARAMETER_PROFILE = 'https://bioschemas.org/profiles/FormalParameter/1.0-RELEASE/'.freeze
         FORMALPARAMETER_TYPE = 'https://bioschemas.org/FormalParameter'.freeze
 
-
         schema_mappings programming_language: :programmingLanguage,
                         inputs: :input,
                         outputs: :output,

--- a/lib/seek/bio_schema/resource_decorators/workflow.rb
+++ b/lib/seek/bio_schema/resource_decorators/workflow.rb
@@ -4,9 +4,11 @@ module Seek
       # Decorator that provides extensions for a Workflow
       class Workflow < CreativeWork
         WORKFLOW_PROFILE = 'https://bioschemas.org/profiles/ComputationalWorkflow/1.0-RELEASE/'.freeze
-        WORKFLOW_TYPE = 'https://bioschemas.org/ComputationalWorkflow'.freeze
+        WORKFLOW_TYPE = 'https://bioschemas.org/terms/ComputationalWorkflow'.freeze
         FORMALPARAMETER_PROFILE = 'https://bioschemas.org/profiles/FormalParameter/1.0-RELEASE/'.freeze
-        FORMALPARAMETER_TYPE = 'https://bioschemas.org/FormalParameter'.freeze
+        FORMALPARAMETER_TYPE = 'https://bioschemas.org/terms/FormalParameter'.freeze
+        INPUT_PROPERTY = 'https://bioschemas.org/terms/input'.freeze
+        OUTPUT_PROPERTY = 'https://bioschemas.org/terms/output'.freeze
 
         schema_mappings programming_language: :programmingLanguage,
                         inputs: :input,
@@ -15,15 +17,11 @@ module Seek
 
         def context
           super.merge(
-            input: "#{WORKFLOW_TYPE}#input",
-            output: "#{WORKFLOW_TYPE}#output",
+            input: INPUT_PROPERTY,
+            output: OUTPUT_PROPERTY,
             ComputationalWorkflow: WORKFLOW_TYPE,
             FormalParameter: FORMALPARAMETER_TYPE
           )
-        end
-
-        def mini_context
-          super.merge(ComputationalWorkflow: WORKFLOW_TYPE)
         end
 
         def contributors

--- a/lib/seek/bio_schema/resource_decorators/workflow.rb
+++ b/lib/seek/bio_schema/resource_decorators/workflow.rb
@@ -4,13 +4,24 @@ module Seek
       # Decorator that provides extensions for a Workflow
       class Workflow < CreativeWork
         WORKFLOW_PROFILE = 'https://bioschemas.org/profiles/ComputationalWorkflow/1.0-RELEASE/'.freeze
-
+        WORKFLOW_TYPE = 'https://bioschemas.org/ComputationalWorkflow'.freeze
         FORMALPARAMETER_PROFILE = 'https://bioschemas.org/profiles/FormalParameter/1.0-RELEASE/'.freeze
+        FORMALPARAMETER_TYPE = 'https://bioschemas.org/FormalParameter'.freeze
+
 
         schema_mappings programming_language: :programmingLanguage,
                         inputs: :input,
                         outputs: :output,
                         sd_publisher: :sdPublisher
+
+        def context
+          super.merge(
+            input: "#{WORKFLOW_TYPE}#input",
+            output: "#{WORKFLOW_TYPE}#output",
+            ComputationalWorkflow: WORKFLOW_TYPE,
+            FormalParameter: FORMALPARAMETER_TYPE
+          )
+        end
 
         def contributors
           [contributor]

--- a/lib/seek/bio_schema/resource_decorators/workflow.rb
+++ b/lib/seek/bio_schema/resource_decorators/workflow.rb
@@ -23,6 +23,10 @@ module Seek
           )
         end
 
+        def mini_context
+          super.merge(ComputationalWorkflow: WORKFLOW_TYPE)
+        end
+
         def contributors
           [contributor]
         end

--- a/lib/seek/bio_schema/serializer.rb
+++ b/lib/seek/bio_schema/serializer.rb
@@ -7,7 +7,8 @@ module Seek
       include ActionView::Helpers::SanitizeHelper
       attr_reader :resource
 
-      SCHEMA_ORG = 'https://schema.org'
+      SCHEMA_ORG = 'https://schema.org/'.freeze
+      DCT = 'http://purl.org/dc/terms/'.freeze
 
       # initialise with a resource
       def initialize(resource)

--- a/lib/seek/bio_schema/serializer.rb
+++ b/lib/seek/bio_schema/serializer.rb
@@ -24,6 +24,8 @@ module Seek
           representation['dct:conformsTo'] = { '@id' => resource_decorator.conformance }
         end
         representation = representation.merge(attributes_json)
+        # After attributes_json has been generated, additional context will be populated
+        representation['@context'].merge!(resource_decorator.additional_context)
         representation.deep_stringify_keys
       end
 

--- a/test/unit/bio_schema/data_dump_test.rb
+++ b/test/unit/bio_schema/data_dump_test.rb
@@ -97,7 +97,7 @@ class DataDumpTest < ActiveSupport::TestCase
 
     assert_equal 'workflows-bioschemas-dump.jsonld', dump.file_name
     assert dump.exists?
-    assert_in_delta 3800, dump.size, 500
+    assert_in_delta 5000, dump.size, 500
     assert_in_delta Time.now, dump.date_modified, 60
   end
 

--- a/test/unit/bio_schema/decorator_test.rb
+++ b/test/unit/bio_schema/decorator_test.rb
@@ -8,9 +8,13 @@ class DecoratorTest < ActiveSupport::TestCase
 
     decorator = Seek::BioSchema::ResourceDecorators::Thing.new(data_file)
     identifier = "http://localhost:3000/data_files/#{data_file.id}"
+    context = {
+      '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+      :dct => Seek::BioSchema::Serializer::DCT
+    }
     assert_equal identifier, decorator.identifier
     assert_equal identifier, decorator.url
-    assert_equal Seek::BioSchema::Serializer::SCHEMA_ORG, decorator.context
+    assert_equal context, decorator.context
     assert_equal %w[blue green red], decorator.keywords.split(',').collect(&:strip).sort
 
     properties = decorator.attributes.collect(&:property).collect(&:to_s).sort

--- a/test/unit/bio_schema/schema_ld_generation_test.rb
+++ b/test/unit/bio_schema/schema_ld_generation_test.rb
@@ -144,7 +144,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
         { '@type' => 'ResearchOrganization', '@id' => "http://localhost:3000/institutions/#{institution.id}",
           'name' => institution.title }
       ],
-      'orcid' => 'https://orcid.org/0000-0001-9842-9718'
+      'identifier' => 'https://orcid.org/0000-0001-9842-9718'
     }
 
     json = JSON.parse(@person.to_schema_ld)
@@ -366,7 +366,8 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     expected = {
       '@context' => {
         '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
-        'dct' => Seek::BioSchema::Serializer::DCT
+        'dct' => Seek::BioSchema::Serializer::DCT,
+        'Sample' => Seek::BioSchema::ResourceDecorators::Sample::SAMPLE_TYPE
       },
       '@type' => 'Sample',
       'dct:conformsTo' => { '@id' => Seek::BioSchema::ResourceDecorators::Sample::SAMPLE_PROFILE },
@@ -375,9 +376,9 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
       'url' => "http://localhost:3000/samples/#{sample.id}",
       'keywords' => 'keyword',
       'additionalProperty' => [
-        { '@type' => 'PropertyValue', 'name' => 'title', 'propertyId' => 'dc:title', 'value' => 'The Title' },
-        { '@type' => 'PropertyValue', 'name' => 'description', 'propertyId' => 'dc:description', 'value' => 'The Description' },
-        { '@type' => 'PropertyValue', 'name' => 'enzyme', 'propertyId' => 'http://purl.uniprot.org/core/enzyme', 'value' => 'EC 4.1.2.13' },
+        { '@type' => 'PropertyValue', 'name' => 'title', 'propertyID' => 'dc:title', 'value' => 'The Title' },
+        { '@type' => 'PropertyValue', 'name' => 'description', 'propertyID' => 'dc:description', 'value' => 'The Description' },
+        { '@type' => 'PropertyValue', 'name' => 'enzyme', 'propertyID' => 'http://purl.uniprot.org/core/enzyme', 'value' => 'EC 4.1.2.13' },
         { '@type' => 'PropertyValue', 'name' => 'weight', 'value' => '88700.2', 'unitCode' => 'g',
           'unitText' => 'gram' },
       ]
@@ -395,7 +396,10 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     expected = {
       '@context' => {
         '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
-        'dct' => Seek::BioSchema::Serializer::DCT
+        'dct' => Seek::BioSchema::Serializer::DCT,
+        'hostInstitution' => Seek::BioSchema::ResourceDecorators::Event::HOST_INSTITUTION_PROPERTY,
+        'contact' => Seek::BioSchema::ResourceDecorators::Event::CONTACT_PROPERTY,
+        'eventType' => Seek::BioSchema::ResourceDecorators::Event::EVENT_TYPE_PROPERTY
       },
       '@id' => "http://localhost:3000/events/#{event.id}",
       'dct:conformsTo' => { '@id' => Seek::BioSchema::ResourceDecorators::Event::EVENT_PROFILE },
@@ -660,7 +664,8 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     expected = {
       '@context' => {
         '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
-        'dct' => Seek::BioSchema::Serializer::DCT
+        'dct' => Seek::BioSchema::Serializer::DCT,
+        'LabProtocol' => Seek::BioSchema::ResourceDecorators::Sop::LAB_PROTOCOL_TYPE
       },
       '@type' => 'Collection',
       '@id' => "http://localhost:3000/collections/#{collection.id}",
@@ -1009,7 +1014,9 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
       '@context' => {
         '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
         'dct' => Seek::BioSchema::Serializer::DCT,
-        'ComputationalWorkflow' => Seek::BioSchema::ResourceDecorators::Workflow::WORKFLOW_TYPE
+        'ComputationalWorkflow' => Seek::BioSchema::ResourceDecorators::Workflow::WORKFLOW_TYPE,
+        'LabProtocol' => Seek::BioSchema::ResourceDecorators::Sop::LAB_PROTOCOL_TYPE,
+        'computationalTool' => "#{Seek::BioSchema::ResourceDecorators::Sop::LAB_PROTOCOL_TYPE}#computationalTool"
       },
       '@type' => 'LabProtocol',
       '@id' => "http://localhost:3000/sops/#{sop.id}",

--- a/test/unit/bio_schema/schema_ld_generation_test.rb
+++ b/test/unit/bio_schema/schema_ld_generation_test.rb
@@ -59,6 +59,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
         with_config_value(:site_base_host, 'http://fairyhub.org') do
           json = JSON.parse(Seek::BioSchema::DataCatalogMockModel.new.to_schema_ld)
           assert_equal expected, json
+          check_schema_org_terms(json)
         end
       end
     end
@@ -113,6 +114,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
                        site_base_host: 'http://fairyhub.org') do
       json = JSON.parse(Seek::BioSchema::DataCatalogMockModel.new.to_schema_ld)
       assert_equal expected, json
+      check_schema_org_terms(json)
     end
   end
 
@@ -147,6 +149,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
 
     json = JSON.parse(@person.to_schema_ld)
     assert_equal expected, json
+    check_schema_org_terms(json)
   end
 
   test 'data file' do
@@ -205,6 +208,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     json = JSON.parse(df.to_schema_ld)
     assert_equal expected, json
     check_version(df.latest_version, expected)
+    check_schema_org_terms(json)
   end
 
   test 'data file without content blob' do
@@ -258,6 +262,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     json = JSON.parse(df.to_schema_ld)
     assert_equal expected, json
     check_version(df.latest_version, expected)
+    check_schema_org_terms(json)
   end
 
   test 'dataset with weblink' do
@@ -310,6 +315,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     json = JSON.parse(df.to_schema_ld)
     assert_equal expected, json
     check_version(df.latest_version, expected)
+    check_schema_org_terms(json)
   end
 
   test 'project' do
@@ -345,6 +351,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
 
     json = JSON.parse(@project.to_schema_ld)
     assert_equal expected, json
+    check_schema_org_terms(json)
   end
 
   test 'sample' do
@@ -378,6 +385,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
 
     json = JSON.parse(sample.to_schema_ld)
     assert_equal expected, json
+    check_schema_org_terms(json)
   end
 
   test 'event' do
@@ -418,6 +426,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
 
     json = JSON.parse(event.to_schema_ld)
     assert_equal expected, json
+    check_schema_org_terms(json)
   end
 
   test 'document' do
@@ -454,6 +463,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     json = JSON.parse(document.to_schema_ld)
     assert_equal expected, json
     check_version(document.latest_version, expected)
+    check_schema_org_terms(json)
   end
 
   test 'presentation' do
@@ -489,6 +499,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     json = JSON.parse(presentation.to_schema_ld)
     assert_equal expected, json
     check_version(presentation.latest_version, expected)
+    check_schema_org_terms(json)
   end
 
   test 'workflow' do
@@ -622,6 +633,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     fine_json_comparison expected, json
     assert_equal expected, json
     check_version(workflow.latest_version, expected)
+    check_schema_org_terms(json)
   end
 
   test 'collection' do
@@ -683,6 +695,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
 
     json = JSON.parse(collection.to_schema_ld)
     assert_equal expected, json
+    check_schema_org_terms(json)
   end
 
   test 'human_disease' do
@@ -708,6 +721,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
 
     json = JSON.parse(human_disease.to_schema_ld)
     assert_equal expected, json
+    check_schema_org_terms(json)
   end
 
   test 'institution' do
@@ -735,6 +749,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
 
     json = JSON.parse(institution.to_schema_ld)
     assert_equal expected, json
+    check_schema_org_terms(json)
 
     # check without ror_id and department
     institution.update_columns(department:'', ror_id:nil)
@@ -742,6 +757,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     expected.delete('department')
     expected.delete('identifier')
     assert_equal expected, json
+    check_schema_org_terms(json)
   end
 
   test 'organism' do
@@ -767,6 +783,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
 
     json = JSON.parse(organism.to_schema_ld)
     assert_equal expected, json
+    check_schema_org_terms(json)
   end
 
   test 'programme' do
@@ -790,6 +807,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
 
     json = JSON.parse(programme.to_schema_ld)
     assert_equal expected, json
+    check_schema_org_terms(json)
   end
 
   test 'version of data file' do
@@ -895,8 +913,10 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
 
     json = JSON.parse(df.find_version(1).to_schema_ld)
     assert_equal v1_expected, json
+    check_schema_org_terms(json)
     json = JSON.parse(df.find_version(2).to_schema_ld)
     assert_equal v2_expected, json
+    check_schema_org_terms(json)
   end
 
   test 'dataset without data dump' do
@@ -926,6 +946,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     with_config_value(:metadata_license, 'CC0-1.0') do
       json = JSON.parse(resource.to_schema_ld)
       assert_equal expected, json
+      check_schema_org_terms(json)
     end
   end
 
@@ -969,6 +990,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
       assert dump.exists?
       json = JSON.parse(resource.to_schema_ld)
       assert_equal expected, json
+      check_schema_org_terms(json)
     end
   end
 
@@ -1009,6 +1031,7 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
 
     json = JSON.parse(sop.to_schema_ld)
     assert_equal expected, json
+    check_schema_org_terms(json)
   end
 
   private
@@ -1025,5 +1048,45 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
   def fine_json_comparison(expected, json)
     expected.each { |k, v| assert_equal v, json[k], "mismatch with key #{k}" }
     json.each { |k, v| assert_equal v, expected[k], "mismatch with key #{k}" }
+  end
+
+  def schema_org_terms
+    @schema_org_terms ||= begin
+      schema_iris = Set.new
+      RDF::Vocab::SCHEMAS.each_entry do |entry|
+        schema_iris << entry.to_s
+      end
+      schema_iris
+    end
+  end
+
+  def check_schema_org_terms(actual)
+    result = JSON::LD::API.expand(actual)
+    terms = collect_schema_terms(result)
+
+    schema_terms = schema_org_terms
+    terms.each do |t|
+      assert schema_terms.include?(t), "Term #{t} is not a valid schema.org term"
+    end
+  end
+
+  def collect_schema_terms(json_array, terms: nil)
+    terms ||= Set.new
+    json_array.each do |node|
+      next unless node.is_a?(Hash)
+
+      Array(node['@type']).each { |t| terms << t if t.start_with?(Seek::BioSchema::Serializer::SCHEMA_ORG) }
+      node.each do |key, value|
+        next unless key.start_with?(Seek::BioSchema::Serializer::SCHEMA_ORG)
+
+        terms << key
+        Array(value).each do |v|
+          next unless v.is_a?(Hash)
+
+          collect_schema_terms([v], terms: terms)
+        end
+      end
+    end
+    terms
   end
 end

--- a/test/unit/bio_schema/schema_ld_generation_test.rb
+++ b/test/unit/bio_schema/schema_ld_generation_test.rb
@@ -986,7 +986,8 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     expected = {
       '@context' => {
         '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
-        'dct' => Seek::BioSchema::Serializer::DCT
+        'dct' => Seek::BioSchema::Serializer::DCT,
+        'ComputationalWorkflow' => Seek::BioSchema::ResourceDecorators::Workflow::WORKFLOW_TYPE
       },
       '@type' => 'LabProtocol',
       '@id' => "http://localhost:3000/sops/#{sop.id}",

--- a/test/unit/bio_schema/schema_ld_generation_test.rb
+++ b/test/unit/bio_schema/schema_ld_generation_test.rb
@@ -167,7 +167,10 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     expected = {
       '@context' => {
         '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
-        'dct' => Seek::BioSchema::Serializer::DCT
+        'dct' => Seek::BioSchema::Serializer::DCT,
+        'hostInstitution' => Seek::BioSchema::ResourceDecorators::Event::HOST_INSTITUTION_PROPERTY,
+        'contact' => Seek::BioSchema::ResourceDecorators::Event::CONTACT_PROPERTY,
+        'eventType' => Seek::BioSchema::ResourceDecorators::Event::EVENT_TYPE_PROPERTY
       },
       '@type' => 'Dataset',
       '@id' => "http://localhost:3000/data_files/#{df.id}",
@@ -229,7 +232,10 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     expected = {
       '@context' => {
         '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
-        'dct' => Seek::BioSchema::Serializer::DCT
+        'dct' => Seek::BioSchema::Serializer::DCT,
+        'hostInstitution' => Seek::BioSchema::ResourceDecorators::Event::HOST_INSTITUTION_PROPERTY,
+        'contact' => Seek::BioSchema::ResourceDecorators::Event::CONTACT_PROPERTY,
+        'eventType' => Seek::BioSchema::ResourceDecorators::Event::EVENT_TYPE_PROPERTY
       },
       '@type' => 'Dataset',
       '@id' => "http://localhost:3000/data_files/#{df.id}",
@@ -281,7 +287,10 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     expected = {
       '@context' => {
         '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
-        'dct' => Seek::BioSchema::Serializer::DCT
+        'dct' => Seek::BioSchema::Serializer::DCT,
+        'hostInstitution' => Seek::BioSchema::ResourceDecorators::Event::HOST_INSTITUTION_PROPERTY,
+        'contact' => Seek::BioSchema::ResourceDecorators::Event::CONTACT_PROPERTY,
+        'eventType' => Seek::BioSchema::ResourceDecorators::Event::EVENT_TYPE_PROPERTY
       },
       '@type' => 'Dataset',
       '@id' => "http://localhost:3000/data_files/#{df.id}",
@@ -328,7 +337,10 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     expected = {
       '@context' => {
         '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
-        'dct' => Seek::BioSchema::Serializer::DCT
+        'dct' => Seek::BioSchema::Serializer::DCT,
+        'hostInstitution' => Seek::BioSchema::ResourceDecorators::Event::HOST_INSTITUTION_PROPERTY,
+        'contact' => Seek::BioSchema::ResourceDecorators::Event::CONTACT_PROPERTY,
+        'eventType' => Seek::BioSchema::ResourceDecorators::Event::EVENT_TYPE_PROPERTY
       },
       '@type' => %w[Project Organization],
       '@id' => "http://localhost:3000/projects/#{@project.id}",
@@ -535,8 +547,8 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
       '@context' => {
         '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
         'dct' => Seek::BioSchema::Serializer::DCT,
-        'input' => "#{Seek::BioSchema::ResourceDecorators::Workflow::WORKFLOW_TYPE}#input",
-        'output' => "#{Seek::BioSchema::ResourceDecorators::Workflow::WORKFLOW_TYPE}#output",
+        'input' => Seek::BioSchema::ResourceDecorators::Workflow::INPUT_PROPERTY,
+        'output' => Seek::BioSchema::ResourceDecorators::Workflow::OUTPUT_PROPERTY,
         'ComputationalWorkflow' => Seek::BioSchema::ResourceDecorators::Workflow::WORKFLOW_TYPE,
         'FormalParameter' => Seek::BioSchema::ResourceDecorators::Workflow::FORMALPARAMETER_TYPE
       },
@@ -665,7 +677,8 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
       '@context' => {
         '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
         'dct' => Seek::BioSchema::Serializer::DCT,
-        'LabProtocol' => Seek::BioSchema::ResourceDecorators::Sop::LAB_PROTOCOL_TYPE
+        'LabProtocol' => Seek::BioSchema::ResourceDecorators::Sop::LAB_PROTOCOL_TYPE,
+        'computationalTool' => Seek::BioSchema::ResourceDecorators::Sop::COMPUTATIONAL_TOOL_PROPERTY
       },
       '@type' => 'Collection',
       '@id' => "http://localhost:3000/collections/#{collection.id}",
@@ -836,7 +849,10 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     v1_expected = {
       '@context' => {
         '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
-        'dct' => Seek::BioSchema::Serializer::DCT
+        'dct' => Seek::BioSchema::Serializer::DCT,
+        'hostInstitution' => Seek::BioSchema::ResourceDecorators::Event::HOST_INSTITUTION_PROPERTY,
+        'contact' => Seek::BioSchema::ResourceDecorators::Event::CONTACT_PROPERTY,
+        'eventType' => Seek::BioSchema::ResourceDecorators::Event::EVENT_TYPE_PROPERTY
       },
       '@type' => 'Dataset',
       '@id' => "http://localhost:3000/data_files/#{df.id}?version=1",
@@ -877,7 +893,10 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     v2_expected = {
       '@context' => {
         '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
-        'dct' => Seek::BioSchema::Serializer::DCT
+        'dct' => Seek::BioSchema::Serializer::DCT,
+        'hostInstitution' => Seek::BioSchema::ResourceDecorators::Event::HOST_INSTITUTION_PROPERTY,
+        'contact' => Seek::BioSchema::ResourceDecorators::Event::CONTACT_PROPERTY,
+        'eventType' => Seek::BioSchema::ResourceDecorators::Event::EVENT_TYPE_PROPERTY
       },
       '@type' => 'Dataset',
       '@id' => "http://localhost:3000/data_files/#{df.id}?version=2",
@@ -1015,8 +1034,11 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
         '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
         'dct' => Seek::BioSchema::Serializer::DCT,
         'ComputationalWorkflow' => Seek::BioSchema::ResourceDecorators::Workflow::WORKFLOW_TYPE,
+        'input' => Seek::BioSchema::ResourceDecorators::Workflow::INPUT_PROPERTY,
+        'output' => Seek::BioSchema::ResourceDecorators::Workflow::OUTPUT_PROPERTY,
+        'FormalParameter' => Seek::BioSchema::ResourceDecorators::Workflow::FORMALPARAMETER_TYPE,
         'LabProtocol' => Seek::BioSchema::ResourceDecorators::Sop::LAB_PROTOCOL_TYPE,
-        'computationalTool' => "#{Seek::BioSchema::ResourceDecorators::Sop::LAB_PROTOCOL_TYPE}#computationalTool"
+        'computationalTool' => Seek::BioSchema::ResourceDecorators::Sop::COMPUTATIONAL_TOOL_PROPERTY
       },
       '@type' => 'LabProtocol',
       '@id' => "http://localhost:3000/sops/#{sop.id}",

--- a/test/unit/bio_schema/schema_ld_generation_test.rb
+++ b/test/unit/bio_schema/schema_ld_generation_test.rb
@@ -17,7 +17,10 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     end
 
     expected = {
-      '@context' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+      '@context' => {
+        '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+        'dct' => Seek::BioSchema::Serializer::DCT
+      },
       '@type' => 'DataCatalog',
       '@id' => 'http://fairyhub.org',
       'dct:conformsTo' => { '@id' => Seek::BioSchema::ResourceDecorators::DataCatalog::DATACATALOG_PROFILE },
@@ -68,7 +71,10 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     end
 
     expected = {
-      '@context' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+      '@context' => {
+        '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+        'dct' => Seek::BioSchema::Serializer::DCT
+      },
       '@type' => 'DataCatalog',
       '@id' => 'http://fairyhub.org',
       'dct:conformsTo' => { '@id' => Seek::BioSchema::ResourceDecorators::DataCatalog::DATACATALOG_PROFILE },
@@ -115,7 +121,10 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     disable_authorization_checks { @person.save! }
     institution = @person.institutions.first
     expected = {
-      '@context' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+      '@context' => {
+        '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+        'dct' => Seek::BioSchema::Serializer::DCT
+      },
       '@id' => "http://localhost:3000/people/#{@person.id}",
       '@type' => 'Person',
       'dct:conformsTo' => { '@id' => Seek::BioSchema::ResourceDecorators::Person::PERSON_PROFILE },
@@ -153,7 +162,10 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     refute df.content_blob.show_as_external_link?
 
     expected = {
-      '@context' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+      '@context' => {
+        '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+        'dct' => Seek::BioSchema::Serializer::DCT
+      },
       '@type' => 'Dataset',
       '@id' => "http://localhost:3000/data_files/#{df.id}",
       'dct:conformsTo' => { '@id' => Seek::BioSchema::ResourceDecorators::DataFile::DATASET_PROFILE },
@@ -211,7 +223,10 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     assert_nil df.content_blob
 
     expected = {
-      '@context' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+      '@context' => {
+        '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+        'dct' => Seek::BioSchema::Serializer::DCT
+      },
       '@type' => 'Dataset',
       '@id' => "http://localhost:3000/data_files/#{df.id}",
       'dct:conformsTo' => { '@id' => Seek::BioSchema::ResourceDecorators::DataFile::DATASET_PROFILE },
@@ -259,7 +274,10 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     assert df.content_blob.show_as_external_link?
 
     expected = {
-      '@context' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+      '@context' => {
+        '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+        'dct' => Seek::BioSchema::Serializer::DCT
+      },
       '@type' => 'Dataset',
       '@id' => "http://localhost:3000/data_files/#{df.id}",
       'dct:conformsTo' => { '@id' => 'https://bioschemas.org/profiles/Dataset/1.0-RELEASE' },
@@ -302,7 +320,10 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     institution = @project.institutions.first
     event = @project.events.first
     expected = {
-      '@context' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+      '@context' => {
+        '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+        'dct' => Seek::BioSchema::Serializer::DCT
+      },
       '@type' => %w[Project Organization],
       '@id' => "http://localhost:3000/projects/#{@project.id}",
       'name' => @project.title,
@@ -336,7 +357,10 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     disable_authorization_checks { sample.save! }
 
     expected = {
-      '@context' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+      '@context' => {
+        '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+        'dct' => Seek::BioSchema::Serializer::DCT
+      },
       '@type' => 'Sample',
       'dct:conformsTo' => { '@id' => Seek::BioSchema::ResourceDecorators::Sample::SAMPLE_PROFILE },
       '@id' => "http://localhost:3000/samples/#{sample.id}",
@@ -361,7 +385,10 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     data_file = event.data_files.first
     presentation = event.presentations.first
     expected = {
-      '@context' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+      '@context' => {
+        '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+        'dct' => Seek::BioSchema::Serializer::DCT
+      },
       '@id' => "http://localhost:3000/events/#{event.id}",
       'dct:conformsTo' => { '@id' => Seek::BioSchema::ResourceDecorators::Event::EVENT_PROFILE },
       '@type' => 'Event',
@@ -402,7 +429,10 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     end
 
     expected = {
-      '@context' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+      '@context' => {
+        '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+        'dct' => Seek::BioSchema::Serializer::DCT
+      },
       '@type' => 'DigitalDocument',
       '@id' => "http://localhost:3000/documents/#{document.id}",
       'name' => 'This Document',
@@ -435,7 +465,10 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     end
 
     expected = {
-      '@context' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+      '@context' => {
+        '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+        'dct' => Seek::BioSchema::Serializer::DCT
+      },
       '@type' => 'PresentationDigitalDocument',
       '@id' => "http://localhost:3000/presentations/#{presentation.id}",
       'name' => 'This presentation',
@@ -484,7 +517,14 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     expected_wf_prefix = workflow.title.downcase.gsub(/[^0-9a-z]/i, '_')
 
     expected = {
-      '@context' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+      '@context' => {
+        '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+        'dct' => Seek::BioSchema::Serializer::DCT,
+        'input' => "#{Seek::BioSchema::ResourceDecorators::Workflow::WORKFLOW_TYPE}#input",
+        'output' => "#{Seek::BioSchema::ResourceDecorators::Workflow::WORKFLOW_TYPE}#output",
+        'ComputationalWorkflow' => Seek::BioSchema::ResourceDecorators::Workflow::WORKFLOW_TYPE,
+        'FormalParameter' => Seek::BioSchema::ResourceDecorators::Workflow::FORMALPARAMETER_TYPE
+      },
       '@type' => %w[SoftwareSourceCode ComputationalWorkflow],
       '@id' => "http://localhost:3000/workflows/#{workflow.id}",
       'dct:conformsTo' => { '@id' => Seek::BioSchema::ResourceDecorators::Workflow::WORKFLOW_PROFILE },
@@ -606,7 +646,10 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     df1 = sel_assets[2]
     df2 = sel_assets[3]
     expected = {
-      '@context' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+      '@context' => {
+        '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+        'dct' => Seek::BioSchema::Serializer::DCT
+      },
       '@type' => 'Collection',
       '@id' => "http://localhost:3000/collections/#{collection.id}",
       'description' => 'A collection of very interesting things',
@@ -650,7 +693,10 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     end
 
     expected = {
-      '@context' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+      '@context' => {
+        '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+        'dct' => Seek::BioSchema::Serializer::DCT
+      },
       '@type' => 'Taxon',
       'dct:conformsTo' => { '@id' => Seek::BioSchema::ResourceDecorators::HumanDisease::TAXON_PROFILE },
       '@id' => "http://localhost:3000/human_diseases/#{human_disease.id}",
@@ -674,7 +720,10 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     end
 
     expected = {
-      '@context' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+      '@context' => {
+        '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+        'dct' => Seek::BioSchema::Serializer::DCT
+      },
       '@type' => 'ResearchOrganization',
       '@id' => "http://localhost:3000/institutions/#{institution.id}",
       'name' => 'University of Manchester',
@@ -703,7 +752,10 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     end
 
     expected = {
-      '@context' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+      '@context' => {
+        '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+        'dct' => Seek::BioSchema::Serializer::DCT
+      },
       '@type' => 'Taxon',
       'dct:conformsTo' => { '@id' => Seek::BioSchema::ResourceDecorators::Organism::TAXON_PROFILE },
       '@id' => "http://localhost:3000/organisms/#{organism.id}",
@@ -725,7 +777,10 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     end
 
     expected = {
-      '@context' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+      '@context' => {
+        '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+        'dct' => Seek::BioSchema::Serializer::DCT
+      },
       '@type' => 'FundingScheme',
       '@id' => "http://localhost:3000/programmes/#{programme.id}",
       'description' => 'A very exciting programme',
@@ -756,7 +811,10 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     refute df.content_blob.show_as_external_link?
 
     v1_expected = {
-      '@context' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+      '@context' => {
+        '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+        'dct' => Seek::BioSchema::Serializer::DCT
+      },
       '@type' => 'Dataset',
       '@id' => "http://localhost:3000/data_files/#{df.id}?version=1",
       'dct:conformsTo' => { '@id' => Seek::BioSchema::ResourceDecorators::DataFile::DATASET_PROFILE },
@@ -794,7 +852,10 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     }
 
     v2_expected = {
-      '@context' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+      '@context' => {
+        '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+        'dct' => Seek::BioSchema::Serializer::DCT
+      },
       '@type' => 'Dataset',
       '@id' => "http://localhost:3000/data_files/#{df.id}?version=2",
       'dct:conformsTo' => { '@id' => Seek::BioSchema::ResourceDecorators::DataFile::DATASET_PROFILE },
@@ -840,7 +901,10 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
 
   test 'dataset without data dump' do
     expected = {
-      '@context' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+      '@context' => {
+        '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+        'dct' => Seek::BioSchema::Serializer::DCT
+      },
       '@type' => 'Dataset',
       'dct:conformsTo' => { '@id' => Seek::BioSchema::ResourceDecorators::Dataset::DATASET_PROFILE },
       '@id' => 'http://localhost:3000/workflows',
@@ -874,7 +938,10 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     size = ActiveSupport::NumberHelper::NumberToHumanSizeConverter.new(dump.size, {}).convert
 
     expected = {
-      '@context' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+      '@context' => {
+        '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+        'dct' => Seek::BioSchema::Serializer::DCT
+      },
       '@type' => 'Dataset',
       'dct:conformsTo' => { '@id' => Seek::BioSchema::ResourceDecorators::Dataset::DATASET_PROFILE },
       '@id' => 'http://localhost:3000/workflows',
@@ -917,7 +984,10 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
     end
 
     expected = {
-      '@context' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+      '@context' => {
+        '@vocab' => Seek::BioSchema::Serializer::SCHEMA_ORG,
+        'dct' => Seek::BioSchema::Serializer::DCT
+      },
       '@type' => 'LabProtocol',
       '@id' => "http://localhost:3000/sops/#{sop.id}",
       'description' => 'How to run a simulation in GROMACS',

--- a/test/unit/bio_schema/schema_ld_generation_test.rb
+++ b/test/unit/bio_schema/schema_ld_generation_test.rb
@@ -588,7 +588,9 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
         'input' => Seek::BioSchema::ResourceDecorators::Workflow::INPUT_PROPERTY,
         'output' => Seek::BioSchema::ResourceDecorators::Workflow::OUTPUT_PROPERTY,
         'ComputationalWorkflow' => Seek::BioSchema::ResourceDecorators::Workflow::WORKFLOW_TYPE,
-        'FormalParameter' => Seek::BioSchema::ResourceDecorators::Workflow::FORMALPARAMETER_TYPE
+        'FormalParameter' => Seek::BioSchema::ResourceDecorators::Workflow::FORMALPARAMETER_TYPE,
+        'LabProtocol' => Seek::BioSchema::ResourceDecorators::Sop::LAB_PROTOCOL_TYPE,
+        'computationalTool' => Seek::BioSchema::ResourceDecorators::Sop::COMPUTATIONAL_TOOL_PROPERTY
       },
       '@type' => %w[SoftwareSourceCode ComputationalWorkflow],
       '@id' => "http://localhost:3000/workflows/#{workflow.id}",

--- a/test/unit/bio_schema/schema_ld_generation_test.rb
+++ b/test/unit/bio_schema/schema_ld_generation_test.rb
@@ -129,7 +129,6 @@ class SchemaLdGenerationTest < ActiveSupport::TestCase
       },
       '@id' => "http://localhost:3000/people/#{@person.id}",
       '@type' => 'Person',
-      'dct:conformsTo' => { '@id' => Seek::BioSchema::ResourceDecorators::Person::PERSON_PROFILE },
       'name' => @person.name,
       'givenName' => @person.first_name,
       'familyName' => @person.last_name,

--- a/test/unit/ro_crate/workflow_crate_test.rb
+++ b/test/unit/ro_crate/workflow_crate_test.rb
@@ -5,7 +5,7 @@ class WorkflowCrateTest < ActiveSupport::TestCase
     crate = ROCrate::WorkflowCrate.new
 
     ids = crate.metadata['conformsTo'].map { |x| x['@id'] }
-    assert_includes ids, 'https://w3id.org/ro/crate/1.2'
+    assert_includes ids, 'https://w3id.org/ro/crate/1.3'
     assert_includes ids, 'https://w3id.org/workflowhub/workflow-ro-crate/1.0'
   end
 


### PR DESCRIPTION
* Recreates #2482 combined with #2553

* Partly resolves #781 and #636

Extend the context to add bioschemas terms used in Workflows.
Extend the context to add dct namespace

Already approved but waiting for RO-Crate synchronization ( see https://github.com/seek4science/seek/pull/2482#pullrequestreview-3813821053 )