### PR TITLE
core annotations ignored when matching sample type for FDS import #2587

### DIFF
--- a/lib/seek/fair_data_station/sample.rb
+++ b/lib/seek/fair_data_station/sample.rb
@@ -18,8 +18,10 @@ module Seek
           # skip types with no matching properties
           next if intersection.empty?
           # skip types where any required attribute is absent from the FDS data — they would fail validation
+          # name/title/description are always populated via core annotation handling even though they're stripped from property_ids
           required_pids = sample_type.sample_attributes.select(&:required?).collect(&:pid).compact_blank
-          next if (required_pids - property_ids).any?
+          always_present_pids = [@schema.name.to_s, @schema.title.to_s, @schema.description.to_s]
+          next if (required_pids - property_ids - always_present_pids).any?
           difference = (property_ids | sample_type_property_ids) - intersection
           [intersection.length, difference.length, sample_type]
         end.sort_by { |x| [-x[0], x[1]] }

--- a/lib/seek/fair_data_station/sample.rb
+++ b/lib/seek/fair_data_station/sample.rb
@@ -12,15 +12,15 @@ module Seek
       end
 
       def find_closest_matching_sample_type(person, property_ids = additional_metadata_annotations.collect { |annotation| annotation[0] })
+        # name/title/description are always populated via core annotation handling even though they're stripped from property_ids
+        always_present_pids = [@schema.name.to_s, @schema.title.to_s, @schema.description.to_s]
         candidates = SampleType.includes(:sample_attributes).authorized_for(:view, person).filter_map do |sample_type|
           sample_type_property_ids = sample_type.sample_attributes.collect(&:pid).compact_blank
           intersection = (property_ids & sample_type_property_ids)
           # skip types with no matching properties
           next if intersection.empty?
           # skip types where any required attribute is absent from the FDS data — they would fail validation
-          # name/title/description are always populated via core annotation handling even though they're stripped from property_ids
           required_pids = sample_type.sample_attributes.select(&:required?).collect(&:pid).compact_blank
-          always_present_pids = [@schema.name.to_s, @schema.title.to_s, @schema.description.to_s]
           next if (required_pids - property_ids - always_present_pids).any?
           difference = (property_ids | sample_type_property_ids) - intersection
           [intersection.length, difference.length, sample_type]

--- a/test/factories/sample_types.rb
+++ b/test/factories/sample_types.rb
@@ -257,12 +257,12 @@ FactoryBot.define do
     title { 'fair data station test case'}
     association :policy, factory: :public_policy
     after(:build) do |type, eval|
-      type.sample_attributes << FactoryBot.build(:sample_attribute, sample_attribute_type: FactoryBot.create(:string_sample_attribute_type), title:'Title', sample_type: type, is_title: true)
+      type.sample_attributes << FactoryBot.build(:sample_attribute, sample_attribute_type: FactoryBot.create(:string_sample_attribute_type), title:'Title', pid:'http://schema.org/name', required: true, sample_type: type, is_title: true)
       type.sample_attributes << FactoryBot.build(:sample_attribute, sample_attribute_type: FactoryBot.create(:string_sample_attribute_type), title:'Description', sample_type: type)
 
       type.sample_attributes << FactoryBot.build(:sample_attribute, sample_attribute_type: FactoryBot.create(:string_sample_attribute_type), title:'Bio safety level', pid:'http://fairbydesign.nl/ontology/biosafety_level', sample_type: type)
-      type.sample_attributes << FactoryBot.build(:sample_attribute, sample_attribute_type: FactoryBot.create(:string_sample_attribute_type), title:'Scientific name', pid:'http://gbol.life/0.1/scientificName', sample_type: type)
-      type.sample_attributes << FactoryBot.build(:sample_attribute, sample_attribute_type: FactoryBot.create(:string_sample_attribute_type), title:'Organism ncbi id', pid:'http://purl.uniprot.org/core/organism', sample_type: type)
+      type.sample_attributes << FactoryBot.build(:sample_attribute, sample_attribute_type: FactoryBot.create(:string_sample_attribute_type), title:'Scientific name', pid:'http://gbol.life/0.1/scientificName', required: true, sample_type: type)
+      type.sample_attributes << FactoryBot.build(:sample_attribute, sample_attribute_type: FactoryBot.create(:string_sample_attribute_type), title:'Organism ncbi id', pid:'http://purl.uniprot.org/core/organism', required: true, sample_type: type)
       type.sample_attributes << FactoryBot.build(:sample_attribute, sample_attribute_type: FactoryBot.create(:string_sample_attribute_type), title:'Collection date', pid:'https://w3id.org/mixs/0000011', sample_type: type)
     end
   end

--- a/test/unit/fair_data_station/fair_data_station_objects_test.rb
+++ b/test/unit/fair_data_station/fair_data_station_objects_test.rb
@@ -225,14 +225,11 @@ class FairDataStationObjectsTest < ActiveSupport::TestCase
     inv = Seek::FairDataStation::Reader.new.parse_graph(path).first
     sample = inv.studies.first.observation_units.first.samples.first
 
-    # create a type whose Title attribute has pid=schema:name (required) — a core annotation that is stripped from
-    # property_ids before matching, but is always populated via populate_seek_sample
-    type_with_core_required = FactoryBot.create(:fairdatastation_test_case_sample_type)
-    title_attr = type_with_core_required.sample_attributes.find { |a| a.title == 'Title' }
-    title_attr.update!(pid: 'http://schema.org/name', required: true)
-    type_with_core_required.reload
+    # Title has pid=schema:name (required) — a core annotation stripped from property_ids but always populated via populate_seek_sample
+    type = FactoryBot.create(:fairdatastation_test_case_sample_type)
+    assert type.sample_attributes.find { |a| a.title == 'Title' }.required?
 
-    assert_equal type_with_core_required, sample.find_closest_matching_sample_type(nil)
+    assert_equal type, sample.find_closest_matching_sample_type(nil)
   end
 
   test 'find closest matching extended metadata type excludes types with missing required attributes' do

--- a/test/unit/fair_data_station/fair_data_station_objects_test.rb
+++ b/test/unit/fair_data_station/fair_data_station_objects_test.rb
@@ -220,6 +220,21 @@ class FairDataStationObjectsTest < ActiveSupport::TestCase
     assert_equal valid_type, sample.find_closest_matching_sample_type(nil)
   end
 
+  test 'find closest matching sample type does not exclude types where only missing required attributes are core annotations' do
+    path = "#{Rails.root}/test/fixtures/files/fair_data_station/seek-fair-data-station-test-case.ttl"
+    inv = Seek::FairDataStation::Reader.new.parse_graph(path).first
+    sample = inv.studies.first.observation_units.first.samples.first
+
+    # create a type whose Title attribute has pid=schema:name (required) — a core annotation that is stripped from
+    # property_ids before matching, but is always populated via populate_seek_sample
+    type_with_core_required = FactoryBot.create(:fairdatastation_test_case_sample_type)
+    title_attr = type_with_core_required.sample_attributes.find { |a| a.title == 'Title' }
+    title_attr.update!(pid: 'http://schema.org/name', required: true)
+    type_with_core_required.reload
+
+    assert_equal type_with_core_required, sample.find_closest_matching_sample_type(nil)
+  end
+
   test 'find closest matching extended metadata type excludes types with missing required attributes' do
     path = "#{Rails.root}/test/fixtures/files/fair_data_station/seek-fair-data-station-test-case.ttl"
     inv = Seek::FairDataStation::Reader.new.parse_graph(path).first


### PR DESCRIPTION
Fixes #2587

## Summary

- When matching sample types during FDS import, `find_closest_matching_sample_type` uses `additional_metadata_annotations` as its default `property_ids`, which strips core annotations (`schema:name`, `schema:title`, `schema:description`)
- The required-field check introduced in #2578 would then incorrectly reject sample types that have any of those pids as required attributes, even though `populate_seek_sample` always sets Title and Description from core annotations
- Fix: compute `always_present_pids` (the three schema pids that are always populated) before the loop and subtract them from the required-pid check
- Extended metadata is not affected — core annotations are never written into EMT data, so rejecting an EMT with a required core annotation pid is correct behaviour
- Updated `fairdatastation_test_case_sample_type` factory to reflect real-world FDS sample types: Title now has `pid: 'http://schema.org/name'` and `required: true`, and Scientific name (`http://gbol.life/0.1/scientificName`) and Organism ncbi id (`http://purl.uniprot.org/core/organism`) are also marked required — matching the `schema:valueRequired true` declarations in the RDF fixture
