### PR TITLE
Related items view respects temporary auth codes #2583

### DIFF
--- a/app/helpers/related_items_helper.rb
+++ b/app/helpers/related_items_helper.rb
@@ -42,7 +42,7 @@ module RelatedItemsHelper
   end
 
   # Get a hash of appropriate related resources for the given resource. Also returns a hash of hidden resources
-  def get_related_resources(resource, limit = nil)
+  def get_related_resources(resource, limit = nil, code: nil)
     items_hash = {}
     resource.class.related_type_methods.each_key do |type|
       next if type == 'Organism' && !resource.is_a?(Sample)
@@ -52,7 +52,7 @@ module RelatedItemsHelper
       items_hash[type] = resource.get_related(type)
     end
 
-    related_items_hash(items_hash, limit)
+    related_items_hash(items_hash, limit, code: code)
   end
 
   def sort_project_member_by_status(resource, project_id)
@@ -70,7 +70,7 @@ module RelatedItemsHelper
   end
 
   # Use order: false to prevent ordering
-  def related_items_hash(items_hash, limit = nil, order: nil)
+  def related_items_hash(items_hash, limit = nil, order: nil, code: nil)
     hash = {}
     items_hash.each_key do |type|
 
@@ -90,7 +90,11 @@ module RelatedItemsHelper
         end
         total = hash[type][:items].to_a
         total_count = hash[type][:items_count]
-        hash[type][:items] = hash[type][:items].authorized_for('view', User.current_user).to_a
+        if code.present?
+          hash[type][:items] = total.select { |item| item.can_view? || (item.respond_to?(:auth_by_code?) && item.auth_by_code?(code)) }
+        else
+          hash[type][:items] = hash[type][:items].authorized_for('view', User.current_user).to_a
+        end
         hash[type][:items_count] = hash[type][:items].count
         hash[type][:hidden_count] = total_count - hash[type][:items_count]
         hash[type][:hidden_items] = total - hash[type][:items]

--- a/app/helpers/resource_list_item_helper.rb
+++ b/app/helpers/resource_list_item_helper.rb
@@ -30,29 +30,11 @@ module ResourceListItemHelper
 
   def list_item_title(resource, options = {})
 
-    html = nil
-
-    cache_key = "#{resource.list_item_title_cache_key_prefix}_#{resource.authorization_supported? && resource.can_manage?}"
-    result = Rails.cache.fetch(cache_key) do
-      title = options[:title]
-      url = options[:url]
-      include_avatar = options[:include_avatar]
-      include_avatar = true if include_avatar.nil?
-
-      title = get_object_title(resource) if title.nil?
-
-      html = '<div class="list_item_title">'
-
-      if resource.class.name.split('::')[0] == 'Person'
-        html = list_item_title_for_person(html, resource, title, url)
-      else
-        if include_avatar && (resource.avatar_key || resource.use_mime_type_for_avatar?)
-          html = list_item_title_with_avatar(html, resource, title, url)
-        else
-          html << (link_to title, (url.nil? ? show_resource_path(resource) : url)).to_s
-        end
-      end
-      html << '</div>'
+    result = if params[:code].present?
+      build_list_item_title_html(resource, options)
+    else
+      cache_key = "#{resource.list_item_title_cache_key_prefix}_#{resource.authorization_supported? && resource.can_manage?}"
+      Rails.cache.fetch(cache_key) { build_list_item_title_html(resource, options) }
     end
 
     if [Person, Project].include?(resource.class)
@@ -78,6 +60,28 @@ module ResourceListItemHelper
     visibility = resource.authorization_supported? && resource.can_manage? ? list_item_visibility(resource) : ''
     result = result.gsub('#item_visibility', visibility)
     result.html_safe
+  end
+
+  def build_list_item_title_html(resource, options)
+    title = options[:title]
+    url = options[:url]
+    include_avatar = options[:include_avatar]
+    include_avatar = true if include_avatar.nil?
+
+    title = get_object_title(resource) if title.nil?
+
+    html = '<div class="list_item_title">'
+
+    if resource.class.name.split('::')[0] == 'Person'
+      html = list_item_title_for_person(html, resource, title, url)
+    else
+      if include_avatar && (resource.avatar_key || resource.use_mime_type_for_avatar?)
+        html = list_item_title_with_avatar(html, resource, title, url)
+      else
+        html << (link_to title, (url.nil? ? show_resource_path(resource) : url)).to_s
+      end
+    end
+    html << '</div>'
   end
 
   def list_item_title_for_person(html, person, title, url)

--- a/app/views/general/_items_related_to.html.erb
+++ b/app/views/general/_items_related_to.html.erb
@@ -1,6 +1,6 @@
 <% parent_item = items_related_to %>
 <% limit ||= Seek::Config.related_items_limit %>
-<% resource_hash = get_related_resources(parent_item, limit) %>
+<% resource_hash = get_related_resources(parent_item, limit, code: params[:code]) %>
 <% title ||= 'Related items' %>
 <h2><%= title %></h2>
 <%= render :partial => "assets/resource_listing_tabbed_by_class", :locals => {:resource_hash => resource_hash,

--- a/test/integration/isa_special_auth_codes_access_test.rb
+++ b/test/integration/isa_special_auth_codes_access_test.rb
@@ -814,5 +814,136 @@ class IsaSpecialAuthCodesAccessTest < ActionDispatch::IntegrationTest
     get "/studies/#{study.id}?code=#{code}"
     assert_response :success
   end
+
+  # ===============================================
+  # Related Items View Tests
+  # ===============================================
+
+  test 'investigation code shows private children at all levels in related items' do
+    contributor = FactoryBot.create(:person)
+    investigation = FactoryBot.create(:investigation,
+      policy: FactoryBot.create(:private_policy),
+      contributor: contributor
+    )
+    study = FactoryBot.create(:study,
+      investigation: investigation,
+      policy: FactoryBot.create(:private_policy),
+      contributor: contributor
+    )
+    assay = FactoryBot.create(:assay,
+      study: study,
+      policy: FactoryBot.create(:private_policy),
+      contributor: contributor
+    )
+    data_file = FactoryBot.create(:data_file,
+      policy: FactoryBot.create(:private_policy),
+      contributor: contributor
+    )
+    sample = FactoryBot.create(:sample,
+      policy: FactoryBot.create(:private_policy),
+      contributor: contributor
+    )
+
+    disable_authorization_checks do
+      assay.assay_assets.create(asset: data_file)
+      assay.assay_assets.create(asset: sample)
+    end
+
+    auth_code = User.with_current_user(contributor.user) do
+      FactoryBot.create(:special_auth_code,
+        expiration_date: (Time.now + 1.days),
+        asset: investigation
+      )
+    end
+
+    code = CGI.escape(auth_code.code)
+    get "/investigations/#{investigation.id}?code=#{code}"
+    assert_response :success
+
+    # the title and favouritable avatar link
+    assert_select '#studies .list_item_title a[href*=?]', "/studies/#{study.id}", count: 2
+    assert_select '#studies .list_item_title a[href*=?]', "code=#{code}", count: 2
+
+    assert_select '#assays .list_item_title a[href*=?]', "/assays/#{assay.id}", count: 2
+    assert_select '#assays .list_item_title a[href*=?]', "code=#{code}", count: 2
+
+    assert_select '#datafiles .list_item_title a[href*=?]', "/data_files/#{data_file.id}", count: 2
+    assert_select '#datafiles .list_item_title a[href*=?]', "code=#{code}", count: 2
+
+    assert_select '#samples .list_item_title a[href*=?]', "/samples/#{sample.id}", count: 2
+    assert_select '#samples .list_item_title a[href*=?]', "code=#{code}", count: 2
+  end
+
+  test 'study code shows private child assays in related items' do
+    investigation = FactoryBot.create(:investigation)
+    study = FactoryBot.create(:study,
+      investigation: investigation,
+      policy: FactoryBot.create(:private_policy)
+    )
+    assay = FactoryBot.create(:assay,
+      study: study,
+      policy: FactoryBot.create(:private_policy),
+      contributor: study.contributor
+    )
+
+    auth_code = User.with_current_user(study.contributor.user) do
+      FactoryBot.create(:special_auth_code,
+        expiration_date: (Time.now + 1.days),
+        asset: study
+      )
+    end
+
+    code = CGI.escape(auth_code.code)
+    get "/studies/#{study.id}?code=#{code}"
+    assert_response :success
+
+    assert_select '#assays .list_item_title a[href*=?]', "/assays/#{assay.id}", count: 2
+    assert_select '#assays .list_item_title a[href*=?]', "code=#{code}", count: 2
+  end
+
+  test 'assay code shows private linked data files in related items' do
+    investigation = FactoryBot.create(:investigation)
+    study = FactoryBot.create(:study, investigation: investigation)
+    assay = FactoryBot.create(:assay,
+      study: study,
+      policy: FactoryBot.create(:private_policy)
+    )
+    data_file = FactoryBot.create(:data_file,
+      policy: FactoryBot.create(:private_policy),
+      contributor: assay.contributor
+    )
+
+    disable_authorization_checks do
+      assay.assay_assets.create(asset: data_file)
+    end
+
+    auth_code = User.with_current_user(assay.contributor.user) do
+      FactoryBot.create(:special_auth_code,
+        expiration_date: (Time.now + 1.days),
+        asset: assay
+      )
+    end
+
+    code = CGI.escape(auth_code.code)
+    get "/assays/#{assay.id}?code=#{code}"
+    assert_response :success
+
+    assert_select '#datafiles .list_item_title a[href*=?]', "/data_files/#{data_file.id}", count: 2
+    assert_select '#datafiles .list_item_title a[href*=?]', "code=#{code}", count: 2
+  end
+
+  test 'private children not shown in related items without code' do
+    investigation = FactoryBot.create(:investigation, policy: FactoryBot.create(:public_policy))
+    study = FactoryBot.create(:study,
+      investigation: investigation,
+      policy: FactoryBot.create(:private_policy),
+      contributor: investigation.contributor
+    )
+
+    get "/investigations/#{investigation.id}"
+    assert_response :success
+
+    assert_select '.list_item a[href*=?]', "/studies/#{study.id}", count: 0
+  end
 end
 


### PR DESCRIPTION
## Summary

- When accessing an ISA resource (Investigation, Study, Assay) via a temporary auth code (`?code=...`), the Related Items panel now correctly shows private related resources that are also accessible via that code
- The Rails cache for list item titles is bypassed when a code parameter is present, preventing cached links without the `?code=` param from being served to code-authenticated viewers
- Adds integration tests covering the related items behaviour with auth codes at all ISA levels

Fixes #2583