### PR TITLE
Fix redis session store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -160,4 +160,4 @@ gem "seven-zip", require: 'seven_zip_ruby'
 gem "ruby-xz", require: 'xz'
 
 gem "redis", "~> 5.4"
-gem "redis-session-store", "~> 0.11.6"
+gem "redis-actionpack", "~> 5.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -790,11 +790,17 @@ GEM
     recaptcha (5.19.0)
     redis (5.4.1)
       redis-client (>= 0.22.0)
+    redis-actionpack (5.5.0)
+      actionpack (>= 5)
+      redis-rack (>= 2.1.0, < 4)
+      redis-store (>= 1.1.0, < 2)
     redis-client (0.28.0)
       connection_pool
-    redis-session-store (0.11.6)
-      actionpack (>= 5.2.4.1, < 9)
-      redis (>= 3, < 6)
+    redis-rack (3.0.0)
+      rack-session (>= 0.2.0)
+      redis-store (>= 1.2, < 2)
+    redis-store (1.11.0)
+      redis (>= 4, < 6)
     regexp_parser (2.10.0)
     reline (0.6.0)
       io-console (~> 0.5)
@@ -1154,7 +1160,7 @@ DEPENDENCIES
   rdoc
   recaptcha
   redis (~> 5.4)
-  redis-session-store (~> 0.11.6)
+  redis-actionpack (~> 5.5)
   remotipart
   request-log-analyzer
   request_store

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -6,8 +6,6 @@
 # FIXME: Use Seek::Config.session_store_timeout somehow
 
 session_url = "#{ENV.fetch('REDIS_URL', 'redis://localhost:6379/0')}/session"
-domain_name = ENV.fetch('SEEK_FQDN', 'localhost')
-enforce_secure_cookies = ENV.fetch('ENFORCE_SECURE_COOKIES', 'false').downcase == 'true'
 
 session_options = {
   servers: [session_url],
@@ -15,12 +13,8 @@ session_options = {
   key: '_seek_session',
   threadsafe: true,
   same_site: :lax,
-  secure: Rails.env.production? && enforce_secure_cookies,
   httponly: true
 }
-
-# Only set the domain constraint if FQDN is configured
-session_options[:domain] = domain_name if domain_name.present? && domain_name != 'localhost'
 
 # Define the redis session store
 SEEK::Application.config.session_store(:redis_store, **session_options)

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -4,13 +4,22 @@
 # which shouldn't be used to store highly confidential information
 # (create the session table with "rails generate session_migration")
 # FIXME: Use Seek::Config.session_store_timeout somehow
-SEEK::Application.config.session_store(:redis_session_store,
-                                       redis: {
-                                         url: ENV.fetch("REDIS_URL", "redis://localhost:6379/0"),
-                                         expire_after: 30.minutes,
-                                         key_prefix: "session:",
-                                         ssl_params: Rails.env.production? ? { verify_mode: OpenSSL::SSL::VERIFY_PEER } : nil
-                                       },
-                                       key: '_seek_session',
-                                       same_site: :lax,
-                                       secure: Rails.env.production?)
+
+session_url = "#{ENV.fetch('REDIS_URL', 'redis://localhost:6379')}/0/session"
+domain_name = ENV.fetch('DOMAIN_NAME', 'localhost')
+
+session_options = {
+  servers: [session_url],
+  expire_after: 30.minutes,
+  key: '_seek_session',
+  threadsafe: true,
+  same_site: :lax,
+  secure: Rails.env.production?,
+  httponly: true
+}
+
+# Only set the domain constraint if FQDN is configured
+session_options[:domain] = domain_name if domain_name != 'localhost'
+
+# Define the redis session store
+SEEK::Application.config.session_store(:redis_store, **session_options)

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -6,7 +6,7 @@
 # FIXME: Use Seek::Config.session_store_timeout somehow
 
 session_url = "#{ENV.fetch('REDIS_URL', 'redis://localhost:6379/0')}/session"
-domain_name = ENV.fetch('DOMAIN_NAME', 'localhost')
+domain_name = ENV.fetch('SEEK_FQDN', 'localhost')
 enforce_secure_cookies = ENV.fetch('ENFORCE_SECURE_COOKIES', 'false').downcase == 'true'
 
 session_options = {

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -20,7 +20,7 @@ session_options = {
 }
 
 # Only set the domain constraint if FQDN is configured
-session_options[:domain] = domain_name if domain_name != 'localhost'
+session_options[:domain] = domain_name if domain_name.present? && domain_name != 'localhost'
 
 # Define the redis session store
 SEEK::Application.config.session_store(:redis_store, **session_options)

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,10 +1,5 @@
 # Be sure to restart your server when you modify this file.
 
-# Use Redis for sessions instead of the cookie-based default,
-# which shouldn't be used to store highly confidential information
-# (create the session table with "rails generate session_migration")
-# FIXME: Use Seek::Config.session_store_timeout somehow
-
 session_url = "#{ENV.fetch('REDIS_URL', 'redis://localhost:6379/0')}/session"
 
 session_options = {

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -16,7 +16,6 @@ session_options = {
   threadsafe: true,
   same_site: :lax,
   secure: Rails.env.production? && enforce_secure_cookies,
-  signed: true,
   httponly: true
 }
 

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,12 +1,13 @@
 # Be sure to restart your server when you modify this file.
 
-# Use the database for sessions instead of the cookie-based default,
+# Use Redis for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information
 # (create the session table with "rails generate session_migration")
 # FIXME: Use Seek::Config.session_store_timeout somehow
 
-session_url = "#{ENV.fetch('REDIS_URL', 'redis://localhost:6379')}/0/session"
+session_url = "#{ENV.fetch('REDIS_URL', 'redis://localhost:6379/0')}/session"
 domain_name = ENV.fetch('DOMAIN_NAME', 'localhost')
+enforce_secure_cookies = ENV.fetch('ENFORCE_SECURE_COOKIES', 'false').downcase == 'true'
 
 session_options = {
   servers: [session_url],
@@ -14,7 +15,8 @@ session_options = {
   key: '_seek_session',
   threadsafe: true,
   same_site: :lax,
-  secure: Rails.env.production?,
+  secure: Rails.env.production? && enforce_secure_cookies,
+  signed: true,
   httponly: true
 }
 

--- a/docker-compose-relative-root.yml
+++ b/docker-compose-relative-root.yml
@@ -9,7 +9,8 @@ x-shared:
       SOLR_PORT: 8983
       SOLR_HOST: solr
       RAILS_LOG_LEVEL: info # debug, info, warn, error or fatal
-      RAILS_RELATIVE_URL_ROOT: '/seek'
+      RAILS_RELATIVE_URL_ROOT: "/seek"
+      REDIS_URL: redis://redis_store:6379/0
     env_file:
       - docker/db.env
     volumes:
@@ -20,7 +21,6 @@ x-shared:
         condition: service_healthy
       solr:
         condition: service_healthy
-
 
 services:
   db:
@@ -42,12 +42,29 @@ services:
     volumes:
       - seek-mysql-db:/var/lib/mysql
     healthcheck:
-      test: [ "CMD-SHELL", "mysqladmin ping -h localhost -u $$MYSQL_USER -p$$MYSQL_PASSWORD --silent" ]
+      test:
+        [
+          "CMD-SHELL",
+          "mysqladmin ping -h localhost -u $$MYSQL_USER -p$$MYSQL_PASSWORD --silent",
+        ]
       interval: 10s
       timeout: 5s
       retries: 5
       start_period: 20s
 
+  redis_store:
+    image: redis:8.6-alpine
+    container_name: seek-session-store
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - seek-redis-data:/data
+    restart: always
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 20s
 
   seek:
     # The SEEK application
@@ -60,7 +77,7 @@ services:
       <<: *seek_base_env
       NO_ENTRYPOINT_WORKERS: 1
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:3000/up" ]
+      test: ["CMD", "curl", "-f", "http://localhost:3000/up"]
       interval: 30s
       timeout: 5s
       retries: 5
@@ -95,7 +112,6 @@ services:
       - solr-precreate
       - seek
       - /opt/solr/server/solr/configsets/seek_config
-
 
 volumes:
   seek-filestore:

--- a/docker-compose-virtuoso.yml
+++ b/docker-compose-virtuoso.yml
@@ -1,5 +1,6 @@
 x-shared:
-  seek_base: &seek_base # build: .
+  seek_base: &seek_base
+    # build: .
     image: fairdom/seek:main
 
     restart: always
@@ -8,6 +9,7 @@ x-shared:
       SOLR_PORT: 8983
       SOLR_HOST: solr
       RAILS_LOG_LEVEL: info # debug, info, warn, error or fatal
+      REDIS_URL: redis://redis_store:6379/0
     env_file:
       - docker/db.env
       - docker/virtuoso.env
@@ -49,6 +51,20 @@ services:
         ]
       interval: 10s
       timeout: 5s
+      retries: 5
+      start_period: 20s
+
+  redis_store:
+    image: redis:8.6-alpine
+    container_name: seek-session-store
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - seek-redis-data:/data
+    restart: always
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
       retries: 5
       start_period: 20s
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,9 @@ x-shared:
       SOLR_PORT: 8983
       SOLR_HOST: solr
       RAILS_LOG_LEVEL: info # debug, info, warn, error or fatal
-      REDIS_URL: redis://redis_store:6379
-#      DOMAIN_NAME: {} # Replace with your FQDN and uncomment
+      REDIS_URL: redis://redis_store:6379/0
+#      DOMAIN_NAME: 'localhost' # Replace with your FQDN and uncomment
+#      ENFORCE_SECURE_COOKIES: "true" # Uncomment if you need to enforce server-side secure cookies
     env_file:
       - docker/db.env
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ x-shared:
       SOLR_HOST: solr
       RAILS_LOG_LEVEL: info # debug, info, warn, error or fatal
       REDIS_URL: redis://redis_store:6379/0
-#      DOMAIN_NAME: 'localhost' # Replace with your FQDN and uncomment
+#      SEEK_FQDN: 'localhost' # Replace with your FQDN and uncomment. E.g. 'example.com' or '.example.com' for including subdomains.
 #      ENFORCE_SECURE_COOKIES: "true" # Uncomment if you need to enforce server-side secure cookies
     env_file:
       - docker/db.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 x-shared:
-  seek_base: &seek_base # build: .
+  seek_base: &seek_base
+#    build: .
     image: fairdom/seek:main
 
     restart: always
@@ -8,7 +9,8 @@ x-shared:
       SOLR_PORT: 8983
       SOLR_HOST: solr
       RAILS_LOG_LEVEL: info # debug, info, warn, error or fatal
-      REDIS_URL: redis://redis:6379/0
+      REDIS_URL: redis://redis_store:6379
+#      DOMAIN_NAME: {} # Replace with your FQDN and uncomment
     env_file:
       - docker/db.env
     volumes:
@@ -19,7 +21,7 @@ x-shared:
         condition: service_healthy
       solr:
         condition: service_healthy
-      redis:
+      redis_store:
         condition: service_healthy
 
 services:
@@ -52,7 +54,7 @@ services:
       retries: 5
       start_period: 20s
 
-  redis:
+  redis_store:
     image: redis:8.6-alpine
     container_name: seek-session-store
     command: ["redis-server", "--appendonly", "yes"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,6 @@ x-shared:
       SOLR_HOST: solr
       RAILS_LOG_LEVEL: info # debug, info, warn, error or fatal
       REDIS_URL: redis://redis_store:6379/0
-#      SEEK_FQDN: 'localhost' # Replace with your FQDN and uncomment. E.g. 'example.com' or '.example.com' for including subdomains.
-#      ENFORCE_SECURE_COOKIES: "true" # Uncomment if you need to enforce server-side secure cookies
     env_file:
       - docker/db.env
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 x-shared:
   seek_base: &seek_base
-#    build: .
+    # build: .
     image: fairdom/seek:main
 
     restart: always
@@ -61,12 +61,7 @@ services:
       - seek-redis-data:/data
     restart: always
     healthcheck:
-      test:
-        [
-          "CMD",
-          "redis-cli",
-          "ping"
-        ]
+      test: ["CMD", "redis-cli", "ping"]
       interval: 5s
       timeout: 3s
       retries: 5

--- a/test/integration/session_store_test.rb
+++ b/test/integration/session_store_test.rb
@@ -7,10 +7,10 @@ class SessionStoreTest < ActionDispatch::IntegrationTest
 
   test 'should timeout after 30 minutes' do
 
-    # test initializer sets the config to 30 minutes (normal defaut is 1 hour)
+    # test initializer sets the config to 30 minutes (normal default is 1 hour)
     # cannot test with `with_config_value` due to being too late after the tests start
 
-    assert_equal 30.minutes, Rails.application.config.session_options[:redis][:expire_after]
+    assert_equal 30.minutes, Rails.application.config.session_options[:expire_after]
     df = FactoryBot.create :data_file, contributor: User.current_user.person
     User.current_user = nil
     get "/data_files/#{df.id}"


### PR DESCRIPTION
- Use `:redis_store` -> better integration wit rack
- Sets the `:secure` attribute of the red by default to false but lets you set it to true through env variables
- Let's you scope the session cookie to an FQDN if desired