### PR TITLE
Add stale issue workflow (dry run)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,36 @@
+name: Mark and close stale issues
+
+on:
+  schedule:
+    - cron: '0 0 * * 1'  # runs every Monday at midnight UTC
+  workflow_dispatch:
+    inputs:
+      debug:
+        description: 'Enable debug logging'
+        type: boolean
+        default: false
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        env:
+          ACTIONS_STEP_DEBUG: ${{ inputs.debug }}
+        with:
+          days-before-stale: 1461      # mark as stale after 4 years (365*4+1 leap year)
+          days-before-close: 14        # close 14 days after being marked stale
+          stale-issue-message: >
+            This issue has been inactive for 4 years and has been marked as stale.
+            It will be closed in 14 days unless there is new activity.
+          close-issue-message: >
+            Closing due to 4+ years of inactivity. Feel free to reopen if this is still relevant.
+          stale-issue-label: 'stale'
+          exempt-issue-labels: 'pinned'
+          days-before-pr-stale: -1     # disable stale marking for PRs
+          days-before-pr-close: -1     # disable closing for PRs
+          enable-statistics: true      # requires ACTIONS_STEP_DEBUG to be visible
+          debug-only: true             # dry run — remove this when ready to go live

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,7 +2,7 @@ name: Mark and close stale issues
 
 on:
   schedule:
-    - cron: '0 0 * * 1'  # runs every Monday at midnight UTC
+    - cron: '0 0 * * *'  # runs daily at midnight UTC
   workflow_dispatch:
     inputs:
       debug:
@@ -12,6 +12,7 @@ on:
 
 permissions:
   issues: write
+  actions: write               # the resume cache lists and deletes Actions caches
 
 jobs:
   stale:
@@ -32,5 +33,7 @@ jobs:
           exempt-issue-labels: 'pinned'
           days-before-pr-stale: -1     # disable stale marking for PRs
           days-before-pr-close: -1     # disable closing for PRs
+          operations-per-run: 100      # API budget per run; a fresh stale marking costs 3
+          ascending: true              # oldest issues first, so the 4-year backlog is reached first
           enable-statistics: true      # requires ACTIONS_STEP_DEBUG to be visible
           debug-only: true             # dry run — remove this when ready to go live

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,11 +4,6 @@ on:
   schedule:
     - cron: '0 0 * * *'  # runs daily at midnight UTC
   workflow_dispatch:
-    inputs:
-      debug:
-        description: 'Enable debug logging'
-        type: boolean
-        default: false
 
 permissions:
   issues: write
@@ -19,8 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v10
-        env:
-          ACTIONS_STEP_DEBUG: ${{ inputs.debug }}
         with:
           days-before-stale: 1461      # mark as stale after 4 years (365*4+1 leap year)
           days-before-close: 14        # close 14 days after being marked stale
@@ -35,5 +28,5 @@ jobs:
           days-before-pr-close: -1     # disable closing for PRs
           operations-per-run: 100      # API budget per run; a fresh stale marking costs 3
           ascending: true              # oldest issues first, so the 4-year backlog is reached first
-          enable-statistics: true      # requires ACTIONS_STEP_DEBUG to be visible
+          enable-statistics: true      # logs a summary of what was processed
           debug-only: true             # dry run — remove this when ready to go live

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,10 +20,11 @@ jobs:
           stale-issue-message: >
             This issue has been inactive for 4 years and has been marked as stale.
             It will be closed in 14 days unless there is new activity.
+            Apply the `not-stale` label to keep it open.
           close-issue-message: >
             Closing due to 4+ years of inactivity. Feel free to reopen if this is still relevant.
           stale-issue-label: 'stale'
-          exempt-issue-labels: 'pinned'
+          exempt-issue-labels: 'not-stale'
           days-before-pr-stale: -1     # disable stale marking for PRs
           days-before-pr-close: -1     # disable closing for PRs
           operations-per-run: 100      # API budget per run; a fresh stale marking costs 3

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@v11
         with:
           days-before-stale: 1461      # mark as stale after 4 years (365*4+1 leap year)
           days-before-close: 14        # close 14 days after being marked stale


### PR DESCRIPTION
Adds a GitHub Actions workflow to mark and close long-inactive issues.

- Marks issues stale after 4 years of inactivity, closes them 14 days later
- PRs are excluded entirely
- Issues labelled `not-stale` are exempt, and the stale comment tells people to apply it
- Runs daily at midnight UTC, and can be triggered manually

**Still a dry run.** `debug-only: true` means nothing is written — a run only logs what it would have done. A follow-up PR removes that flag once the logged output looks right.

### Pacing

There are currently ~185 open issues with no activity since August 2022, so the first live runs work through a backlog rather than a trickle.

`operations-per-run: 100` is the API budget per run. Marking one issue costs 3 operations — a comment, a label, and an event lookup to find when the label was added — so a run covers roughly 30 issues. That keeps the burst of comment and label writes under GitHub's secondary rate limit of 80 content-generating requests per minute. Raising it is tempting but risky: the action's Octokit client does not retry 403s and swallows them into per-issue error logs, so an over-limit run silently does partial work and still reports success. Daily runs at this budget clear the backlog in a few weeks.

`ascending: true` processes oldest issues first. The default order is newest-created first, which would spend the early runs on issues nowhere near the threshold.

### Repo changes outside this diff

Two labels were created, since neither existed:

- `stale` (grey) — applied by the action
- `not-stale` (green) — applied by people, to opt an issue out of the sweep

The `pinned` label is no longer referenced; `not-stale` says what it does here and leaves pinning to mean pinning.

### Notes for review

`permissions` includes `actions: write` because the action keeps its resume state in an Actions cache entry and manages that entry through the cache API. Without the scope, the existence check fails silently and every run restarts from the first issue, re-spending an operation on each already-labelled issue. This only starts mattering once the dry run is lifted, as resume state is deliberately not persisted in debug mode.

The `workflow_dispatch` debug-logging input from the first commit has been dropped. A step-level `ACTIONS_STEP_DEBUG` has no effect — the runner reads that name from a repository secret or variable and translates it into `RUNNER_DEBUG`, which is what `@actions/core` checks. Little was being gated anyway: the per-issue decisions and the statistics summary are all logged at info level. (The action's README claims `enable-statistics` needs debug logging to be visible; that is out of date, and has been since at least v4.)

Uses `actions/stale@v11`. The major bump is an ESM migration plus dependency updates — `action.yml` is byte-identical to v10.4.0, so every input, default and the node24 runtime are unchanged.
