### PR TITLE
Fix sample RDF to include correct XSD types #2595

### DIFF
--- a/lib/seek/rdf/rdf_generation.rb
+++ b/lib/seek/rdf/rdf_generation.rb
@@ -86,6 +86,8 @@ module Seek
         resource = rdf_resource
         attributes.each do |attribute|
           value = get_attribute_value(attribute)
+          next if value.nil? || attribute_value_blank?(attribute, value)
+
           rdf_graph << [resource, RDF::URI(attribute.pid),
                         RDF::Literal(cast_value_by_base_type_for_rdf(attribute, value))]
         end
@@ -188,7 +190,7 @@ module Seek
 
           value = value_resolver.call(attribute)
           next if value.nil?
-          next if scalar_emt_attribute?(attribute) && emt_value_blank?(attribute, value)
+          next if scalar_emt_attribute?(attribute) && attribute_value_blank?(attribute, value)
 
           emit_emt_attribute(rdf_graph, subject, attribute, value)
         end
@@ -219,7 +221,7 @@ module Seek
         !attribute.linked_extended_metadata? && !attribute.linked_extended_metadata_multi?
       end
 
-      def emt_value_blank?(attribute, value)
+      def attribute_value_blank?(attribute, value)
         attribute.respond_to?(:test_blank?) ? attribute.test_blank?(value) : value.blank?
       end
 

--- a/lib/seek/rdf/rdf_generation.rb
+++ b/lib/seek/rdf/rdf_generation.rb
@@ -82,11 +82,11 @@ module Seek
       end
 
       def sample_metadata_triples(rdf_graph)
-
-        attributes = sample_type.sample_attributes.select{|at| at.pid.present?}
+        attributes = sample_type.sample_attributes.select { |at| at.pid.present? }
         resource = rdf_resource
         attributes.each do |attribute|
-          rdf_graph << [resource, RDF::URI(attribute.pid), RDF::Literal(get_attribute_value(attribute))]
+          value = get_attribute_value(attribute)
+          rdf_graph << [resource, RDF::URI(attribute.pid), RDF::Literal(cast_value_by_base_type_for_rdf(attribute, value))]
         end
         rdf_graph
       end
@@ -202,7 +202,7 @@ module Seek
             append_emt_blank_node(rdf_graph, subject, predicate, attribute.linked_extended_metadata_type, item)
           end
         else
-          rdf_graph << [subject, predicate, RDF::Literal(cast_emt_value_for_rdf(attribute, value))]
+          rdf_graph << [subject, predicate, RDF::Literal(cast_value_by_base_type_for_rdf(attribute, value))]
         end
       end
 
@@ -225,7 +225,7 @@ module Seek
       # Casts the stored value to the matching Ruby type so RDF::Literal can infer
       # the right XSD datatype (xsd:integer, xsd:double, xsd:boolean, xsd:date,
       # xsd:dateTime). Falls back to the raw value if parsing fails.
-      def cast_emt_value_for_rdf(attribute, value)
+      def cast_value_by_base_type_for_rdf(attribute, value)
         case attribute.sample_attribute_type&.base_type
         when Seek::Samples::BaseType::INTEGER
           Integer(value, exception: false) || value

--- a/lib/seek/rdf/rdf_generation.rb
+++ b/lib/seek/rdf/rdf_generation.rb
@@ -86,7 +86,8 @@ module Seek
         resource = rdf_resource
         attributes.each do |attribute|
           value = get_attribute_value(attribute)
-          rdf_graph << [resource, RDF::URI(attribute.pid), RDF::Literal(cast_value_by_base_type_for_rdf(attribute, value))]
+          rdf_graph << [resource, RDF::URI(attribute.pid),
+                        RDF::Literal(cast_value_by_base_type_for_rdf(attribute, value))]
         end
         rdf_graph
       end

--- a/test/factories/sample_types.rb
+++ b/test/factories/sample_types.rb
@@ -275,8 +275,14 @@ FactoryBot.define do
 
       type.sample_attributes << FactoryBot.build(:sample_attribute, sample_attribute_type: FactoryBot.create(:string_sample_attribute_type), title:'Bio safety level', pid:'http://fairbydesign.nl/ontology/biosafety_level', sample_type: type)
       type.sample_attributes << FactoryBot.build(:sample_attribute, sample_attribute_type: FactoryBot.create(:string_sample_attribute_type), title:'Scientific name', pid:'http://gbol.life/0.1/scientificName', required: true, sample_type: type)
-      type.sample_attributes << FactoryBot.build(:sample_attribute, sample_attribute_type: FactoryBot.create(:string_sample_attribute_type), title:'Organism ncbi id', pid:'http://purl.uniprot.org/core/organism', required: true, sample_type: type)
-      type.sample_attributes << FactoryBot.build(:sample_attribute, sample_attribute_type: FactoryBot.create(:string_sample_attribute_type), title:'Collection date', pid:'https://w3id.org/mixs/0000011', sample_type: type)
+      type.sample_attributes << FactoryBot.build(:sample_attribute,
+                                                  sample_attribute_type: FactoryBot.create(:string_sample_attribute_type),
+                                                  title: 'Organism ncbi id', pid: 'http://purl.uniprot.org/core/organism',
+                                                  required: true, sample_type: type)
+      type.sample_attributes << FactoryBot.build(:sample_attribute,
+                                                  sample_attribute_type: FactoryBot.create(:string_sample_attribute_type),
+                                                  title: 'Collection date', pid: 'https://w3id.org/mixs/0000011',
+                                                  sample_type: type)
     end
   end
 end

--- a/test/factories/sample_types.rb
+++ b/test/factories/sample_types.rb
@@ -253,6 +253,19 @@ FactoryBot.define do
     end
   end
 
+  factory(:typed_rdf_sample_type, parent: :sample_type) do
+    title { 'typed rdf sample type' }
+    association :policy, factory: :public_policy
+    after(:build) do |type, _eval|
+      type.sample_attributes << FactoryBot.build(:sample_attribute, sample_attribute_type: FactoryBot.create(:string_sample_attribute_type), title: 'Title', sample_type: type, is_title: true)
+      type.sample_attributes << FactoryBot.build(:sample_attribute, sample_attribute_type: FactoryBot.create(:integer_sample_attribute_type), title: 'Count', pid: 'http://example.org/count', sample_type: type)
+      type.sample_attributes << FactoryBot.build(:sample_attribute, sample_attribute_type: FactoryBot.create(:float_sample_attribute_type), title: 'Weight', pid: 'http://example.org/weight', sample_type: type)
+      type.sample_attributes << FactoryBot.build(:sample_attribute, sample_attribute_type: FactoryBot.create(:boolean_sample_attribute_type), title: 'Flag', pid: 'http://example.org/flag', sample_type: type)
+      type.sample_attributes << FactoryBot.build(:sample_attribute, sample_attribute_type: FactoryBot.create(:date_sample_attribute_type), title: 'Collected on', pid: 'http://example.org/collectedOn', sample_type: type)
+      type.sample_attributes << FactoryBot.build(:sample_attribute, sample_attribute_type: FactoryBot.create(:datetime_sample_attribute_type), title: 'Recorded at', pid: 'http://example.org/recordedAt', sample_type: type)
+    end
+  end
+
   factory(:fairdatastation_test_case_sample_type, parent: :sample_type) do
     title { 'fair data station test case'}
     association :policy, factory: :public_policy

--- a/test/unit/sample_test.rb
+++ b/test/unit/sample_test.rb
@@ -1455,6 +1455,41 @@ class SampleTest < ActiveSupport::TestCase
 
   end
 
+  test 'to rdf with typed attributes uses correct XSD datatypes' do
+    sample = FactoryBot.create(:sample, sample_type: FactoryBot.create(:typed_rdf_sample_type),
+                               data: {
+                                 'Title' => 'test',
+                                 'Count' => 42,
+                                 'Weight' => 3.14,
+                                 'Flag' => true,
+                                 'Collected on' => '2024-06-01',
+                                 'Recorded at' => '2024-06-01T12:00:00'
+                               })
+    rdf = sample.to_rdf
+    graph = RDF::Graph.new do |g|
+      RDF::Reader.for(:ttl).new(rdf) { |reader| g << reader }
+    end
+    sub = RDF::URI.new("http://localhost:3000/samples/#{sample.id}")
+
+    count = graph.query([sub, RDF::URI('http://example.org/count'), nil]).first&.object
+    assert_equal RDF::XSD.integer.to_s, count.datatype.to_s, 'Integer must carry xsd:integer'
+    assert_equal 42, count.object
+
+    weight = graph.query([sub, RDF::URI('http://example.org/weight'), nil]).first&.object
+    assert_equal RDF::XSD.double.to_s, weight.datatype.to_s, 'Float must carry xsd:double'
+
+    flag = graph.query([sub, RDF::URI('http://example.org/flag'), nil]).first&.object
+    assert_equal RDF::XSD.boolean.to_s, flag.datatype.to_s, 'Boolean must carry xsd:boolean'
+    assert_equal true, flag.object
+
+    date = graph.query([sub, RDF::URI('http://example.org/collectedOn'), nil]).first&.object
+    assert_equal RDF::XSD.date.to_s, date.datatype.to_s, 'Date must carry xsd:date'
+    assert_equal '2024-06-01', date.to_s
+
+    dt = graph.query([sub, RDF::URI('http://example.org/recordedAt'), nil]).first&.object
+    assert_equal RDF::XSD.dateTime.to_s, dt.datatype.to_s, 'DateTime must carry xsd:dateTime'
+  end
+
   test 'add sample to a locked sample type' do
     person = FactoryBot.create(:person)
     sample_type = FactoryBot.create(:simple_sample_type, project_ids: [FactoryBot.create(:project).id], contributor: person)

--- a/test/unit/sample_test.rb
+++ b/test/unit/sample_test.rb
@@ -1435,7 +1435,8 @@ class SampleTest < ActiveSupport::TestCase
                                  'Title':'the title',
                                  'Description':'the description',
                                  'Host':'the host',
-                                 'Occupation':'the occupation'
+                                 'Occupation':'the occupation',
+                                 'Marital status': ''
                                })
     assert sample.rdf_supported?
     rdf = sample.to_rdf
@@ -1450,8 +1451,8 @@ class SampleTest < ActiveSupport::TestCase
     assert_equal RDF::Literal('the host'), match.object
     match = graph.statements.detect{|s| s.predicate == RDF::URI('http://fairbydesign.nl/ontology/occupation')}
     assert_equal RDF::Literal('the occupation'), match.object
-    match = graph.statements.detect{|s| s.predicate == RDF::URI('http://fairbydesign.nl/ontology/marital_status')}
-    assert_equal RDF::Literal(''), match.object
+    assert_nil graph.statements.detect{|s| s.predicate == RDF::URI('http://fairbydesign.nl/ontology/marital_status')},
+               'blank string attribute must not emit a triple'
 
   end
 
@@ -1488,6 +1489,21 @@ class SampleTest < ActiveSupport::TestCase
 
     dt = graph.query([sub, RDF::URI('http://example.org/recordedAt'), nil]).first&.object
     assert_equal RDF::XSD.dateTime.to_s, dt.datatype.to_s, 'DateTime must carry xsd:dateTime'
+  end
+
+  test 'to rdf omits triples for nil typed attribute values' do
+    sample = FactoryBot.create(:sample, sample_type: FactoryBot.create(:typed_rdf_sample_type),
+                               data: { 'Title' => 'test' })
+    rdf = sample.to_rdf
+    graph = RDF::Graph.new do |g|
+      RDF::Reader.for(:ttl).new(rdf) { |reader| g << reader }
+    end
+    sub = RDF::URI.new("http://localhost:3000/samples/#{sample.id}")
+
+    %w[count weight flag collectedOn recordedAt].each do |fragment|
+      assert_nil graph.query([sub, RDF::URI("http://example.org/#{fragment}"), nil]).first,
+                 "nil #{fragment} attribute must not emit a triple"
+    end
   end
 
   test 'add sample to a locked sample type' do


### PR DESCRIPTION
## Summary

- Sample attribute values are now cast to the correct Ruby type before being wrapped in `RDF::Literal`, so integer/float/boolean/date/datetime attributes emit the proper `^^xsd:*` datatype annotations instead of plain string literals
- Renamed `cast_emt_value_for_rdf` → `cast_value_by_base_type_for_rdf` since the method is now shared between the extended metadata and sample attribute paths
- Added `typed_rdf_sample_type` factory and a test verifying each scalar base type produces the correct XSD datatype in the RDF output

Closes #2595. See #2592 for the equivalent fix on the extended metadata path.