### PR TITLE
Allow temp links for ObservationUnit and include in auth chain for parent Study #2554

### DIFF
--- a/app/helpers/assets_helper.rb
+++ b/app/helpers/assets_helper.rb
@@ -214,6 +214,8 @@ module AssetsHelper
                          instance_variable_get('@study')
                        when 'assays'
                          instance_variable_get('@assay')
+                       when 'observation_units'
+                         instance_variable_get('@observation_unit')
                        else
                          nil
                        end
@@ -235,6 +237,15 @@ module AssetsHelper
 
     # If current is an Assay, check if target is its Study or Investigation
     if current.is_a?(Assay)
+      if target.is_a?(Study)
+        return current.study == target
+      elsif target.is_a?(Investigation)
+        return current.investigation == target
+      end
+    end
+
+    # If current is an ObservationUnit, check if target is its Study or Investigation
+    if current.is_a?(ObservationUnit)
       if target.is_a?(Study)
         return current.study == target
       elsif target.is_a?(Investigation)

--- a/app/views/assets/_special_auth_code_form.html.erb
+++ b/app/views/assets/_special_auth_code_form.html.erb
@@ -7,7 +7,8 @@
           help_text = if f.object.is_a?(Investigation)
             "Here you can create a temporary access link for reviewing this #{t('investigation')}. The reviewers with this link can view this #{t('investigation')}, all associated #{t('study').pluralize}, #{t('assays.assay').pluralize}, and download all associated assets (#{t('data_file').pluralize}, #{t('sop').pluralize}, #{t('model').pluralize}, etc.) with no login required."
           elsif f.object.is_a?(Study)
-            "Here you can create a temporary access link for reviewing this #{t('study')}. The reviewers with this link can view this #{t('study')}, all associated #{t('assays.assay').pluralize}, and download all associated assets (#{t('data_file').pluralize}, #{t('sop').pluralize}, #{t('model').pluralize}, etc.) with no login required."
+            ou_text = Seek::Config.observation_units_enabled ? ", #{t('observation_unit').pluralize}" : ""
+            "Here you can create a temporary access link for reviewing this #{t('study')}. The reviewers with this link can view this #{t('study')}, all associated #{t('assays.assay').pluralize}#{ou_text}, and download all associated assets (#{t('data_file').pluralize}, #{t('sop').pluralize}, #{t('model').pluralize}, etc.) with no login required."
           elsif f.object.is_a?(ObservationUnit)
             "Here you can create a temporary access link for reviewing this #{t('observation_unit')}. The reviewers with this link can view this #{t('observation_unit')} and all associated samples and #{t('data_file').pluralize} with no login required."
           elsif f.object.is_a?(Assay)
@@ -40,7 +41,8 @@
                   link_scope_text = if f.object.is_a?(Investigation)
                     "This link will grant access to view this #{t('investigation')}, its #{t('study').pluralize}, #{t('assays.assay').pluralize}, and download associated assets. The link will not be active until you click 'Update'."
                   elsif f.object.is_a?(Study)
-                    "This link will grant access to view this #{t('study')}, its #{t('assays.assay').pluralize}, and download associated assets. The link will not be active until you click 'Update'."
+                    ou_text = Seek::Config.observation_units_enabled ? " and #{t('observation_unit').pluralize}" : ""
+                    "This link will grant access to view this #{t('study')}, its #{t('assays.assay').pluralize}#{ou_text}, and download associated assets. The link will not be active until you click 'Update'."
                   elsif f.object.is_a?(ObservationUnit)
                     "This link will grant access to view this #{t('observation_unit')} and its associated samples and #{t('data_file').pluralize}. The link will not be active until you click 'Update'."
                   elsif f.object.is_a?(Assay)

--- a/app/views/assets/_special_auth_code_form.html.erb
+++ b/app/views/assets/_special_auth_code_form.html.erb
@@ -8,6 +8,8 @@
             "Here you can create a temporary access link for reviewing this #{t('investigation')}. The reviewers with this link can view this #{t('investigation')}, all associated #{t('study').pluralize}, #{t('assays.assay').pluralize}, and download all associated assets (#{t('data_file').pluralize}, #{t('sop').pluralize}, #{t('model').pluralize}, etc.) with no login required."
           elsif f.object.is_a?(Study)
             "Here you can create a temporary access link for reviewing this #{t('study')}. The reviewers with this link can view this #{t('study')}, all associated #{t('assays.assay').pluralize}, and download all associated assets (#{t('data_file').pluralize}, #{t('sop').pluralize}, #{t('model').pluralize}, etc.) with no login required."
+          elsif f.object.is_a?(ObservationUnit)
+            "Here you can create a temporary access link for reviewing this #{t('observation_unit')}. The reviewers with this link can view this #{t('observation_unit')} and all associated samples and #{t('data_file').pluralize} with no login required."
           elsif f.object.is_a?(Assay)
             "Here you can create a temporary access link for reviewing this #{t('assays.assay')}. The reviewers with this link can view this #{t('assays.assay')} and download all associated assets (#{t('data_file').pluralize}, #{t('sop').pluralize}, #{t('model').pluralize}, #{t('document').pluralize}, etc.) with no login required."
           else
@@ -39,6 +41,8 @@
                     "This link will grant access to view this #{t('investigation')}, its #{t('study').pluralize}, #{t('assays.assay').pluralize}, and download associated assets. The link will not be active until you click 'Update'."
                   elsif f.object.is_a?(Study)
                     "This link will grant access to view this #{t('study')}, its #{t('assays.assay').pluralize}, and download associated assets. The link will not be active until you click 'Update'."
+                  elsif f.object.is_a?(ObservationUnit)
+                    "This link will grant access to view this #{t('observation_unit')} and its associated samples and #{t('data_file').pluralize}. The link will not be active until you click 'Update'."
                   elsif f.object.is_a?(Assay)
                     "This link will grant access to view this #{t('assays.assay')} and download its associated assets. The link will not be active until you click 'Update'."
                   else

--- a/app/views/observation_units/manage.html.erb
+++ b/app/views/observation_units/manage.html.erb
@@ -1,1 +1,1 @@
-<%= render partial:'assets/manage_form', locals: {resource:@observation_unit, show_projects:false, sharing_link:false} %>
+<%= render partial:'assets/manage_form', locals: {resource:@observation_unit, show_projects:false, sharing_link:true} %>

--- a/app/views/observation_units/show.html.erb
+++ b/app/views/observation_units/show.html.erb
@@ -16,6 +16,7 @@
         </div>
 
         <%= render partial: 'extended_metadata/extended_metadata_attribute_values', locals: { resource: @observation_unit } %>
+        <%= render partial: 'assets/special_auth_code_display', locals: { resource: @observation_unit } %>
         <%= render partial: "general/isa_graph", locals: {root_item: @observation_unit, deep: true, include_parents: true} %>
       </div>
 

--- a/lib/seek/permissions/code_based_authorization.rb
+++ b/lib/seek/permissions/code_based_authorization.rb
@@ -22,18 +22,46 @@ module Seek
           return false
         elsif is_a?(Study) && respond_to?(:investigation)
           return investigation.special_auth_codes.unexpired.where(code: code).exists? if investigation
+        elsif is_a?(ObservationUnit)
+          if respond_to?(:study) && study
+            return true if study.special_auth_codes.unexpired.where(code: code).exists?
+            return study.investigation.special_auth_codes.unexpired.where(code: code).exists? if study.investigation
+          end
         elsif is_a?(Assay)
           if respond_to?(:study) && study
             return true if study.special_auth_codes.unexpired.where(code: code).exists?
             return study.investigation.special_auth_codes.unexpired.where(code: code).exists? if study.investigation
           end
-        elsif respond_to?(:assays) && assays.any?
-          assays.each do |assay|
-            return true if assay.special_auth_codes.unexpired.where(code: code).exists?
+        else
+          if respond_to?(:assays) && assays.any?
+            assays.each do |assay|
+              return true if assay.special_auth_codes.unexpired.where(code: code).exists?
 
-            if assay.study
-              return true if assay.study.special_auth_codes.unexpired.where(code: code).exists?
-              return true if assay.study.investigation&.special_auth_codes&.unexpired&.where(code: code)&.exists?
+              if assay.study
+                return true if assay.study.special_auth_codes.unexpired.where(code: code).exists?
+                return true if assay.study.investigation&.special_auth_codes&.unexpired&.where(code: code)&.exists?
+              end
+            end
+          end
+
+          # Check via observation_unit (singular belongs_to, e.g. Sample)
+          if respond_to?(:observation_unit) && observation_unit
+            ou = observation_unit
+            return true if ou.special_auth_codes.unexpired.where(code: code).exists?
+            if ou.study
+              return true if ou.study.special_auth_codes.unexpired.where(code: code).exists?
+              return true if ou.study.investigation&.special_auth_codes&.unexpired&.where(code: code)&.exists?
+            end
+          end
+
+          # Check via observation_units (plural has_many, e.g. DataFile via observation_unit_assets)
+          if respond_to?(:observation_units) && observation_units.any?
+            observation_units.each do |ou|
+              return true if ou.special_auth_codes.unexpired.where(code: code).exists?
+              if ou.study
+                return true if ou.study.special_auth_codes.unexpired.where(code: code).exists?
+                return true if ou.study.investigation&.special_auth_codes&.unexpired&.where(code: code)&.exists?
+              end
             end
           end
         end

--- a/lib/seek/permissions/code_based_authorization.rb
+++ b/lib/seek/permissions/code_based_authorization.rb
@@ -33,7 +33,7 @@ module Seek
             return study.investigation.special_auth_codes.unexpired.where(code: code).exists? if study.investigation
           end
         else
-          if respond_to?(:assays) && assays.any?
+          if respond_to?(:assays)
             assays.each do |assay|
               return true if assay.special_auth_codes.unexpired.where(code: code).exists?
 
@@ -55,7 +55,7 @@ module Seek
           end
 
           # Check via observation_units (plural has_many, e.g. DataFile via observation_unit_assets)
-          if respond_to?(:observation_units) && observation_units.any?
+          if respond_to?(:observation_units)
             observation_units.each do |ou|
               return true if ou.special_auth_codes.unexpired.where(code: code).exists?
               if ou.study

--- a/test/unit/code_based_authorization_test.rb
+++ b/test/unit/code_based_authorization_test.rb
@@ -480,5 +480,200 @@ class CodeBasedAuthorizationTest < ActiveSupport::TestCase
     assert assay.auth_by_code?(assay_code.code), 'Assay accessible with its own code'
     assert data_file.auth_by_code?(assay_code.code), 'DataFile accessible with Assay code'
   end
+
+  # ===============================================
+  # ObservationUnit Tests
+  # ===============================================
+
+  test 'observation_unit auth_by_code with own code' do
+    investigation = FactoryBot.create(:investigation, contributor: @person)
+    study = FactoryBot.create(:study, investigation: investigation, contributor: @person)
+    obs_unit = FactoryBot.create(:observation_unit, study: study, contributor: @person)
+
+    code = nil
+    disable_authorization_checks do
+      code = SpecialAuthCode.create!(
+        asset: obs_unit,
+        code: SecureRandom.base64(30),
+        expiration_date: Date.today + 7.days
+      )
+    end
+
+    assert obs_unit.auth_by_code?(code.code), 'ObservationUnit should be accessible with its own code'
+  end
+
+  test 'observation_unit auth_by_code with parent study code' do
+    investigation = FactoryBot.create(:investigation, contributor: @person)
+    study = FactoryBot.create(:study, investigation: investigation, contributor: @person)
+    obs_unit = FactoryBot.create(:observation_unit, study: study, contributor: @person)
+
+    study_code = nil
+    disable_authorization_checks do
+      study_code = SpecialAuthCode.create!(
+        asset: study,
+        code: SecureRandom.base64(30),
+        expiration_date: Date.today + 7.days
+      )
+    end
+
+    assert obs_unit.auth_by_code?(study_code.code),
+           'ObservationUnit should be accessible with parent Study code (downward propagation)'
+  end
+
+  test 'observation_unit auth_by_code with grandparent investigation code' do
+    investigation = FactoryBot.create(:investigation, contributor: @person)
+    study = FactoryBot.create(:study, investigation: investigation, contributor: @person)
+    obs_unit = FactoryBot.create(:observation_unit, study: study, contributor: @person)
+
+    inv_code = nil
+    disable_authorization_checks do
+      inv_code = SpecialAuthCode.create!(
+        asset: investigation,
+        code: SecureRandom.base64(30),
+        expiration_date: Date.today + 7.days
+      )
+    end
+
+    assert obs_unit.auth_by_code?(inv_code.code),
+           'ObservationUnit should be accessible with grandparent Investigation code (downward propagation)'
+  end
+
+  test 'observation_unit code does not grant access upward to study or investigation' do
+    investigation = FactoryBot.create(:investigation, contributor: @person)
+    study = FactoryBot.create(:study, investigation: investigation, contributor: @person)
+    obs_unit = FactoryBot.create(:observation_unit, study: study, contributor: @person)
+
+    ou_code = nil
+    disable_authorization_checks do
+      ou_code = SpecialAuthCode.create!(
+        asset: obs_unit,
+        code: SecureRandom.base64(30),
+        expiration_date: Date.today + 7.days
+      )
+    end
+
+    refute investigation.auth_by_code?(ou_code.code), 'Investigation NOT accessible with ObservationUnit code'
+    refute study.auth_by_code?(ou_code.code), 'Study NOT accessible with ObservationUnit code'
+    assert obs_unit.auth_by_code?(ou_code.code), 'ObservationUnit accessible with its own code'
+  end
+
+  test 'sample auth_by_code with parent observation_unit code' do
+    investigation = FactoryBot.create(:investigation, contributor: @person)
+    study = FactoryBot.create(:study, investigation: investigation, contributor: @person)
+    obs_unit = FactoryBot.create(:observation_unit, study: study, contributor: @person)
+    sample = FactoryBot.create(:sample, contributor: @person)
+
+    disable_authorization_checks do
+      sample.observation_unit = obs_unit
+      sample.save!
+    end
+
+    ou_code = nil
+    disable_authorization_checks do
+      ou_code = SpecialAuthCode.create!(
+        asset: obs_unit,
+        code: SecureRandom.base64(30),
+        expiration_date: Date.today + 7.days
+      )
+    end
+
+    assert sample.auth_by_code?(ou_code.code),
+           'Sample should be accessible with parent ObservationUnit code (downward propagation)'
+  end
+
+  test 'sample auth_by_code with grandparent study code via observation_unit' do
+    investigation = FactoryBot.create(:investigation, contributor: @person)
+    study = FactoryBot.create(:study, investigation: investigation, contributor: @person)
+    obs_unit = FactoryBot.create(:observation_unit, study: study, contributor: @person)
+    sample = FactoryBot.create(:sample, contributor: @person)
+
+    disable_authorization_checks do
+      sample.observation_unit = obs_unit
+      sample.save!
+    end
+
+    study_code = nil
+    disable_authorization_checks do
+      study_code = SpecialAuthCode.create!(
+        asset: study,
+        code: SecureRandom.base64(30),
+        expiration_date: Date.today + 7.days
+      )
+    end
+
+    assert sample.auth_by_code?(study_code.code),
+           'Sample should be accessible with grandparent Study code via ObservationUnit (downward propagation)'
+  end
+
+  test 'data_file auth_by_code with parent observation_unit code' do
+    investigation = FactoryBot.create(:investigation, contributor: @person)
+    study = FactoryBot.create(:study, investigation: investigation, contributor: @person)
+    obs_unit = FactoryBot.create(:observation_unit, study: study, contributor: @person)
+    data_file = FactoryBot.create(:data_file, contributor: @person)
+
+    disable_authorization_checks do
+      obs_unit.observation_unit_assets.create!(asset: data_file)
+    end
+
+    ou_code = nil
+    disable_authorization_checks do
+      ou_code = SpecialAuthCode.create!(
+        asset: obs_unit,
+        code: SecureRandom.base64(30),
+        expiration_date: Date.today + 7.days
+      )
+    end
+
+    assert data_file.auth_by_code?(ou_code.code),
+           'DataFile should be accessible with parent ObservationUnit code (downward propagation)'
+  end
+
+  test 'data_file auth_by_code with grandparent study code via observation_unit' do
+    investigation = FactoryBot.create(:investigation, contributor: @person)
+    study = FactoryBot.create(:study, investigation: investigation, contributor: @person)
+    obs_unit = FactoryBot.create(:observation_unit, study: study, contributor: @person)
+    data_file = FactoryBot.create(:data_file, contributor: @person)
+
+    disable_authorization_checks do
+      obs_unit.observation_unit_assets.create!(asset: data_file)
+    end
+
+    study_code = nil
+    disable_authorization_checks do
+      study_code = SpecialAuthCode.create!(
+        asset: study,
+        code: SecureRandom.base64(30),
+        expiration_date: Date.today + 7.days
+      )
+    end
+
+    assert data_file.auth_by_code?(study_code.code),
+           'DataFile should be accessible with grandparent Study code via ObservationUnit (downward propagation)'
+  end
+
+  test 'complete ISA hierarchy with observation_unit - investigation code grants access to all levels' do
+    investigation = FactoryBot.create(:investigation, contributor: @person)
+    study = FactoryBot.create(:study, investigation: investigation, contributor: @person)
+    obs_unit = FactoryBot.create(:observation_unit, study: study, contributor: @person)
+    data_file = FactoryBot.create(:data_file, contributor: @person)
+
+    disable_authorization_checks do
+      obs_unit.observation_unit_assets.create!(asset: data_file)
+    end
+
+    inv_code = nil
+    disable_authorization_checks do
+      inv_code = SpecialAuthCode.create!(
+        asset: investigation,
+        code: SecureRandom.base64(30),
+        expiration_date: Date.today + 7.days
+      )
+    end
+
+    assert investigation.auth_by_code?(inv_code.code), 'Investigation accessible with its own code'
+    assert study.auth_by_code?(inv_code.code), 'Study accessible with Investigation code'
+    assert obs_unit.auth_by_code?(inv_code.code), 'ObservationUnit accessible with Investigation code'
+    assert data_file.auth_by_code?(inv_code.code), 'DataFile accessible with Investigation code via ObservationUnit'
+  end
 end
 


### PR DESCRIPTION
## Summary

- Adds temporary access link (special auth code) support for `ObservationUnit`, enabling the sharing link UI on its manage and show pages.
- Extends the auth code chain so that assets linked to an `ObservationUnit` (via `observation_unit` belongs_to or `observation_units` has_many) are granted access when a valid code exists on the `ObservationUnit`, its parent `Study`, or parent `Investigation`.
- Conditionally mentions observation units in the Study temp link help text when the feature is enabled.

Closes https://github.com/seek4science/seek/issues/2554

