### PR TITLE
Fix model files lost after validation error on create (#2582)

### DIFF
--- a/app/assets/javascripts/upload.js
+++ b/app/assets/javascripts/upload.js
@@ -36,7 +36,7 @@ $j(document).ready(function () {
         // Local file
         var addLocalFile = function () {
             var newField = HandlebarsTemplates['upload/file_field']();
-            $j(this).parent().append(newField);
+            $j(this).parent().append($j(newField).addClass('hide-no-file-text'));
             var filename = this.value.split(/\\/)[this.value.split(/\\/).length - 1];
             var listItem = $j(HandlebarsTemplates['upload/local_file']({ text: filename }));
             pending.append(listItem);
@@ -44,6 +44,12 @@ $j(document).ready(function () {
         };
 
         field.on('change', 'input[type=file][data-batch-upload=true]', addLocalFile);
+
+        // When existing files are already listed (e.g. after a validation error re-render),
+        // hide the "No file chosen" text beside the file input since files are already shown.
+        if (pending.children().length > 0) {
+            $j('input[type=file][data-batch-upload=true]', field).first().addClass('hide-no-file-text');
+        }
 
         // Remote file
         var addRemoteFile = function () {

--- a/app/assets/javascripts/validation.js
+++ b/app/assets/javascripts/validation.js
@@ -35,7 +35,9 @@ function validateUploadFormFields(resourceName=null, parentId=null) {
 
     // Also count retained blobs from a previous upload attempt (shown after a validation error)
     if (!hasFiles) {
-        hasFiles = $j('input[name="retained_content_blob_ids[]"]').toArray().some(function (f) { return f.value; });
+        var retainedSelector = 'input[name="retained_content_blob_ids[]"]';
+        var retained = parentId ? $j(`#${parentId} ${retainedSelector}`) : $j(retainedSelector);
+        hasFiles = retained.toArray().some(function (f) { return f.value; });
     }
     var valid = true;
 

--- a/app/assets/javascripts/validation.js
+++ b/app/assets/javascripts/validation.js
@@ -35,8 +35,8 @@ function validateUploadFormFields(resourceName=null, parentId=null) {
 
     // Also count retained blobs from a previous upload attempt (shown after a validation error)
     if (!hasFiles) {
-        var retainedSelector = 'input[name="retained_content_blob_ids[]"]';
-        var retained = parentId ? $j(`#${parentId} ${retainedSelector}`) : $j(retainedSelector);
+        const retainedSelector = 'input[name="retained_content_blob_ids[]"]';
+        const retained = parentId ? $j(`#${parentId} ${retainedSelector}`) : $j(retainedSelector);
         hasFiles = retained.toArray().some(function (f) { return f.value; });
     }
     var valid = true;

--- a/app/assets/javascripts/validation.js
+++ b/app/assets/javascripts/validation.js
@@ -32,6 +32,11 @@ function validateUploadFormFields(resourceName=null, parentId=null) {
     }
 
     var hasFiles = files.toArray().some(function (f) { return f.value }); // Count non-blank file fields
+
+    // Also count retained blobs from a previous upload attempt (shown after a validation error)
+    if (!hasFiles) {
+        hasFiles = $j('input[name="retained_content_blob_ids[]"]').toArray().some(function (f) { return f.value; });
+    }
     var valid = true;
 
     if ($j('#model_image_image_file').length) { // If it's a model...

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -610,6 +610,12 @@ li.upload-field-tab {
   cursor: pointer;
 }
 
+// Hides the "No file chosen" label beside the native file input button without affecting the button itself.
+// Used when files are already shown in the pending list, so the label is misleading.
+input[type="file"].hide-no-file-text {
+  color: transparent;
+}
+
 img.github-logo {
   width: 16px;
   height: 16px;

--- a/lib/seek/assets_standard_controller_actions.rb
+++ b/lib/seek/assets_standard_controller_actions.rb
@@ -131,21 +131,41 @@ module Seek
     def create_asset_and_respond(item)
       item = create_asset(item)
       if item.save
+        attach_retained_orphaned_content_blobs(item)
         unless return_to_fancy_parent(item)
           flash[:notice] = "#{t(item.class.name.underscore)} was successfully uploaded and saved."
           respond_to do |format|
             format.html { redirect_to params[:single_page] ?
-              { controller: :single_pages, action: :show, id: params[:single_page] } 
+              { controller: :single_pages, action: :show, id: params[:single_page] }
               : item }
             format.json { render json: item, include: json_api_include_param }
           end
         end
       else
+        preserve_content_blobs_for_rerender(item)
         respond_to do |format|
           format.html { render action: 'new' }
           format.json { render json: json_api_errors(item), status: :unprocessable_entity }
         end
       end
+    end
+
+    # Saves any unsaved content blobs as orphaned records (no parent asset) so they have database IDs
+    # and their file data is persisted on disk. This allows the re-rendered form to reference them
+    # by ID via retained_content_blob_ids, so they survive a validation error on multi-file assets.
+    def preserve_content_blobs_for_rerender(item)
+      return unless Seek::Util.is_multi_file_asset_type?(item.class)
+      item.content_blobs.select(&:new_record?).each { |blob| blob.save(validate: false) }
+    end
+
+    # After a successful save, updates any orphaned content blobs (saved during a previous failed
+    # validation attempt) to point to the newly created asset. Only applies to multi-file assets.
+    def attach_retained_orphaned_content_blobs(item)
+      return unless Seek::Util.is_multi_file_asset_type?(item.class)
+      ids = retained_content_blob_ids.select(&:positive?)
+      return if ids.blank?
+      ContentBlob.where(id: ids, asset_id: nil)
+                 .update_all(asset_id: item.id, asset_type: item.class.name, asset_version: item.version)
     end
 
     # makes sure the asset it only associated with projects that match the current user

--- a/lib/seek/assets_standard_controller_actions.rb
+++ b/lib/seek/assets_standard_controller_actions.rb
@@ -156,7 +156,10 @@ module Seek
     def preserve_content_blobs_for_rerender(item)
       return unless Seek::Util.is_multi_file_asset_type?(item.class)
 
-      item.content_blobs.select(&:new_record?).each { |blob| blob.save(validate: false) }
+      saved_ids = item.content_blobs.select(&:new_record?).filter_map do |blob|
+        blob.id if blob.save(validate: false)
+      end
+      session[:orphaned_content_blob_ids] = (session[:orphaned_content_blob_ids] || []) | saved_ids
     end
 
     # After a successful save, updates any orphaned content blobs (saved during a previous failed
@@ -164,11 +167,12 @@ module Seek
     def attach_retained_orphaned_content_blobs(item)
       return unless Seek::Util.is_multi_file_asset_type?(item.class)
 
-      ids = retained_content_blob_ids.select(&:positive?)
+      ids = safe_retained_content_blob_ids
       return if ids.blank?
 
       ContentBlob.where(id: ids, asset_id: nil)
                  .update_all(asset_id: item.id, asset_type: item.class.name, asset_version: item.version)
+      session[:orphaned_content_blob_ids] = (session[:orphaned_content_blob_ids] || []) - ids
     end
 
     # makes sure the asset it only associated with projects that match the current user

--- a/lib/seek/assets_standard_controller_actions.rb
+++ b/lib/seek/assets_standard_controller_actions.rb
@@ -108,6 +108,8 @@ module Seek
     def manage; end
 
     def create
+      session.delete(:orphaned_content_blob_ids) if retained_content_blob_ids.blank?
+
       item = initialize_asset
 
       if item.is_git_versioned? || handle_upload_data
@@ -170,8 +172,9 @@ module Seek
       ids = safe_retained_content_blob_ids
       return if ids.blank?
 
-      ContentBlob.where(id: ids, asset_id: nil)
-                 .update_all(asset_id: item.id, asset_type: item.class.name, asset_version: item.version)
+      ContentBlob.where(id: ids, asset_id: nil).each do |blob|
+        blob.update(asset_id: item.id, asset_type: item.class.name, asset_version: item.version)
+      end
       session[:orphaned_content_blob_ids] = (session[:orphaned_content_blob_ids] || []) - ids
     end
 

--- a/lib/seek/assets_standard_controller_actions.rb
+++ b/lib/seek/assets_standard_controller_actions.rb
@@ -158,9 +158,7 @@ module Seek
     def preserve_content_blobs_for_rerender(item)
       return unless Seek::Util.is_multi_file_asset_type?(item.class)
 
-      saved_ids = item.content_blobs.select(&:new_record?).filter_map do |blob|
-        blob.id if blob.save
-      end
+      saved_ids = item.content_blobs.select(&:new_record?).filter_map { |blob| save_orphaned_blob(blob) }
       session[:orphaned_content_blob_ids] = (session[:orphaned_content_blob_ids] || []) | saved_ids
     end
 
@@ -172,10 +170,10 @@ module Seek
       ids = safe_retained_content_blob_ids
       return if ids.blank?
 
-      ContentBlob.where(id: ids, asset_id: nil).each do |blob|
-        blob.update(asset_id: item.id, asset_type: item.class.name, asset_version: item.version)
+      attached_ids = ContentBlob.where(id: ids, asset_id: nil).filter_map do |blob|
+        blob.id if blob.update(asset_id: item.id, asset_type: item.class.name, asset_version: item.version)
       end
-      session[:orphaned_content_blob_ids] = (session[:orphaned_content_blob_ids] || []) - ids
+      session[:orphaned_content_blob_ids] = (session[:orphaned_content_blob_ids] || []) - attached_ids
     end
 
     # makes sure the asset it only associated with projects that match the current user
@@ -229,6 +227,13 @@ module Seek
 
     def json_api_include_param
       [params[:include]]
+    end
+
+    def save_orphaned_blob(blob)
+      return blob.id if blob.save
+
+      Rails.logger.warn "Failed to preserve content blob for re-render: #{blob.errors.full_messages.join(', ')}"
+      nil
     end
   end
 end

--- a/lib/seek/assets_standard_controller_actions.rb
+++ b/lib/seek/assets_standard_controller_actions.rb
@@ -155,6 +155,7 @@ module Seek
     # by ID via retained_content_blob_ids, so they survive a validation error on multi-file assets.
     def preserve_content_blobs_for_rerender(item)
       return unless Seek::Util.is_multi_file_asset_type?(item.class)
+
       item.content_blobs.select(&:new_record?).each { |blob| blob.save(validate: false) }
     end
 
@@ -162,8 +163,10 @@ module Seek
     # validation attempt) to point to the newly created asset. Only applies to multi-file assets.
     def attach_retained_orphaned_content_blobs(item)
       return unless Seek::Util.is_multi_file_asset_type?(item.class)
+
       ids = retained_content_blob_ids.select(&:positive?)
       return if ids.blank?
+
       ContentBlob.where(id: ids, asset_id: nil)
                  .update_all(asset_id: item.id, asset_type: item.class.name, asset_version: item.version)
     end

--- a/lib/seek/assets_standard_controller_actions.rb
+++ b/lib/seek/assets_standard_controller_actions.rb
@@ -157,7 +157,7 @@ module Seek
       return unless Seek::Util.is_multi_file_asset_type?(item.class)
 
       saved_ids = item.content_blobs.select(&:new_record?).filter_map do |blob|
-        blob.id if blob.save(validate: false)
+        blob.id if blob.save
       end
       session[:orphaned_content_blob_ids] = (session[:orphaned_content_blob_ids] || []) | saved_ids
     end

--- a/lib/seek/upload_handling/data_upload.rb
+++ b/lib/seek/upload_handling/data_upload.rb
@@ -129,7 +129,7 @@ module Seek
       # asset's in-memory association, so they appear correctly on re-render and are available for
       # attachment after a successful save.
       def load_orphaned_content_blobs(asset)
-        retained_ids = retained_content_blob_ids.select(&:positive?)
+        retained_ids = safe_retained_content_blob_ids
         return if retained_ids.blank?
         return unless asset.respond_to?(:content_blobs)
 

--- a/lib/seek/upload_handling/data_upload.rb
+++ b/lib/seek/upload_handling/data_upload.rb
@@ -74,7 +74,10 @@ module Seek
 
         unless model_image_present? && params[:content_blobs].blank?
           (params[:content_blobs] || []).each do |item_params|
-            next if item_params[:tmp_io_object].blank? && item_params[:data_url].blank? && item_params[:base64_data].blank?
+            next if item_params[:tmp_io_object].blank? &&
+                    item_params[:data_url].blank? &&
+                    item_params[:base64_data].blank?
+
             attributes = build_attributes_hash_for_content_blob(item_params, version)
             if asset.respond_to?(:content_blobs)
               asset.content_blobs.build(attributes)
@@ -92,8 +95,11 @@ module Seek
           raise 'No content-blob defined'
         end
 
-        retain_previous_content_blobs(asset, version) if version && version > 1
-        load_orphaned_content_blobs(asset) unless version && version > 1
+        if version && version > 1
+          retain_previous_content_blobs(asset, version)
+        else
+          load_orphaned_content_blobs(asset)
+        end
       end
 
       def build_attributes_hash_for_content_blob(item_params, version)

--- a/lib/seek/upload_handling/data_upload.rb
+++ b/lib/seek/upload_handling/data_upload.rb
@@ -73,7 +73,8 @@ module Seek
         version += 1 if new_version
 
         unless model_image_present? && params[:content_blobs].blank?
-          content_blobs_params.each do |item_params|
+          (params[:content_blobs] || []).each do |item_params|
+            next if item_params[:tmp_io_object].blank? && item_params[:data_url].blank? && item_params[:base64_data].blank?
             attributes = build_attributes_hash_for_content_blob(item_params, version)
             if asset.respond_to?(:content_blobs)
               asset.content_blobs.build(attributes)
@@ -92,6 +93,7 @@ module Seek
         end
 
         retain_previous_content_blobs(asset, version) if version && version > 1
+        load_orphaned_content_blobs(asset) unless version && version > 1
       end
 
       def build_attributes_hash_for_content_blob(item_params, version)
@@ -113,6 +115,19 @@ module Seek
           retained_blobs.each do |blob|
             copy_blob_to_asset(asset, blob, new_version)
           end
+        end
+      end
+
+      # Loads previously saved orphaned content blobs (from a failed validation attempt) into the
+      # asset's in-memory association, so they appear correctly on re-render and are available for
+      # attachment after a successful save.
+      def load_orphaned_content_blobs(asset)
+        retained_ids = retained_content_blob_ids.select(&:positive?)
+        return if retained_ids.blank?
+        return unless asset.respond_to?(:content_blobs)
+
+        ContentBlob.where(id: retained_ids, asset_id: nil).each do |blob|
+          asset.content_blobs.target.push(blob)
         end
       end
 

--- a/lib/seek/upload_handling/data_upload.rb
+++ b/lib/seek/upload_handling/data_upload.rb
@@ -34,7 +34,10 @@ module Seek
         end
 
         blob_params.each do |item_params|
-          return false unless allow_empty_content_blob || check_for_data_or_url(item_params)
+          unless allow_empty_content_blob || check_for_data_or_url(item_params)
+            flash.now[:error] ||= missing_content_error(item_params) || 'Please select a file to upload or provide a URL to the data.'
+            return false
+          end
 
           if add_from_upload?(item_params)
             return false unless add_data_for_upload(item_params)

--- a/lib/seek/upload_handling/data_upload.rb
+++ b/lib/seek/upload_handling/data_upload.rb
@@ -35,7 +35,8 @@ module Seek
 
         blob_params.each do |item_params|
           unless allow_empty_content_blob || check_for_data_or_url(item_params)
-            flash.now[:error] ||= missing_content_error(item_params) || 'Please select a file to upload or provide a URL to the data.'
+            flash.now[:error] ||= missing_content_error(item_params) ||
+                                  'Please select a file to upload or provide a URL to the data.'
             return false
           end
 

--- a/lib/seek/upload_handling/data_upload.rb
+++ b/lib/seek/upload_handling/data_upload.rb
@@ -22,7 +22,7 @@ module Seek
 
         allow_empty_content_blob = model_image_present? || json_api_request?
 
-        unless allow_empty_content_blob || retained_content_blob_ids.present?
+        unless allow_empty_content_blob || safe_retained_content_blob_ids.present?
           if blob_params.empty? || blob_params.none? { |p| check_for_data_or_url(p) }
             flash.now[:error] ||= 'Please select a file to upload or provide a URL to the data.'
             return false
@@ -134,7 +134,7 @@ module Seek
         return unless asset.respond_to?(:content_blobs)
 
         ContentBlob.where(id: retained_ids, asset_id: nil).each do |blob|
-          asset.content_blobs.target.push(blob)
+          asset.content_blobs.proxy_association.add_to_target(blob)
         end
       end
 

--- a/lib/seek/upload_handling/data_upload.rb
+++ b/lib/seek/upload_handling/data_upload.rb
@@ -74,7 +74,8 @@ module Seek
 
         unless model_image_present? && params[:content_blobs].blank?
           (params[:content_blobs] || []).each do |item_params|
-            next if item_params[:tmp_io_object].blank? &&
+            next if !json_api_request? &&
+                    item_params[:tmp_io_object].blank? &&
                     item_params[:data_url].blank? &&
                     item_params[:base64_data].blank?
 

--- a/lib/seek/upload_handling/data_upload.rb
+++ b/lib/seek/upload_handling/data_upload.rb
@@ -35,8 +35,7 @@ module Seek
 
         blob_params.each do |item_params|
           unless allow_empty_content_blob || check_for_data_or_url(item_params)
-            flash.now[:error] ||= missing_content_error(item_params) ||
-                                  'Please select a file to upload or provide a URL to the data.'
+            flash.now[:error] ||= missing_content_error(item_params)
             return false
           end
 

--- a/lib/seek/upload_handling/parameter_handling.rb
+++ b/lib/seek/upload_handling/parameter_handling.rb
@@ -22,7 +22,7 @@ module Seek
       # Returns retained blob IDs that were recorded in the session during a previous failed save,
       # preventing a user from attaching blobs they did not upload by tampering with params.
       def safe_retained_content_blob_ids
-        allowed = (session[:orphaned_content_blob_ids] || [])
+        allowed = session[:orphaned_content_blob_ids] || []
         retained_content_blob_ids & allowed
       end
 

--- a/lib/seek/upload_handling/parameter_handling.rb
+++ b/lib/seek/upload_handling/parameter_handling.rb
@@ -31,17 +31,14 @@ module Seek
       end
 
       def check_for_data_or_url(blob_param)
-        if blob_param[:data].blank? && blob_param[:data_url].blank? && blob_param[:base64_data].blank?
-          if blob_param.include?(:data_url)
-            flash.now[:error] = 'Please select a file to upload or provide a URL to the data.'
-          elsif blob_param.include?(:data_url)
-            flash.now[:error] = 'Please select a file to upload.'
-          else
-            # What to do?
-          end
-          false
-        else
-          true
+        blob_param[:data].present? || blob_param[:data_url].present? || blob_param[:base64_data].present?
+      end
+
+      def missing_content_error(blob_param)
+        if blob_param.include?(:data_url)
+          'Please select a file to upload or provide a URL to the data.'
+        elsif blob_param.include?(:data)
+          'Please select a file to upload.'
         end
       end
 

--- a/lib/seek/upload_handling/parameter_handling.rb
+++ b/lib/seek/upload_handling/parameter_handling.rb
@@ -16,13 +16,13 @@ module Seek
       end
 
       def retained_content_blob_ids
-        (params[:retained_content_blob_ids] || []).map(&:to_i).sort
+        (params[:retained_content_blob_ids] || []).map(&:to_i).select(&:positive?).sort
       end
 
       # Returns retained blob IDs that were recorded in the session during a previous failed save,
       # preventing a user from attaching blobs they did not upload by tampering with params.
       def safe_retained_content_blob_ids
-        allowed = session[:orphaned_content_blob_ids] || []
+        allowed = (session[:orphaned_content_blob_ids] || []).map(&:to_i)
         retained_content_blob_ids & allowed
       end
 

--- a/lib/seek/upload_handling/parameter_handling.rb
+++ b/lib/seek/upload_handling/parameter_handling.rb
@@ -37,7 +37,7 @@ module Seek
       def missing_content_error(blob_param)
         if blob_param.include?(:data_url)
           'Please select a file to upload or provide a URL to the data.'
-        elsif blob_param.include?(:data)
+        else
           'Please select a file to upload.'
         end
       end

--- a/lib/seek/upload_handling/parameter_handling.rb
+++ b/lib/seek/upload_handling/parameter_handling.rb
@@ -19,6 +19,13 @@ module Seek
         (params[:retained_content_blob_ids] || []).map(&:to_i).sort
       end
 
+      # Returns retained blob IDs that were recorded in the session during a previous failed save,
+      # preventing a user from attaching blobs they did not upload by tampering with params.
+      def safe_retained_content_blob_ids
+        allowed = (session[:orphaned_content_blob_ids] || [])
+        retained_content_blob_ids & allowed
+      end
+
       def model_image_present?
         params[:model_image] && params[:model_image][:image_file]
       end

--- a/test/functional/models_controller_test.rb
+++ b/test/functional/models_controller_test.rb
@@ -275,7 +275,7 @@ class ModelsControllerTest < ActionController::TestCase
 
     other_persons_orphan.reload
     assert_nil other_persons_orphan.asset_id, 'Tampered blob should not have been attached'
-    assert_not_nil flash.now[:error]
+    assert_equal 'Please select a file to upload or provide a URL to the data.', flash.now[:error]
   end
 
   test 'associates assay' do

--- a/test/functional/models_controller_test.rb
+++ b/test/functional/models_controller_test.rb
@@ -229,6 +229,7 @@ class ModelsControllerTest < ActionController::TestCase
     orphaned_blobs = ContentBlob.where(asset_id: nil).where.not(id: blobs_before)
     assert_equal 2, orphaned_blobs.count
     assert orphaned_blobs.all?(&:file_exists?), 'Orphaned blob files should exist on disk'
+    assert_equal orphaned_blobs.map(&:id).sort, session[:orphaned_content_blob_ids].sort
   end
 
   test 'orphaned content blobs attached to model on successful resubmit after validation error' do

--- a/test/functional/models_controller_test.rb
+++ b/test/functional/models_controller_test.rb
@@ -210,6 +210,54 @@ class ModelsControllerTest < ActionController::TestCase
     assert_not_nil flash.now[:error]
   end
 
+  test 'content blobs preserved as orphans after validation error, and attached on successful resubmit' do
+    # Submit with valid files but invalid model (no projects) → validation error
+    invalid_model = { title: 'Test' }
+    blob1_params = { data: file_for_upload, data_url: '', original_filename: '', make_local_copy: '0' }
+    blob2_params = { data: fixture_file_upload('little_file_v2.txt', 'text/plain'), data_url: '', original_filename: '', make_local_copy: '0' }
+
+    blobs_before = ContentBlob.where(asset_id: nil).pluck(:id)
+
+    assert_no_difference('Model.count') do
+      assert_difference('ContentBlob.count', 2) do
+        post :create, params: { model: invalid_model, content_blobs: [blob1_params, blob2_params], policy_attributes: valid_sharing }
+      end
+    end
+
+    assert_response :success
+    assert assigns(:model).errors.any?
+
+    # Orphaned blobs should be saved to DB with IDs but no parent asset
+    orphaned_blobs = ContentBlob.where(asset_id: nil).where.not(id: blobs_before)
+    assert_equal 2, orphaned_blobs.count
+    orphan_ids = orphaned_blobs.pluck(:id)
+    assert orphaned_blobs.all?(&:file_exists?), 'Orphaned blob files should exist on disk'
+
+    # Resubmit with fixed model params and retained blob IDs
+    assert_difference('Model.count', 1) do
+      assert_no_difference('ContentBlob.count') do
+        post :create, params: {
+          model: valid_model,
+          content_blobs: [{ data_url: '' }],
+          retained_content_blob_ids: orphan_ids.map(&:to_s),
+          policy_attributes: valid_sharing
+        }
+      end
+    end
+
+    assert_redirected_to model_path(assigns(:model))
+    created_model = assigns(:model)
+
+    # The orphaned blobs are now attached to the model
+    attached_blobs = ContentBlob.where(id: orphan_ids)
+    assert_equal 2, attached_blobs.count
+    attached_blobs.each do |blob|
+      assert_equal created_model.id, blob.asset_id
+      assert_equal 'Model', blob.asset_type
+      assert_equal 1, blob.asset_version
+    end
+  end
+
   test 'associates assay' do
     login_as(:model_owner) # can edit assay_can_edit_by_my_first_sop_owner
     m = models(:teusink)

--- a/test/functional/models_controller_test.rb
+++ b/test/functional/models_controller_test.rb
@@ -261,10 +261,10 @@ class ModelsControllerTest < ActionController::TestCase
     end
   end
 
-  test 'tampered retained_content_blob_ids not in session are not attached' do
+  test 'tampered retained_content_blob_ids not in session are not attached and model is not created' do
     other_persons_orphan = FactoryBot.create(:content_blob, original_filename: 'stolen.txt')
 
-    assert_difference('Model.count', 1) do
+    assert_no_difference('Model.count') do
       post :create, params: {
         model: valid_model,
         content_blobs: [{ data_url: '' }],
@@ -275,6 +275,7 @@ class ModelsControllerTest < ActionController::TestCase
 
     other_persons_orphan.reload
     assert_nil other_persons_orphan.asset_id, 'Tampered blob should not have been attached'
+    assert_not_nil flash.now[:error]
   end
 
   test 'associates assay' do

--- a/test/functional/models_controller_test.rb
+++ b/test/functional/models_controller_test.rb
@@ -232,7 +232,6 @@ class ModelsControllerTest < ActionController::TestCase
   end
 
   test 'orphaned content blobs attached to model on successful resubmit after validation error' do
-    # Simulate blobs saved as orphans during a prior failed attempt
     orphan1 = FactoryBot.create(:content_blob, original_filename: 'file1.txt')
     orphan2 = FactoryBot.create(:content_blob, original_filename: 'file2.txt')
     orphan_ids = [orphan1.id, orphan2.id]
@@ -244,7 +243,7 @@ class ModelsControllerTest < ActionController::TestCase
           content_blobs: [{ data_url: '' }],
           retained_content_blob_ids: orphan_ids.map(&:to_s),
           policy_attributes: valid_sharing
-        }
+        }, session: { orphaned_content_blob_ids: orphan_ids }
       end
     end
 
@@ -257,6 +256,22 @@ class ModelsControllerTest < ActionController::TestCase
       assert_equal 'Model', blob.asset_type
       assert_equal 1, blob.asset_version
     end
+  end
+
+  test 'tampered retained_content_blob_ids not in session are not attached' do
+    other_persons_orphan = FactoryBot.create(:content_blob, original_filename: 'stolen.txt')
+
+    assert_difference('Model.count', 1) do
+      post :create, params: {
+        model: valid_model,
+        content_blobs: [{ data_url: '' }],
+        retained_content_blob_ids: [other_persons_orphan.id.to_s],
+        policy_attributes: valid_sharing
+      }
+    end
+
+    other_persons_orphan.reload
+    assert_nil other_persons_orphan.asset_id, 'Tampered blob should not have been attached'
   end
 
   test 'associates assay' do

--- a/test/functional/models_controller_test.rb
+++ b/test/functional/models_controller_test.rb
@@ -213,13 +213,15 @@ class ModelsControllerTest < ActionController::TestCase
   test 'content blobs preserved as orphans after validation error' do
     invalid_model = { title: 'Test' }
     blob1_params = { data: file_for_upload, data_url: '', original_filename: '', make_local_copy: '0' }
-    blob2_params = { data: fixture_file_upload('little_file_v2.txt', 'text/plain'), data_url: '', original_filename: '', make_local_copy: '0' }
+    blob2_params = { data: fixture_file_upload('little_file_v2.txt', 'text/plain'),
+                     data_url: '', original_filename: '', make_local_copy: '0' }
 
     blobs_before = ContentBlob.where(asset_id: nil).pluck(:id)
 
     assert_no_difference('Model.count') do
       assert_difference('ContentBlob.count', 2) do
-        post :create, params: { model: invalid_model, content_blobs: [blob1_params, blob2_params], policy_attributes: valid_sharing }
+        post :create, params: { model: invalid_model, content_blobs: [blob1_params, blob2_params],
+                                policy_attributes: valid_sharing }
       end
     end
 

--- a/test/functional/models_controller_test.rb
+++ b/test/functional/models_controller_test.rb
@@ -210,8 +210,7 @@ class ModelsControllerTest < ActionController::TestCase
     assert_not_nil flash.now[:error]
   end
 
-  test 'content blobs preserved as orphans after validation error, and attached on successful resubmit' do
-    # Submit with valid files but invalid model (no projects) → validation error
+  test 'content blobs preserved as orphans after validation error' do
     invalid_model = { title: 'Test' }
     blob1_params = { data: file_for_upload, data_url: '', original_filename: '', make_local_copy: '0' }
     blob2_params = { data: fixture_file_upload('little_file_v2.txt', 'text/plain'), data_url: '', original_filename: '', make_local_copy: '0' }
@@ -227,13 +226,17 @@ class ModelsControllerTest < ActionController::TestCase
     assert_response :success
     assert assigns(:model).errors.any?
 
-    # Orphaned blobs should be saved to DB with IDs but no parent asset
     orphaned_blobs = ContentBlob.where(asset_id: nil).where.not(id: blobs_before)
     assert_equal 2, orphaned_blobs.count
-    orphan_ids = orphaned_blobs.pluck(:id)
     assert orphaned_blobs.all?(&:file_exists?), 'Orphaned blob files should exist on disk'
+  end
 
-    # Resubmit with fixed model params and retained blob IDs
+  test 'orphaned content blobs attached to model on successful resubmit after validation error' do
+    # Simulate blobs saved as orphans during a prior failed attempt
+    orphan1 = FactoryBot.create(:content_blob, original_filename: 'file1.txt')
+    orphan2 = FactoryBot.create(:content_blob, original_filename: 'file2.txt')
+    orphan_ids = [orphan1.id, orphan2.id]
+
     assert_difference('Model.count', 1) do
       assert_no_difference('ContentBlob.count') do
         post :create, params: {
@@ -248,10 +251,8 @@ class ModelsControllerTest < ActionController::TestCase
     assert_redirected_to model_path(assigns(:model))
     created_model = assigns(:model)
 
-    # The orphaned blobs are now attached to the model
-    attached_blobs = ContentBlob.where(id: orphan_ids)
-    assert_equal 2, attached_blobs.count
-    attached_blobs.each do |blob|
+    orphan_ids.each do |id|
+      blob = ContentBlob.find(id)
       assert_equal created_model.id, blob.asset_id
       assert_equal 'Model', blob.asset_type
       assert_equal 1, blob.asset_version


### PR DESCRIPTION
## Summary

Fixes #2582 — uploaded model files were silently lost when a validation error occurred during creation and the user resubmitted the form.

**Root cause:** `ContentBlob` records built on an unsaved `Model` have no database ID. The `existing_file.hbs` template uses `{{id}}` to populate `retained_content_blob_ids[]` hidden fields, so with `id = nil` the fields submitted as empty strings and the files were discarded on resubmit.

- On validation failure, save the in-memory `ContentBlob` records as orphans (no `asset_id`) so they get real database IDs the form can reference
- On resubmit, load those orphaned blobs back into the in-memory association so they are treated as already-attached
- On successful save, update the orphaned blobs' `asset_id`/`asset_type`/`asset_version` to point to the newly created model
- Use the session as an ownership allowlist for retained blob IDs, preventing a user from attaching blobs they did not upload by tampering with params
- Fix client-side `validateUploadFormFields` in `validation.js` to also check `retained_content_blob_ids[]` inputs, preventing a spurious "Please specify at least a file/image" alert on resubmit
- Hide the "No file chosen" label beside the file input button when files are already shown in the pending list

Orphaned blobs from abandoned sessions are cleaned up by the existing `RegularMaintenanceJob#remove_dangling_content_blobs` after 8 hours.

## Changes

- `lib/seek/assets_standard_controller_actions.rb` — `preserve_content_blobs_for_rerender` and `attach_retained_orphaned_content_blobs`
- `lib/seek/upload_handling/data_upload.rb` — `load_orphaned_content_blobs` using `add_to_target`; use `safe_retained_content_blob_ids` throughout
- `lib/seek/upload_handling/parameter_handling.rb` — `retained_content_blob_ids` and `safe_retained_content_blob_ids` (session-based allowlist)
- `app/assets/javascripts/upload.js` — hide "No file chosen" text when files are already listed
- `app/assets/javascripts/validation.js` — check retained blob IDs in client-side validation; scope retained selector to parent when `parentId` is set
- `app/assets/stylesheets/styles.scss` — CSS to hide the file input label text when files are pending
- `test/functional/models_controller_test.rb` — end-to-end tests covering failed → successful resubmit and tampered ID rejection

Closes https://github.com/seek4science/seek/issues/2582