### PR TITLE
Trim sessions in batches

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -89,5 +89,5 @@ end
 
 # trim sessions
 every 1.day, at: '1:15 am' do
-  rake 'db:sessions:trim'
+  rake 'db:sessions:batch_trim'
 end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -16,17 +16,17 @@ end
 
 namespace :db do
   namespace :sessions do
-    desc 'Trims sessions in batches according to env vars \'BATCH_SIZE\' and \'DAYS_OLD\'. Defaults: BATCH_SIZE=1000, DAYS_OLD=7).'
+    desc 'Trims sessions in batches according to env vars \'SESSION_TRIM_BATCH_SIZE\' and \'SESSION_DAYS_TRIM_THRESHOLD\'. Defaults: SESSION_TRIM_BATCH_SIZE=1000, SESSION_DAYS_TRIM_THRESHOLD=30).'
     task(batch_trim: :environment) do
-      batch_size = ENV.fetch('BATCH_SIZE', '1000').to_i
-      days_old = ENV.fetch('DAYS_OLD', '7').to_i
+      batch_size = ENV.fetch('SESSION_TRIM_BATCH_SIZE', '1000').to_i
+      days_old = ENV.fetch('SESSION_DAYS_TRIM_THRESHOLD', '30').to_i
 
       if batch_size <= 0
-        abort "BATCH_SIZE must be a positive integer"
+        abort "SESSION_TRIM_BATCH_SIZE must be a positive integer"
       end
 
       if days_old <= 0
-        abort "DAYS_OLD must be a positive integer"
+        abort "SESSION_DAYS_TRIM_THRESHOLD must be a positive integer"
       end
 
       cutoff_date = days_old.days.ago

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -13,3 +13,30 @@ Rake::Task['db:schema:dump'].enhance do
     puts "Failed to convert schema.rb to db agnostic - #{e.message}"
   end
 end
+
+namespace :db do
+  namespace :sessions do
+    desc 'Trims sessions in batches according to env vars \'BATCH_SIZE\' and \'DAYS_OLD\' (Defaults => BATCH_SIZE: 1000, DAYS_OLD: 7).'
+    task(batch_trim: :environment) do
+      batch_size = ENV['BATCH_SIZE']&.to_i || 1_000
+      days_old = ENV['DAYS_OLD']&.to_i || 7
+      cutoff_date = days_old.days.ago
+
+      deleted_total = 0
+      loop do
+        delete_ids = ActiveRecord::SessionStore::Session.where('updated_at < ?',
+                                                               cutoff_date).limit(batch_size).pluck(:id)
+        deleted_count = delete_ids.count
+        ActiveRecord::SessionStore::Session.where(id: delete_ids).delete_all
+        deleted_total += deleted_count
+
+        puts "Deleted #{deleted_count} sessions (Total: #{deleted_total})"
+        break if delete_ids.empty?
+
+        sleep(1) # Wait longer between batches to release locks
+      end
+
+      puts "\nFinished! Deleted #{deleted_total} total sessions older than #{days_old} days."
+    end
+  end
+end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -7,7 +7,7 @@ require 'terrapin'
 Rake::Task['db:schema:dump'].enhance do
   begin
     cmd = Terrapin::CommandLine.new("sed -e 's/charset: \"[^\"]*\", //' -e 's/collation: \"[^\"]*\", //' db/schema.rb > db/schema2.rb " \
-      '&& mv db/schema2.rb db/schema.rb')
+                                      '&& mv db/schema2.rb db/schema.rb')
     cmd.run
   rescue StandardError => e
     puts "Failed to convert schema.rb to db agnostic - #{e.message}"
@@ -16,22 +16,42 @@ end
 
 namespace :db do
   namespace :sessions do
-    desc 'Trims sessions in batches according to env vars \'BATCH_SIZE\' and \'DAYS_OLD\' (Defaults => BATCH_SIZE: 1000, DAYS_OLD: 7).'
+    desc 'Trims sessions in batches according to env vars \'BATCH_SIZE\' and \'DAYS_OLD\'. Defaults: BATCH_SIZE=1000, DAYS_OLD=7).'
     task(batch_trim: :environment) do
-      batch_size = ENV['BATCH_SIZE']&.to_i || 1_000
-      days_old = ENV['DAYS_OLD']&.to_i || 7
-      cutoff_date = days_old.days.ago
+      batch_size = ENV.fetch('BATCH_SIZE', '1000').to_i
+      days_old = ENV.fetch('DAYS_OLD', '7').to_i
 
+      if batch_size <= 0
+        abort "BATCH_SIZE must be a positive integer"
+      end
+
+      if days_old <= 0
+        abort "DAYS_OLD must be a positive integer"
+      end
+
+      cutoff_date = days_old.days.ago
       deleted_total = 0
+
+
+      puts "Deleting sessions older than #{days_old} days in batches of #{batch_size}..."
+      puts "Cutoff: #{cutoff_date}"
+
       loop do
-        delete_ids = ActiveRecord::SessionStore::Session.where('updated_at < ?',
-                                                               cutoff_date).limit(batch_size).pluck(:id)
-        deleted_count = delete_ids.count
-        ActiveRecord::SessionStore::Session.where(id: delete_ids).delete_all
+        delete_ids = ActiveRecord::SessionStore::Session
+                       .where('updated_at < ?', cutoff_date)
+                       .order(:updated_at, :id)
+                       .limit(batch_size)
+                       .pluck(:id)
+
+        break if delete_ids.empty?
+
+        deleted_count = ActiveRecord::SessionStore::Session
+                          .where(id: delete_ids)
+                          .delete_all
+
         deleted_total += deleted_count
 
         puts "Deleted #{deleted_count} sessions (Total: #{deleted_total})"
-        break if delete_ids.empty?
 
         sleep(1) # Wait longer between batches to release locks
       end


### PR DESCRIPTION
Adds a rake task that trims the sessions in batches, according to two environment variables:
- SESSION_TRIM_BATCH_SIZE (defaults to '1000')
- SESSION_DAYS_TRIM_THRESHOLD (defaults to '30')
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

Example:

```sh
SESSION_DAYS_TRIM_THRESHOLD=20 SESSION_TRIM_BATCH_SIZE=2 bundle exec rake db:sessions:batch_trim
```

```
Deleting sessions older than 20 days in batches of 2...
Cutoff: 2026-04-06 14:54:59 UTC
Deleted 2 sessions (Total: 2)
Deleted 2 sessions (Total: 4)
Deleted 2 sessions (Total: 6)
Deleted 2 sessions (Total: 8)
Deleted 2 sessions (Total: 10)
Deleted 2 sessions (Total: 12)
Deleted 2 sessions (Total: 14)
Deleted 2 sessions (Total: 16)
Deleted 2 sessions (Total: 18)
Deleted 2 sessions (Total: 20)
Deleted 2 sessions (Total: 22)
Deleted 2 sessions (Total: 24)
...
Finished! Deleted 328 total sessions older than 20 days.
```