### PR TITLE
2560 remove minimal isa template from study assay create step

### DIFF
--- a/app/helpers/templates_helper.rb
+++ b/app/helpers/templates_helper.rb
@@ -14,9 +14,13 @@ module TemplatesHelper
     end
   end
 
-  def load_templates
+  def load_templates(sample_type_creation=false)
     privilege = Seek::Permissions::Translator.translate('view')
-    Template.order(:group, :group_order).select { |t| t.can_perform?(privilege) }.map do |item|
+    templates = Template.order(:group, :group_order).select { |t| t.can_perform?(privilege) }
+    if sample_type_creation
+      templates.reject! { |t| t.group == "ISA minimal starter" }
+    end
+    templates.map do |item|
       { title: sanitize(item.title),
         group: sanitize(item.group),
         level: sanitize(item.level),

--- a/app/helpers/templates_helper.rb
+++ b/app/helpers/templates_helper.rb
@@ -16,10 +16,17 @@ module TemplatesHelper
 
   def load_templates(sample_type_creation=false)
     privilege = Seek::Permissions::Translator.translate('view')
-    templates = Template.order(:group, :group_order).select { |t| t.can_perform?(privilege) }
-    if sample_type_creation
-      templates.reject! { |t| t.group == "ISA minimal starter" }
-    end
+    templates = if sample_type_creation
+                  Template
+                    .for_sample_type_creation
+                    .order(:group, :group_order)
+                    .select { |t| t.can_perform?(privilege) }
+                else
+                  Template
+                    .order(:group, :group_order)
+                    .select { |t| t.can_perform?(privilege) }
+                end
+
     templates.map do |item|
       { title: sanitize(item.title),
         group: sanitize(item.group),

--- a/app/helpers/templates_helper.rb
+++ b/app/helpers/templates_helper.rb
@@ -16,16 +16,9 @@ module TemplatesHelper
 
   def load_templates(sample_type_creation=false)
     privilege = Seek::Permissions::Translator.translate('view')
-    templates = if sample_type_creation
-                  Template
-                    .for_sample_type_creation
-                    .order(:group, :group_order)
-                    .select { |t| t.can_perform?(privilege) }
-                else
-                  Template
-                    .order(:group, :group_order)
-                    .select { |t| t.can_perform?(privilege) }
-                end
+    templates = (sample_type_creation ? Template.for_sample_type_creation : Template)
+                  .order(:group, :group_order)
+                  .select { |t| t.can_perform?(privilege) }
 
     templates.map do |item|
       { title: sanitize(item.title),

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -14,6 +14,7 @@ class Template < ApplicationRecord
   validate :validate_template_attributes
 
   accepts_nested_attributes_for :template_attributes, allow_destroy: true
+  scope :for_sample_type_creation, -> { where.not(group: Seek::ISATemplates::TemplateGroup::FOR_SAMPLE_TYPE_CREATION) }
 
   has_filter :isa_template_group
   def can_delete?(user = User.current_user)

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -14,7 +14,7 @@ class Template < ApplicationRecord
   validate :validate_template_attributes
 
   accepts_nested_attributes_for :template_attributes, allow_destroy: true
-  scope :for_sample_type_creation, -> { where.not(group: Seek::ISATemplates::TemplateGroup::FOR_SAMPLE_TYPE_CREATION) }
+  scope :for_sample_type_creation, -> { where.not(group: Seek::ISATemplates::TemplateGroup::EXCLUDED_FROM_SAMPLE_TYPE_CREATION) }
 
   has_filter :isa_template_group
   def can_delete?(user = User.current_user)

--- a/app/views/isa_assays/_form.html.erb
+++ b/app/views/isa_assays/_form.html.erb
@@ -73,7 +73,7 @@
 
 
 <script>
-    const templates = <%= load_templates().to_json.html_safe %>
+    const templates = <%= load_templates(true).to_json.html_safe %>
     const initTemplateModal = function(field_name) {
       Templates.context.description_elem = `#isa_assay_${field_name}_description`
       Templates.context.suffix = "_" + field_name

--- a/app/views/isa_studies/_form.html.erb
+++ b/app/views/isa_studies/_form.html.erb
@@ -61,7 +61,7 @@
 
 
 <script>
-    const templates = <%= load_templates().to_json.html_safe %>
+    const templates = <%= load_templates(true).to_json.html_safe %>
     const initTemplateModal = function(field_name) {
       if (templates.length > 0) {
         Templates.context.description_elem = `#isa_study_${field_name}_description`

--- a/app/views/templates/_form.html.erb
+++ b/app/views/templates/_form.html.erb
@@ -153,5 +153,5 @@
         Templates.init($j('#template-attributes'));
     });
 
-    const templates = <%= load_templates().to_json.html_safe %>;
+    const templates = <%= load_templates.to_json.html_safe %>;
 </script>

--- a/db/seeds/017_minimal_starter_isa_templates.seeds.rb
+++ b/db/seeds/017_minimal_starter_isa_templates.seeds.rb
@@ -14,7 +14,7 @@ end
 
 # Source - ISA minimal starter template
 source_template = Template.find_or_initialize_by(title: 'Source - ISA minimal starter template', level: 'study source',
-                                                 group: 'ISA minimal starter')
+                                                 group: Seek::ISATemplates::TemplateGroup::ISA_MINIMAL_STARTER)
 
 source_temp_attributes = []
 source_temp_attributes << upsert_template_attribute('Source Name',
@@ -50,7 +50,7 @@ end
 
 # Sample - ISA minimal starter template
 sample_template = Template.find_or_initialize_by(title: 'Sample - ISA minimal starter template', level: 'study sample',
-                                                 group: 'ISA minimal starter')
+                                                 group: Seek::ISATemplates::TemplateGroup::ISA_MINIMAL_STARTER)
 
 sample_temp_attributes = []
 sample_temp_attributes << upsert_template_attribute('Input',
@@ -112,7 +112,7 @@ end
 
 # Material output assay - ISA minimal starter template
 material_template = Template.find_or_initialize_by(title: 'Material output assay - ISA minimal starter template',
-                                                   level: 'assay - material', group: 'ISA minimal starter')
+                                                   level: 'assay - material', group: Seek::ISATemplates::TemplateGroup::ISA_MINIMAL_STARTER)
 
 material_temp_attributes = []
 material_temp_attributes << upsert_template_attribute('Input',
@@ -174,7 +174,7 @@ end
 
 # Data file output assay - ISA minimal starter template
 data_file_template = Template.find_or_initialize_by(title: 'Data file output assay - ISA minimal starter template',
-                                                    level: 'assay - data file', group: 'ISA minimal starter')
+                                                    level: 'assay - data file', group: Seek::ISATemplates::TemplateGroup::ISA_MINIMAL_STARTER)
 
 data_file_temp_attributes = []
 data_file_temp_attributes << upsert_template_attribute('Input',

--- a/lib/seek/isa_templates/template_group.rb
+++ b/lib/seek/isa_templates/template_group.rb
@@ -3,7 +3,7 @@ module Seek
   module ISATemplates
     module TemplateGroup
       ISA_MINIMAL_STARTER = "ISA minimal starter"
-      EXCLUDED_FROM_SAMPLE_TYPE_CREATION = [ISA_MINIMAL_STARTER]
+      EXCLUDED_FROM_SAMPLE_TYPE_CREATION = [ISA_MINIMAL_STARTER].freeze
     end
   end
 end

--- a/lib/seek/isa_templates/template_group.rb
+++ b/lib/seek/isa_templates/template_group.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+module Seek
+  module ISATemplates
+    module TemplateGroup
+      ISA_MINIMAL_STARTER = "ISA minimal starter"
+      FOR_SAMPLE_TYPE_CREATION = [ISA_MINIMAL_STARTER]
+    end
+  end
+end

--- a/lib/seek/isa_templates/template_group.rb
+++ b/lib/seek/isa_templates/template_group.rb
@@ -3,7 +3,7 @@ module Seek
   module ISATemplates
     module TemplateGroup
       ISA_MINIMAL_STARTER = "ISA minimal starter"
-      FOR_SAMPLE_TYPE_CREATION = [ISA_MINIMAL_STARTER]
+      EXCLUDED_FROM_SAMPLE_TYPE_CREATION = [ISA_MINIMAL_STARTER]
     end
   end
 end

--- a/test/unit/helpers/templates_helper_test.rb
+++ b/test/unit/helpers/templates_helper_test.rb
@@ -21,6 +21,26 @@ class TemplatesHelperTest < ActionView::TestCase
         assert_equal @template.template_attributes.length, test_template[:attributes].length
     end
 
+    test 'should not load the Minimal ISA templates when applying to a Sample Type' do
+      %i[
+      isa_source_template
+      isa_sample_collection_template
+      isa_assay_material_template
+      isa_assay_data_file_template
+      ].each do |t|
+        FactoryBot.create(t, group: "ISA minimal starter",
+                          policy: FactoryBot.create(:policy, access_type: Policy::VISIBLE ))
+      end
+
+      templates_for_sample_types = load_templates(true)
+      assert_equal templates_for_sample_types.length, 1
+      assert_equal Template.count, 5
+      assert templates_for_sample_types.none? { |t| t[:group] == "ISA minimal starter" }
+
+      templates_for_templates = load_templates
+      assert_equal templates_for_templates.length, Template.count
+    end
+
     test 'should not show private templates' do
         assert_equal Template.all.length, load_templates.length
         FactoryBot.create(:template, policy: FactoryBot.create(:policy, access_type: Policy::NO_ACCESS ))

--- a/test/unit/helpers/templates_helper_test.rb
+++ b/test/unit/helpers/templates_helper_test.rb
@@ -28,14 +28,15 @@ class TemplatesHelperTest < ActionView::TestCase
       isa_assay_material_template
       isa_assay_data_file_template
       ].each do |t|
-        FactoryBot.create(t, group: "ISA minimal starter",
+        FactoryBot.create(t, group: Seek::ISATemplates::TemplateGroup::ISA_MINIMAL_STARTER,
                           policy: FactoryBot.create(:policy, access_type: Policy::VISIBLE ))
       end
 
       templates_for_sample_types = load_templates(true)
-      assert_equal templates_for_sample_types.length, 1
-      assert_equal Template.count, 5
-      assert templates_for_sample_types.none? { |t| t[:group] == "ISA minimal starter" }
+      assert_equal 1, templates_for_sample_types.length
+      assert_equal 1, Template.for_sample_type_creation.length
+      assert_equal 5, Template.count
+      assert templates_for_sample_types.none? { |t| t[:group] == Seek::ISATemplates::TemplateGroup::ISA_MINIMAL_STARTER }
 
       templates_for_templates = load_templates
       assert_equal templates_for_templates.length, Template.count


### PR DESCRIPTION
Filters out templates of the type 'ISA minimal starter' when creating a Sample Type.
Closes #2560 