### PR TITLE
Prevent ISATag appearing in HTML search results

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -66,6 +66,7 @@ class SearchController < ApplicationController
     if type == 'all'
       sources = searchable_types
       sources -= [Strain, Sample] if request.format.json?
+      sources -= [ISATag] unless request.format.json?
     else
       type_name = type.singularize.camelize
       unless searchable_types.map(&:to_s).include?(type_name)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -65,7 +65,7 @@ class SearchController < ApplicationController
 
     if type == 'all'
       sources = searchable_types
-      sources -= [Strain, Sample] if request.format.json?
+      sources -= [Strain] if request.format.json?
       sources -= [ISATag] unless request.format.json?
     else
       type_name = type.singularize.camelize

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -228,6 +228,28 @@ class SearchControllerTest < ActionController::TestCase
   end
 
 
+  test 'ISATag is excluded from HTML search results' do
+    isa_tag = FactoryBot.create(:min_isa_tag)
+
+    ISATag.stub(:solr_cache, -> (q) { [isa_tag.id] }) do
+      get :index, params: { q: 'isa' }
+    end
+
+    assert_response :success
+    assert_nil assigns(:results)['ISATag']
+  end
+
+  test 'ISATag is included in JSON API search results' do
+    isa_tag = FactoryBot.create(:min_isa_tag)
+
+    ISATag.stub(:solr_cache, -> (q) { [isa_tag.id] }) do
+      get :index, params: { q: 'isa' }, format: :json
+    end
+
+    assert_response :success
+    assert_equal 1, assigns(:results)['ISATag'].count
+  end
+
   test 'remember external search' do
     FactoryBot.create(:model, policy: FactoryBot.create(:public_policy))
 

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -250,6 +250,17 @@ class SearchControllerTest < ActionController::TestCase
     assert_equal 1, assigns(:results)['ISATag'].count
   end
 
+  test 'Sample is included in JSON API search results' do
+    sample = FactoryBot.create(:sample, policy: FactoryBot.create(:public_policy))
+
+    Sample.stub(:solr_cache, -> (q) { [sample.id] }) do
+      get :index, params: { q: 'sample' }, format: :json
+    end
+
+    assert_response :success
+    assert_equal 1, assigns(:results)['Sample'].count
+  end
+
   test 'remember external search' do
     FactoryBot.create(:model, policy: FactoryBot.create(:public_policy))
 


### PR DESCRIPTION
## Summary

- Excludes `ISATag` from HTML search sources in `SearchController#determine_sources`, preventing an `ActionView::Template::Error` when ISATag records match a search query (ISATag has no view partial or avatar support)
- Removes the erroneous exclusion of `Sample` from JSON API search results — samples are fully API-supported with `api_actions` and a serializer

Closes #2604