### PR TITLE
Remove v1.17.0 upgrade tasks from seek_upgrades.rake

### DIFF
--- a/lib/tasks/seek_upgrades.rake
+++ b/lib/tasks/seek_upgrades.rake
@@ -7,16 +7,9 @@ namespace :seek do
   # these are the tasks required for this version upgrade
   task upgrade_version_tasks: %i[
     environment
-    db:seed:011_topics_controlled_vocab
-    db:seed:012_operations_controlled_vocab
-    db:seed:013_data_formats_controlled_vocab
-    db:seed:014_data_types_controlled_vocab
-    db:seed:003_model_formats
-    db:seed:004_model_recommended_environments
     db:seed:004_model_types
     db:seed:005_publication_types
     update_rdf
-    update_morpheus_model
     db:seed:018_discipline_vocab
     strip_publication_abstracts
     db:seed:015_isa_tags
@@ -72,36 +65,6 @@ namespace :seek do
           FileUtils.rm_rf(path, secure: true)
         end
       end
-    end
-  end
-
-  task(update_morpheus_model: [:environment]) do
-    puts "... updating morpheus model"
-    affected_models = []
-    errors = []
-    Model.find_each do |model|
-      next unless model.is_morpheus_supported?
-      begin
-        unless model.model_format
-          model.model_format = ModelFormat.find_by!(title: 'Morpheus')
-        end
-        unless model.recommended_environment
-          model.recommended_environment = RecommendedModelEnvironment.find_by!(title: 'Morpheus')
-        end
-      rescue ActiveRecord::RecordNotFound => e
-        error_message = "Error: #{e.message}. Ensure that the required 'Morpheus' records exist in the database."
-        puts error_message
-        errors << error_message
-        next
-      end
-      model.update_columns(model_format_id: model.model_format_id, recommended_environment_id: model.recommended_environment_id)
-      affected_models << model
-    end
-    ReindexingQueue.enqueue(affected_models)
-    puts "... reindexing job triggered for #{affected_models.count} models"
-    unless errors.empty?
-      puts "The following errors were encountered during the update:"
-      errors.each { |error| puts error }
     end
   end
 

--- a/lib/tasks/seek_upgrades.rake
+++ b/lib/tasks/seek_upgrades.rake
@@ -54,7 +54,7 @@ namespace :seek do
 
   # if rdf repository enabled then generate jobs, otherwise just clear the cache. Only runs once
   task(update_rdf: [:environment]) do
-    only_once('seek:update_rdf 1.17.0') do
+    only_once('seek:update_rdf 1.18.0') do
       if Seek::Rdf::RdfRepository.instance&.configured?
         puts '... triggering rdf generation jobs'
         Rake::Task['seek_rdf:generate'].invoke


### PR DESCRIPTION
## Summary

- Removes 6 seed tasks from v1.17.0 that have already been run by any installation on 1.17.x: `011_topics_controlled_vocab`, `012_operations_controlled_vocab`, `013_data_formats_controlled_vocab`, `014_data_types_controlled_vocab`, `003_model_formats`, `004_model_recommended_environments`
- Removes `update_morpheus_model` task (and its implementation) which was also v1.17.0-specific and had no `only_once` guard
- Retains `update_rdf` (protected by `only_once`) and the post-v1.17.0 patch tasks (`004_model_types`, `005_publication_types`, `018_discipline_vocab`, `strip_publication_abstracts`) for users who may have skipped patch releases

The removed seed files were confirmed unchanged between v1.17.0 and the head of seek-1.17, and the corresponding `config/default_data/controlled-vocabs/` files were also untouched for those vocabs.

