### PR TITLE
reject sample or extended metadata type candidates that have a required field that isn't present in the FDS import rdf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ docker-compose.override.yml
 
 *.ignore
 /tmp/local_secret.txt
+/.claude/

--- a/lib/seek/fair_data_station/base.rb
+++ b/lib/seek/fair_data_station/base.rb
@@ -155,12 +155,13 @@ module Seek
 
       def find_closest_matching_extended_metadata_type(property_ids = additional_metadata_annotations.collect { |annotation| annotation[0] })
         candidates = ::ExtendedMetadataType.where(supported_type: type_name).enabled.includes(:extended_metadata_attributes).filter_map do |emt|
-          extended_metadata_property_ids = emt.deep_extended_metadata_attributes.collect(&:pid).compact_blank
+          deep_attributes = emt.deep_extended_metadata_attributes
+          extended_metadata_property_ids = deep_attributes.collect(&:pid).compact_blank
           intersection = (property_ids & extended_metadata_property_ids)
           # skip types with no matching properties
           next if intersection.empty?
           # skip types where any required attribute is absent from the FDS data — they would fail validation
-          required_pids = emt.deep_extended_metadata_attributes.select(&:required?).collect(&:pid).compact_blank
+          required_pids = deep_attributes.select(&:required?).collect(&:pid).compact_blank
           next if (required_pids - property_ids).any?
           difference = (property_ids | extended_metadata_property_ids) - intersection
           [intersection.length, difference.length, emt]

--- a/lib/seek/fair_data_station/base.rb
+++ b/lib/seek/fair_data_station/base.rb
@@ -153,20 +153,18 @@ module Seek
         emt
       end
 
-      def find_closest_matching_extended_metadata_type(property_ids = additional_metadata_annotations.collect do |annotation|
-        annotation[0]
-      end)
-        # collect and sort those with the most properties that match, eliminating any where no properties match
-        candidates = ::ExtendedMetadataType.where(supported_type: type_name).enabled.includes(:extended_metadata_attributes).collect do |emt|
+      def find_closest_matching_extended_metadata_type(property_ids = additional_metadata_annotations.collect { |annotation| annotation[0] })
+        candidates = ::ExtendedMetadataType.where(supported_type: type_name).enabled.includes(:extended_metadata_attributes).filter_map do |emt|
           extended_metadata_property_ids = emt.deep_extended_metadata_attributes.collect(&:pid).compact_blank
           intersection = (property_ids & extended_metadata_property_ids)
+          # skip types with no matching properties
+          next if intersection.empty?
+          # skip types where any required attribute is absent from the FDS data — they would fail validation
+          required_pids = emt.deep_extended_metadata_attributes.select(&:required?).collect(&:pid).compact_blank
+          next if (required_pids - property_ids).any?
           difference = (property_ids | extended_metadata_property_ids) - intersection
-          emt = nil if intersection.empty?
           [intersection.length, difference.length, emt]
-        end.sort_by do |x|
-          # order by the number of properties matched coming top, but downgraded by the number of differences
-          [-x[0], x[1]]
-        end
+        end.sort_by { |x| [-x[0], x[1]] }
 
         candidates.first&.last
       end

--- a/lib/seek/fair_data_station/sample.rb
+++ b/lib/seek/fair_data_station/sample.rb
@@ -12,16 +12,17 @@ module Seek
       end
 
       def find_closest_matching_sample_type(person, property_ids = additional_metadata_annotations.collect { |annotation| annotation[0] })
-        candidates = SampleType.includes(:sample_attributes).authorized_for(:view, person).collect do |sample_type|
+        candidates = SampleType.includes(:sample_attributes).authorized_for(:view, person).filter_map do |sample_type|
           sample_type_property_ids = sample_type.sample_attributes.collect(&:pid).compact_blank
           intersection = (property_ids & sample_type_property_ids)
+          # skip types with no matching properties
+          next if intersection.empty?
+          # skip types where any required attribute is absent from the FDS data — they would fail validation
+          required_pids = sample_type.sample_attributes.select(&:required?).collect(&:pid).compact_blank
+          next if (required_pids - property_ids).any?
           difference = (property_ids | sample_type_property_ids) - intersection
-          emt = nil if intersection.empty?
           [intersection.length, difference.length, sample_type]
-        end.sort_by do |x|
-          # order by the number of properties matched coming top, but downgraded by the number of differences
-          [-x[0], x[1]]
-        end
+        end.sort_by { |x| [-x[0], x[1]] }
 
         candidates.first&.last
       end

--- a/test/unit/fair_data_station/fair_data_station_objects_test.rb
+++ b/test/unit/fair_data_station/fair_data_station_objects_test.rb
@@ -195,6 +195,54 @@ class FairDataStationObjectsTest < ActiveSupport::TestCase
     assert_equal partial_sample_type, sample.find_closest_matching_sample_type(nil)
   end
 
+  test 'find closest matching sample type excludes types with missing required attributes' do
+    path = "#{Rails.root}/test/fixtures/files/fair_data_station/seek-fair-data-station-test-case.ttl"
+    inv = Seek::FairDataStation::Reader.new.parse_graph(path).first
+    sample = inv.studies.first.observation_units.first.samples.first
+
+    # create a type that matches all FDS properties but has an extra required attribute not in FDS data
+    type_with_missing_required = FactoryBot.create(:fairdatastation_test_case_sample_type)
+    type_with_missing_required.sample_attributes << FactoryBot.build(
+      :sample_attribute,
+      sample_attribute_type: FactoryBot.create(:string_sample_attribute_type),
+      title: 'Required missing field',
+      pid: 'http://example.com/not_in_fds_data',
+      required: true,
+      sample_type: type_with_missing_required
+    )
+    type_with_missing_required.reload
+
+    # only the type with missing required exists — should return nil
+    assert_nil sample.find_closest_matching_sample_type(nil)
+
+    # add a valid type with no missing required attributes — should be preferred
+    valid_type = FactoryBot.create(:fairdatastation_test_case_sample_type)
+    assert_equal valid_type, sample.find_closest_matching_sample_type(nil)
+  end
+
+  test 'find closest matching extended metadata type excludes types with missing required attributes' do
+    path = "#{Rails.root}/test/fixtures/files/fair_data_station/seek-fair-data-station-test-case.ttl"
+    inv = Seek::FairDataStation::Reader.new.parse_graph(path).first
+    assay = inv.studies.first.assays.first
+
+    # create a type that matches all FDS properties but has an extra required attribute not in FDS data
+    type_with_missing_required = FactoryBot.create(:fairdata_test_case_assay_extended_metadata)
+    type_with_missing_required.extended_metadata_attributes << FactoryBot.create(
+      :study_title_extended_metadata_attribute,
+      title: 'Required missing field',
+      pid: 'http://example.com/not_in_fds_data',
+      required: true
+    )
+    type_with_missing_required.reload
+
+    # only the type with missing required exists — should return nil
+    assert_nil assay.find_closest_matching_extended_metadata_type
+
+    # add a valid type with no missing required attributes — should be preferred
+    valid_type = FactoryBot.create(:fairdata_test_case_assay_extended_metadata)
+    assert_equal valid_type, assay.find_closest_matching_extended_metadata_type
+  end
+
   test 'find_exact_matching_sample_type dont pick if private' do
     path = "#{Rails.root}/test/fixtures/files/fair_data_station/seek-fair-data-station-test-case-irregular.ttl"
     inv = Seek::FairDataStation::Reader.new.parse_graph(path).first


### PR DESCRIPTION
* fix for #2527

skips the types where there isn't a matching property value for the pid's for a required attribute.