### PR TITLE
Fix incorrect 'sample type already exists' detection #2589

### DIFF
--- a/lib/seek/fair_data_station/sample.rb
+++ b/lib/seek/fair_data_station/sample.rb
@@ -33,6 +33,7 @@ module Seek
         additional_ids = all_additional_potential_annotation_predicates
         property_ids = additional_ids | [@schema.title.to_s, @schema.description.to_s]
         sample_type = find_closest_matching_sample_type(person, property_ids)
+        # count check catches attributes without PIDs, which are invisible to the PID comparison below
         return unless sample_type && sample_type.sample_attributes.count == property_ids.count
 
         core_pid_strings = core_annotations.map(&:to_s)

--- a/lib/seek/fair_data_station/sample.rb
+++ b/lib/seek/fair_data_station/sample.rb
@@ -30,10 +30,16 @@ module Seek
       end
 
       def find_exact_matching_sample_type(person)
-        property_ids = all_additional_potential_annotation_predicates
-        property_ids |= [@schema.title.to_s, @schema.description.to_s]
+        additional_ids = all_additional_potential_annotation_predicates
+        property_ids = additional_ids | [@schema.title.to_s, @schema.description.to_s]
         sample_type = find_closest_matching_sample_type(person, property_ids)
         return unless sample_type && sample_type.sample_attributes.count == property_ids.count
+
+        core_pid_strings = core_annotations.map(&:to_s)
+        sample_type_additional_pids = sample_type.sample_attributes.collect(&:pid).compact_blank.reject do |pid|
+          core_pid_strings.include?(pid)
+        end
+        return unless additional_ids.sort == sample_type_additional_pids.sort
 
         sample_type
       end

--- a/test/unit/fair_data_station/fair_data_station_objects_test.rb
+++ b/test/unit/fair_data_station/fair_data_station_objects_test.rb
@@ -256,7 +256,6 @@ class FairDataStationObjectsTest < ActiveSupport::TestCase
   end
 
   test 'find_exact_matching_sample_type does not falsely match when attribute count matches but pids differ' do
-    # Regression test for https://github.com/seek4science/seek/issues/2589
     # A sample type from a different FDS source with the same attribute count but different non-core PIDs
     # was incorrectly detected as an exact match.
     path = "#{Rails.root}/test/fixtures/files/fair_data_station/seek-fair-data-station-test-case-irregular.ttl"

--- a/test/unit/fair_data_station/fair_data_station_objects_test.rb
+++ b/test/unit/fair_data_station/fair_data_station_objects_test.rb
@@ -255,6 +255,24 @@ class FairDataStationObjectsTest < ActiveSupport::TestCase
     assert_equal valid_type, assay.find_closest_matching_extended_metadata_type
   end
 
+  test 'find_exact_matching_sample_type does not falsely match when attribute count matches but pids differ' do
+    # Regression test for https://github.com/seek4science/seek/issues/2589
+    # A sample type from a different FDS source with the same attribute count but different non-core PIDs
+    # was incorrectly detected as an exact match.
+    path = "#{Rails.root}/test/fixtures/files/fair_data_station/seek-fair-data-station-test-case-irregular.ttl"
+    inv = Seek::FairDataStation::Reader.new.parse_graph(path).first
+    sample = inv.studies.first.observation_units.first.samples.first
+    person = FactoryBot.create(:person)
+
+    # Same attribute count as the exact match, but one non-core PID replaced with an unrelated one.
+    wrong_sample_type = FactoryBot.create(:fairdatastation_test_case_sample_type)
+    attr = wrong_sample_type.sample_attributes.find { |a| a.pid == 'https://w3id.org/mixs/0000011' }
+    attr.update_column(:pid, 'http://example.com/different_prop')
+
+    assert_equal 6, wrong_sample_type.sample_attributes.count
+    assert_nil sample.find_exact_matching_sample_type(person)
+  end
+
   test 'find_exact_matching_sample_type dont pick if private' do
     path = "#{Rails.root}/test/fixtures/files/fair_data_station/seek-fair-data-station-test-case-irregular.ttl"
     inv = Seek::FairDataStation::Reader.new.parse_graph(path).first


### PR DESCRIPTION
## Summary

- Fixes a false positive in `find_exact_matching_sample_type` where a sample type from a different FDS RDF source was incorrectly detected as an exact match solely because it had the same number of attributes.
- Adds an additional check that compares the actual non-core PIDs (sorted) between the FDS sample's annotations and the candidate sample type's attributes, not just their count.
- Adds a regression test covering the case where attribute count matches but PIDs differ.

Closes #2589
