### PR TITLE
Generate UUIDs via `SecureRandom`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,7 +106,6 @@ gem 'sqlite3'
 gem 'sunspot_rails'
 gem 'terrapin'
 gem 'terser'
-gem 'uuid'
 gem 'validate_url'
 gem 'whenever', require: false
 gem 'will_paginate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1185,7 +1185,6 @@ DEPENDENCIES
   terrapin
   terser
   test-prof
-  uuid
   validate_url
   vcr
   web-console

--- a/app/controllers/single_pages_controller.rb
+++ b/app/controllers/single_pages_controller.rb
@@ -121,7 +121,7 @@ class SinglePagesController < ApplicationController
   end
 
   def export_to_excel
-    cache_uuid = UUID.new.generate
+    cache_uuid = SecureRandom.uuid
     sample_ids = JSON.parse(params[:sample_ids])
     sample_type_id = JSON.parse(params[:sample_type_id])
     study_id = JSON.parse(params[:study_id])

--- a/app/models/notifiee_info.rb
+++ b/app/models/notifiee_info.rb
@@ -1,5 +1,3 @@
-require 'uuid'
-
 class NotifieeInfo < ApplicationRecord
   belongs_to :notifiee,:polymorphic=>true
   validates_presence_of :notifiee
@@ -11,7 +9,7 @@ class NotifieeInfo < ApplicationRecord
   
   def check_unique_key
     if self.unique_key.nil? || self.unique_key.blank?
-      self.unique_key = UUID.generate
+      self.unique_key = SecureRandom.uuid
     end
   end    
   

--- a/app/views/single_pages/_new_samples_panel.html.erb
+++ b/app/views/single_pages/_new_samples_panel.html.erb
@@ -15,7 +15,7 @@
         </thead>
         <tbody>
         <% for new_sample in @new_samples %>
-          <% new_sample_id = UUID.generate %>
+          <% new_sample_id = SecureRandom.uuid %>
           <tr id='<%= "new-sample-#{new_sample_id}" %>'>
             <td>
               <button id=<%= "remove-#{new_sample_id}" %> class="btn glyphicon glyphicon-trash danger"

--- a/app/views/single_pages/download_samples_spreadsheet.axlsx
+++ b/app/views/single_pages/download_samples_spreadsheet.axlsx
@@ -2,7 +2,7 @@
 debug = Rails.env.development?
 #####################################
 
-secret_pwd = debug ? 'seek' : UUID.new.generate
+secret_pwd = debug ? 'seek' : SecureRandom.uuid
 
 xlsx_package = Axlsx::Package.new
 workbook = xlsx_package.workbook

--- a/config/initializers/seek_main.rb
+++ b/config/initializers/seek_main.rb
@@ -7,7 +7,6 @@ require 'sunspot_rails'
 require 'mimemagic'
 require 'omniauth-ldap'
 require 'recaptcha'
-require 'uuid'
 require 'libreconv'
 require 'extensions/secret_key_base'
 

--- a/lib/isa_exporter.rb
+++ b/lib/isa_exporter.rb
@@ -70,12 +70,12 @@ module ISAExporter
       end
 
       study_comments.append({
-        '@id': "#study_comment/#{ [study_id, UUID.new.generate].join('_') }",
+        '@id': "#study_comment/#{ [study_id, SecureRandom.uuid].join('_') }",
         'name': 'SEEK Study ID',
         'value': study_id.to_s
       })
       study_comments.append({
-        '@id': "#study_comment/#{ [study_id, UUID.new.generate].join('_') }",
+        '@id': "#study_comment/#{ [study_id, SecureRandom.uuid].join('_') }",
         'name': 'SEEK creation date',
         'value': study.created_at.utc.iso8601
       })

--- a/lib/nels/rest/client.rb
+++ b/lib/nels/rest/client.rb
@@ -242,7 +242,7 @@ module Nels
         download_url = response['url']
         Rails.logger.info("Download url: #{download_url}")
 
-        tmp_file = File.new(File.join("/tmp","nels-download-#{UUID.generate}"), 'wb')
+        tmp_file = File.new(File.join("/tmp","nels-download-#{SecureRandom.uuid}"), 'wb')
 
         File.open(tmp_file.path, 'wb') do |file|
           block = proc { |response|

--- a/lib/seek/fair_data_station/base.rb
+++ b/lib/seek/fair_data_station/base.rb
@@ -115,7 +115,7 @@ module Seek
 
       def to_extended_metadata_type_json
         json = {}
-        json['title'] = "FDS #{type_name.underscore.humanize} - #{package_name || UUID.generate}"
+        json['title'] = "FDS #{type_name.underscore.humanize} - #{package_name || SecureRandom.uuid}"
         json['supported_type'] = type_name
         json['enabled'] = true
         seek_attributes = all_additional_potential_annotation_details.collect(&:to_extended_metadata_attribute_json)

--- a/lib/seek/remote_downloader.rb
+++ b/lib/seek/remote_downloader.rb
@@ -120,7 +120,7 @@ module Seek
 
     # caches the result into a temporary file
     def cache(file_obj, data_result, url, username, password)
-      data_result[:uuid] = UUID.generate
+      data_result[:uuid] = SecureRandom.uuid
       key = generate_key url, username, password
 
       begin

--- a/lib/seek/templates/samples_writer.rb
+++ b/lib/seek/templates/samples_writer.rb
@@ -9,7 +9,7 @@ module Seek
 
       def initialize(sample_type)
         @sample_type = sample_type
-        @tmp_file = "/tmp/#{UUID.generate}.xlxs"
+        @tmp_file = "/tmp/#{SecureRandom.uuid}.xlxs"
       end
 
       def generate

--- a/lib/seek/uniquely_identifiable.rb
+++ b/lib/seek/uniquely_identifiable.rb
@@ -15,7 +15,7 @@ module Seek
 
     module InstanceMethods
       def regenerate_uuid
-        self.uuid = UUID.generate
+        self.uuid = SecureRandom.uuid
       end
 
       def uuid

--- a/lib/tasks/seek_dev.rake
+++ b/lib/tasks/seek_dev.rake
@@ -159,7 +159,7 @@ namespace :seek_dev do
 
   task(random_projects: :environment) do
     (0...50).to_a.each do
-      title = ('A'..'Z').to_a[rand(26)] + UUID.generate
+      title = ('A'..'Z').to_a[rand(26)] + SecureRandom.uuid
       p = Project.create title: title
       p.save!
     end

--- a/test/factories/content_blobs.rb
+++ b/test/factories/content_blobs.rb
@@ -2,13 +2,13 @@ FactoryBot.define do
   # ContentBlob
   # either url or data should be provided for assets
   factory(:content_blob) do
-    sequence(:uuid) { UUID.generate }
+    sequence(:uuid) { SecureRandom.uuid }
     sequence(:data) { |n| "data [#{n}]" }
     sequence(:original_filename) { |n| "file-#{n}" }
   end
   
   factory(:min_content_blob, class: ContentBlob) do
-    sequence(:uuid) { UUID.generate }
+    sequence(:uuid) { SecureRandom.uuid }
     data { 'Min Data' }
     original_filename { 'min file' }
     asset { FactoryBot.create(:pdf_sop, policy: FactoryBot.create(:downloadable_public_policy)) }

--- a/test/fixtures/content_blobs.yml
+++ b/test/fixtures/content_blobs.yml
@@ -11,7 +11,7 @@
   end
   
   def init_blob(name)
-      uuid = UUID.generate
+      uuid = SecureRandom.uuid
       make_file(uuid,name)
       return uuid
   end
@@ -205,7 +205,7 @@ private_data_file_blob:
 
 url_based_data_file_blob:
   url: http://mockedlocation.com/a-piccy.png
-  uuid: <%= UUID.generate %>
+  uuid: <%= SecureRandom.uuid %>
   asset: url_based_data_file (DataFile)
   asset_version: 1
   original_filename: sysmologo.png
@@ -272,7 +272,7 @@ private_spreadsheet_blob:
 
 url_content_blob:
   url: http://mockedlocation.com/a-piccy.png
-  uuid: <%= UUID.generate %>
+  uuid: <%= SecureRandom.uuid %>
   asset: url_content_blob (DataFile)
   asset_version: 1
   original_filename: sysmologo.png
@@ -280,7 +280,7 @@ url_content_blob:
 
 url_no_host_content_blob:
   url: http://sdkfhsdfkhskfj.com/pic.png 
-  uuid: <%= UUID.generate %>
+  uuid: <%= SecureRandom.uuid %>
   asset: url_no_host_data_file (DataFile)
   asset_version: 1
   original_filename: sysmologo.png
@@ -288,7 +288,7 @@ url_no_host_content_blob:
 
 url_not_found_content_blob:
   url: http://mocked404.com
-  uuid: <%= UUID.generate %>
+  uuid: <%= SecureRandom.uuid %>
   asset: url_not_found_data_file (DataFile)
   asset_version: 1
   original_filename: sysmologo.png

--- a/test/functional/content_blobs_controller_test.rb
+++ b/test/functional/content_blobs_controller_test.rb
@@ -377,7 +377,7 @@ class ContentBlobsControllerTest < ActionController::TestCase
                       content_blob: FactoryBot.create(:pdf_content_blob,
                                             data: nil,
                                             url: 'http://somewhere.com/piccy.pdf',
-                                            uuid: UUID.generate))
+                                            uuid: SecureRandom.uuid))
     assert !pdf_sop.content_blob.file_exists?
     assert pdf_sop.content_blob.cachable?
 
@@ -405,7 +405,7 @@ class ContentBlobsControllerTest < ActionController::TestCase
                       content_blob: FactoryBot.create(:doc_content_blob,
                                             data: nil,
                                             url: 'http://somewhere.com/piccy.doc',
-                                            uuid: UUID.generate))
+                                            uuid: SecureRandom.uuid))
     with_config_value(:hard_max_cachable_size, 10_000) do # Temporarily increase this, as the PDF is ~9kB
       get :get_pdf, params: { sop_id: doc_sop.id, id: doc_sop.content_blob.id }
     end
@@ -427,7 +427,7 @@ class ContentBlobsControllerTest < ActionController::TestCase
                   content_blob: FactoryBot.create(:doc_content_blob,
                                         data: nil,
                                         url: 'http://somewhere.com/piccy.doc',
-                                        uuid: UUID.generate))
+                                        uuid: SecureRandom.uuid))
     blob = sop.content_blob
     get :get_pdf, params: { sop_id: 999, id: blob.id }
     assert_redirected_to root_path
@@ -645,7 +645,7 @@ class ContentBlobsControllerTest < ActionController::TestCase
                  policy: FactoryBot.create(:all_sysmo_downloadable_policy),
                  content_blob: FactoryBot.create(:url_content_blob,
                                        url: 'http://mocked302.com',
-                                       uuid: UUID.generate)
+                                       uuid: SecureRandom.uuid)
     assert !df.content_blob.file_exists?
 
     get :download, params: { data_file_id: df, id: df.content_blob }
@@ -658,7 +658,7 @@ class ContentBlobsControllerTest < ActionController::TestCase
                  policy: FactoryBot.create(:all_sysmo_downloadable_policy),
                  content_blob: FactoryBot.create(:url_content_blob,
                                        url: 'http://mocked401.com',
-                                       uuid: UUID.generate)
+                                       uuid: SecureRandom.uuid)
     assert !df.content_blob.file_exists?
 
     get :download, params: { data_file_id: df, id: df.content_blob }
@@ -700,7 +700,7 @@ class ContentBlobsControllerTest < ActionController::TestCase
                       content_blob: FactoryBot.create(:doc_content_blob,
                                             data: nil,
                                             url: 'http://somewhere.com/piccy.doc',
-                                            uuid: UUID.generate))
+                                            uuid: SecureRandom.uuid))
     get :download, params: { sop_id: doc_sop, id: doc_sop.content_blob }
     assert_response :success
 
@@ -722,7 +722,7 @@ class ContentBlobsControllerTest < ActionController::TestCase
                  policy: FactoryBot.create(:all_sysmo_downloadable_policy),
                  content_blob: FactoryBot.create(:url_content_blob,
                                        url: 'http://mockedlocation.com/a-piccy.png',
-                                       uuid: UUID.generate)
+                                       uuid: SecureRandom.uuid)
     assert_difference('ActivityLog.count') do
       get :download, params: { data_file_id: df, id: df.content_blob }
     end
@@ -735,7 +735,7 @@ class ContentBlobsControllerTest < ActionController::TestCase
                  policy: FactoryBot.create(:all_sysmo_downloadable_policy),
                  content_blob: FactoryBot.create(:url_content_blob,
                                        url: 'http://unknownhost.com/pic.png',
-                                       uuid: UUID.generate)
+                                       uuid: SecureRandom.uuid)
 
     get :download, params: { data_file_id: df, id: df.content_blob }
 
@@ -749,7 +749,7 @@ class ContentBlobsControllerTest < ActionController::TestCase
                  policy: FactoryBot.create(:all_sysmo_downloadable_policy),
                  content_blob: FactoryBot.create(:url_content_blob,
                                        url: 'http://mocked404.com',
-                                       uuid: UUID.generate)
+                                       uuid: SecureRandom.uuid)
 
     get :download, params: { data_file_id: df, id: df.content_blob }
     assert_redirected_to data_file_path(df, version: df.version)
@@ -762,7 +762,7 @@ class ContentBlobsControllerTest < ActionController::TestCase
                  policy: FactoryBot.create(:all_sysmo_downloadable_policy),
                  content_blob: FactoryBot.create(:url_content_blob,
                                        url: 'http://mocked500.com',
-                                       uuid: UUID.generate)
+                                       uuid: SecureRandom.uuid)
 
     get :download, params: { data_file_id: df, id: df.content_blob }
     assert_redirected_to data_file_path(df, version: df.version)

--- a/test/functional/nels_controller_test.rb
+++ b/test/functional/nels_controller_test.rb
@@ -239,7 +239,7 @@ class NelsControllerTest < ActionController::TestCase
   end
 
   test 'fetch file valid key' do
-    key = UUID.generate
+    key = SecureRandom.uuid
     path = "/tmp/nels-download-#{key}"
     file = File.new(path, 'wb')
     file.write('wibble')
@@ -253,7 +253,7 @@ class NelsControllerTest < ActionController::TestCase
   end
 
   test 'fetch file missing file' do
-    key = UUID.generate
+    key = SecureRandom.uuid
 
     assert_raises Nels::Rest::Client::FetchFileError, match: /temp copy of file doesnt exist/ do
       get :fetch_file, params: {filename:'wibble.txt', file_key: key}


### PR DESCRIPTION
The `uuid` gem is no longer maintained, and the UUIDs generated by `SecureRandom` in the standard library are cryptographically secure.