### PR TITLE
2566 different behaviours when applying an est to create an assay in datahub test instance

### DIFF
--- a/app/assets/javascripts/templates.js
+++ b/app/assets/javascripts/templates.js
@@ -189,13 +189,13 @@ function updateIsaTagSelect(template_level, attribute_row) {
   const isa_tags = get_filtered_isa_tags(template_level);
 
   // Remove all options first from the select items that were not disabled, except blank one
-  $j(attribute_row).find('select[data-attr="isa_tag_title"]:not(:disabled) option:not([value=""])').each(function() {
+  $j(attribute_row).find('select[data-attr="isa_tag_id"]:not(:disabled) option:not([value=""])').each(function() {
     $j(this).remove();
   });
 
   // Append filtered option to a new attribute row
   $j.each(isa_tags, function (i, tag) {
-    $j(attribute_row).find('select[data-attr="isa_tag_title"]:not(:disabled)').append($j('<option>', {
+    $j(attribute_row).find('select[data-attr="isa_tag_id"]:not(:disabled)').append($j('<option>', {
       value: tag.value,
       text: tag.text
     }));

--- a/app/assets/javascripts/templates.js
+++ b/app/assets/javascripts/templates.js
@@ -249,11 +249,12 @@ const applyTemplate = () => {
     $j(newRow).find('[data-attr="type"]').val(row[3]);
     if (appliedToSampleType) $j(newRow).find('[data-attr="type"]').addClass("disabled");
     $j(newRow).find('[data-attr="cv_id"]').val(row[4]);
-    if (appliedToSampleType) $j(newRow).find('[data-attr="cv_id"]').parent().addClass("disabled");
+    if (appliedToSampleType)
+      $j(newRow).find('[data-attr="cv_id"]').addClass("disabled");
     $j(newRow).find('[data-attr="allow_cv_free_text"]').prop("checked", row[5]);
     if (appliedToSampleType) $j(newRow)
-                                .find('[data-attr="allow_cv_free_text"]')
-                                .addClass("disabled");
+                                .find('input[type="checkbox"][data-attr="allow_cv_free_text"]')
+                                .prop("disabled", true);
     $j(newRow).find('[data-attr="unit"]').val(row[6]);
     if (appliedToSampleType)  $j(newRow).find('[data-attr="unit"]').addClass("disabled");
     $j(newRow).find('[data-attr="pid"]').val(row[9]);

--- a/app/assets/javascripts/templates.js
+++ b/app/assets/javascripts/templates.js
@@ -250,7 +250,7 @@ const applyTemplate = () => {
     if (appliedToSampleType) $j(newRow).find('[data-attr="type"]').addClass("disabled");
     $j(newRow).find('[data-attr="cv_id"]').val(row[4]);
     if (appliedToSampleType)
-      $j(newRow).find('[data-attr="cv_id"]').addClass("disabled");
+      $j(newRow).find('[data-attr="cv_id"]').parent().addClass("disabled");
     $j(newRow).find('[data-attr="allow_cv_free_text"]').prop("checked", row[5]);
     if (appliedToSampleType) $j(newRow)
                                 .find('input[type="checkbox"][data-attr="allow_cv_free_text"]')

--- a/app/assets/javascripts/templates.js
+++ b/app/assets/javascripts/templates.js
@@ -188,13 +188,13 @@ function updateIsaTagSelect(template_level, attribute_row) {
   const isa_tags = get_filtered_isa_tags(template_level);
 
   // Remove all options first from the select items that were not disabled, except blank one
-  $j(attribute_row).find('select[data-attr="isa_tag_id"]:not(:disabled) option:not([value=""])').each(function() {
+  $j(attribute_row).find('select[data-attr="isa_tag_id"]:not(:disabled):not(.disabled) option:not([value=""])').each(function() {
     $j(this).remove();
   });
 
   // Append filtered option to a new attribute row
   $j.each(isa_tags, function (i, tag) {
-    $j(attribute_row).find('select[data-attr="isa_tag_id"]:not(:disabled)').append($j('<option>', {
+    $j(attribute_row).find('select[data-attr="isa_tag_id"]:not(:disabled):not(.disabled)').append($j('<option>', {
       value: tag.value,
       text: tag.text
     }));

--- a/app/assets/javascripts/templates.js
+++ b/app/assets/javascripts/templates.js
@@ -123,7 +123,6 @@ Templates.mapData = (data) =>
     item.pid,
     item.pos,
     item.isa_tag_id,
-    item.isa_tag_title,
     item.linked_sample_type_id,
     item.template_attribute_id
   ]);

--- a/app/assets/javascripts/templates.js
+++ b/app/assets/javascripts/templates.js
@@ -259,9 +259,8 @@ const applyTemplate = () => {
     if (appliedToSampleType)  $j(newRow).find('[data-attr="unit"]').addClass("disabled");
     $j(newRow).find('[data-attr="pid"]').val(row[9]);
     $j(newRow).find('[data-attr="isa_tag_id"]').val(row[11]);
-    $j(newRow).find('[data-attr="isa_tag_title"]').val(row[11]);
     $j(newRow)
-        .find('[data-attr="isa_tag_title"]')
+        .find('[data-attr="isa_tag_id"]')
         .addClass("disabled");
     $j(newRow).find('[data-attr="template_attribute_id"]').val(row[14]); // In case of a sample type
     $j(newRow).find('[data-attr="parent_attribute_id"]').val(row[14]); // In case of a template

--- a/app/forms/isa_assay.rb
+++ b/app/forms/isa_assay.rb
@@ -80,12 +80,12 @@ class ISAAssay
 
     unless @sample_type.sample_attributes.select { |a| a.input_attribute? }.one?
       errors.add(:base,
-                  "[Sample type]: Should have exactly one attribute with the 'input' ISA Tag.".html_safe)
+                  "[Sample type]: Should have exactly one attribute with the 'input' ISA Tag.")
     end
 
     if @sample_type.sample_attributes.select { |a| a.isa_tag.nil? }.any?
       errors.add(:base,
-                  "[Sample type]: All attributes should have an ISA Tag.".html_safe)
+                  "[Sample type]: All attributes should have an ISA Tag.")
     end
 
     assay_sample_or_datafile_attributes = @sample_type.sample_attributes.select do |a|

--- a/app/helpers/templates_helper.rb
+++ b/app/helpers/templates_helper.rb
@@ -93,7 +93,6 @@ module TemplatesHelper
       unit_id: attribute.unit_id,
       pos: attribute.pos,
       isa_tag_id: attribute.isa_tag_id,
-      isa_tag_title: sanitize(attribute.isa_tag&.title),
       linked_sample_type_id: attribute.linked_sample_type_id,
       template_attribute_id: attribute.id
     }

--- a/app/models/sample_type.rb
+++ b/app/models/sample_type.rb
@@ -105,9 +105,16 @@ class SampleType < ApplicationRecord
   end
 
   def is_isa_json_compliant?
-    return false if investigations.blank?
+    # At creation time the link with assays / studies does not exist yet.
+    # That would mean that 'new' Sample Types are by definition never ISA-JSON compliant.
+    # For this reason, we need to be a bit more lenient at creation time.
+    if self.new_record?
+      isa_template.present?
+    else
+      return false if investigations.blank?
 
-    (studies.any? || assays.any?) && investigations.all? { |inv| inv.is_isa_json_compliant } && !isa_template.nil?
+      (studies.any? || assays.any?) && investigations.all? { |inv| inv.is_isa_json_compliant } && isa_template.present?
+    end
   end
 
   def locked?

--- a/app/models/sample_type.rb
+++ b/app/models/sample_type.rb
@@ -105,8 +105,9 @@ class SampleType < ApplicationRecord
   end
 
   def is_isa_json_compliant?
-    has_only_isa_json_compliant_investigations = studies.map(&:investigation).compact.all?(&:is_isa_json_compliant?) || assays.map(&:investigation).compact.all?(&:is_isa_json_compliant?)
-    (studies.any? || assays.any?) && has_only_isa_json_compliant_investigations && !isa_template.nil?
+    return false if investigations.blank?
+
+    (studies.any? || assays.any?) && investigations.all? { |inv| inv.is_isa_json_compliant } && !isa_template.nil?
   end
 
   def locked?

--- a/app/views/isa_studies/_sample_types_form.html.erb
+++ b/app/views/isa_studies/_sample_types_form.html.erb
@@ -96,19 +96,6 @@
         $j("#<%=attribute_table_id%>").on('change', '.sample-type-attribute-type', SampleTypes.attributeTypeChanged);
         $j("#<%=attribute_table_id%>").on('change', '.controlled-vocab-selection', SampleTypeControlledVocab.controlledVocabChanged);
         $j('.controlled-vocab-selection').change();
-
-        // Change ISA tag ID of the sample attribute when the select is changed
-        const sampleTypeTables = [
-          '#attribute-table_source_sample_type',
-          '#attribute-table_sample_collection_sample_type',
-          '#attribute-table_sample_type'
-        ].join(', ');
-        $j(sampleTypeTables).on('change', 'select[data-attr="isa_tag_title"]', function() {
-            const hiddenInputName = $j(this).attr('name').replace('isa_tag_title', 'isa_tag_id');
-            const isa_tag_id_sel = $j(this).val();
-
-            $j(`input:hidden[name="${hiddenInputName}"]`).val(isa_tag_id_sel);
-        });
     });
     $j(document).on('submit', function(){
       // Remove the table from the form

--- a/app/views/isa_studies/_sample_types_form.html.erb
+++ b/app/views/isa_studies/_sample_types_form.html.erb
@@ -97,31 +97,17 @@
         $j("#<%=attribute_table_id%>").on('change', '.controlled-vocab-selection', SampleTypeControlledVocab.controlledVocabChanged);
         $j('.controlled-vocab-selection').change();
 
-        // Change ISA tag ID of the study source when the select is changed
-        $j('#attribute-table_source_sample_type').on('change', 'select[data-attr="isa_tag_title"]', function() {
+        // Change ISA tag ID of the sample attribute when the select is changed
+        const sampleTypeTables = [
+          '#attribute-table_source_sample_type',
+          '#attribute-table_sample_collection_sample_type',
+          '#attribute-table_sample_type'
+        ].join(', ');
+        $j(sampleTypeTables).on('change', 'select[data-attr="isa_tag_title"]', function() {
             const hiddenInputName = $j(this).attr('name').replace('isa_tag_title', 'isa_tag_id');
             const isa_tag_id_sel = $j(this).val();
 
             $j(`input:hidden[name="${hiddenInputName}"]`).val(isa_tag_id_sel);
-
-        });
-
-        // Change ISA tag ID of the study sample when the select is changed
-        $j('#attribute-table_sample_collection_sample_type').on('change', 'select[data-attr="isa_tag_title"]', function() {
-            const hiddenInputName = $j(this).attr('name').replace('isa_tag_title', 'isa_tag_id');
-            const isa_tag_id_sel = $j(this).val();
-
-            $j(`input:hidden[name="${hiddenInputName}"]`).val(isa_tag_id_sel);
-
-        });
-
-        // Change ISA tag ID of the assay sample when the select is changed
-        $j('#attribute-table_sample_type').on('change', 'select[data-attr="isa_tag_title"]', function() {
-            const hiddenInputName = $j(this).attr('name').replace('isa_tag_title', 'isa_tag_id');
-            const isa_tag_id_sel = $j(this).val();
-
-            $j(`input:hidden[name="${hiddenInputName}"]`).val(isa_tag_id_sel);
-
         });
     });
     $j(document).on('submit', function(){

--- a/app/views/sample_types/_sample_attribute_form.html.erb
+++ b/app/views/sample_types/_sample_attribute_form.html.erb
@@ -28,7 +28,6 @@
   ########
   # Sample Type editing constraints
   ########
-  # constraints = (display_isa_tag && sample_type.new_record?) ? sample_type.creation_constraints : sample_type.editing_constraints
   constraints = sample_type.editing_constraints
   allow_title_change = sample_type.new_record? ? constraints.allow_change_at_creation?(sample_attribute) : constraints.allow_type_change?(sample_attribute)
   allow_required = sample_type.new_record? ? constraints.allow_change_at_creation?(sample_attribute) : constraints.allow_required?(sample_attribute)

--- a/app/views/sample_types/_sample_attribute_form.html.erb
+++ b/app/views/sample_types/_sample_attribute_form.html.erb
@@ -29,7 +29,6 @@
   # Sample Type editing constraints
   ########
   constraints = sample_type.editing_constraints
-  allow_title_change = sample_type.new_record? ? constraints.allow_change_at_creation?(sample_attribute) : constraints.allow_type_change?(sample_attribute)
   allow_required = sample_type.new_record? ? constraints.allow_change_at_creation?(sample_attribute) : constraints.allow_required?(sample_attribute)
 
   # Attribute removal should not be different at creation time
@@ -52,7 +51,7 @@
   </th>
   <td>
 
-    <%= text_field_tag "#{field_name_prefix}[title]", title, class: "form-control#{allow_title_change ? '' : ' disabled'}",
+    <%= text_field_tag "#{field_name_prefix}[title]", title, class: 'form-control',
                        placeholder: 'Attribute name', data: { attr: "title" } %>
   </td>
 

--- a/app/views/sample_types/_sample_attribute_form.html.erb
+++ b/app/views/sample_types/_sample_attribute_form.html.erb
@@ -58,13 +58,20 @@
   <td class="text-center" title="<%= required_title_text %>">
     <div class="checkbox-inline">
       <%= hidden_field_tag "#{field_name_prefix}[required]", '0' %>
-      <%= check_box_tag "#{field_name_prefix}[required]", '1', required, class: "#{ allow_required ? '' : 'disabled' }", data: { attr: "required" } %>
+      <%= check_box_tag "#{field_name_prefix}[required]", '1', required,
+                        class: "#{ allow_required ? '' : 'disabled' }",
+                        tabindex: (allow_required ? nil : '-1'),
+                        aria: { disabled: allow_required ? nil : 'true' },
+                        data: { attr: "required" } %>
     </div>
   </td>
   <td class="text-center" title="<%= is_title_title_text %>">
     <div class="checkbox-inline">
       <%= hidden_field_tag "#{field_name_prefix}[is_title]", '0' %>
-      <%= check_box_tag "#{field_name_prefix}[is_title]", '1', is_title, class: "sample-type-is-title #{ allow_required ? '' : 'disabled' }"%>
+      <%= check_box_tag "#{field_name_prefix}[is_title]", '1', is_title,
+                        class: "sample-type-is-title #{ allow_required ? '' : 'disabled' }",
+                        tabindex: (allow_required ? nil : '-1'),
+                        aria: { disabled: allow_required ? nil : 'true' } %>
     </div>
   </td>
   <td>
@@ -73,6 +80,8 @@
                      [t.title, t.id,{'data-use-cv': t.controlled_vocab? || t.seek_cv_list?, 'data-is-seek-sample': t.seek_sample? || t.seek_sample_multi? }]
                    end , attribute_type_id),
                    class: "form-control sample-type-attribute-type#{allow_type_change ? '' : ' disabled'}",
+                   tabindex: (allow_type_change ? nil : '-1'),
+                   aria: { disabled: allow_type_change ? nil : 'true' },
                    data: { attr: "type" } %>
     <div class='controlled-vocab-block' style="<%= 'display:none;' unless sample_attribute.try(:controlled_vocab?) %>">
       <br/>
@@ -81,6 +90,8 @@
                                         sample_controlled_vocab_id),
                      include_blank: true,
                      class: "form-control controlled-vocab-selection#{allow_type_change ? '' : ' disabled'}",
+                     tabindex: (allow_type_change ? nil : '-1'),
+                     aria: { disabled: allow_type_change ? nil : 'true' },
                      data: { attr: "cv_id" }%>
 
       <div>

--- a/app/views/sample_types/_sample_attribute_form.html.erb
+++ b/app/views/sample_types/_sample_attribute_form.html.erb
@@ -129,15 +129,14 @@
 
   <% if display_isa_tag %>
     <td>
-      <%= select_tag "#{field_name_prefix}[isa_tag_title]",
+      <%= select_tag "#{field_name_prefix}[isa_tag_id]",
                       options_for_select(isa_tags_options, isa_tag_id),
-                      include_blank: true, class: 'form-control',
-                      data: {attr: "isa_tag_title"},
-                      disabled: !allow_isa_tag_change %>
+                      include_blank: true,
+                      data: {attr: "isa_tag_id"},
+                      class: "form-control#{allow_isa_tag_change ? '' : ' disabled'}"%>
     </td>
 
     <%= hidden_field_tag "#{field_name_prefix}[template_attribute_id]", template_attribute_id, data: { attr: "template_attribute_id" } %>
-    <%= hidden_field_tag "#{field_name_prefix}[isa_tag_id]", (display_isa_tag ? isa_tag_id : nil), data: { attr: "isa_tag_id" }  %>
   <% end %>
 
   <td>

--- a/app/views/sample_types/_sample_attribute_form.html.erb
+++ b/app/views/sample_types/_sample_attribute_form.html.erb
@@ -135,6 +135,9 @@
                       data: {attr: "isa_tag_title"},
                       disabled: !allow_isa_tag_change %>
     </td>
+
+    <%= hidden_field_tag "#{field_name_prefix}[template_attribute_id]", template_attribute_id, data: { attr: "template_attribute_id" } %>
+    <%= hidden_field_tag "#{field_name_prefix}[isa_tag_id]", (display_isa_tag ? isa_tag_id : nil), data: { attr: "isa_tag_id" }  %>
   <% end %>
 
   <td>
@@ -148,11 +151,8 @@
     %>
   </td>
 
-
   <td>
     <% if allow_attribute_removal %>
-      <%= hidden_field_tag "#{field_name_prefix}[isa_tag_id]", (display_isa_tag ? isa_tag_id : nil), data: { attr: "isa_tag_id" }  %>
-      <%= hidden_field_tag "#{field_name_prefix}[template_attribute_id]", template_attribute_id, data: { attr: "template_attribute_id" } %>
       <%= hidden_field_tag "#{field_name_prefix}[_destroy]", '0', autocomplete: 'off' %>
       <div class="btn-group" data-toggle="buttons">
         <label class="btn btn-danger">
@@ -166,10 +166,8 @@
     <% end %>
   </td>
 
-
   <% if sample_attribute %>
-      <%= hidden_field_tag("#{field_name_prefix}[id]", id) %>
-      <%= hidden_field_tag("#{field_name_prefix}[template_column_index]", template_column_index) %>
-
+    <%= hidden_field_tag("#{field_name_prefix}[id]", id) %>
+    <%= hidden_field_tag("#{field_name_prefix}[template_column_index]", template_column_index) %>
   <% end %>
 </tr>

--- a/app/views/sample_types/_sample_attribute_form.html.erb
+++ b/app/views/sample_types/_sample_attribute_form.html.erb
@@ -103,7 +103,10 @@
 <% else %>
   <%= hidden_field_tag "#{field_name_prefix}[allow_cv_free_text]", (allow_cv_free_text ? '1' : '0') %>
   <%= check_box_tag "#{field_name_prefix}[allow_cv_free_text]", '1', allow_cv_free_text,
-                    disabled: true, data: { attr: 'allow_cv_free_text' } %>
+                    class: 'disabled',
+                    tabindex: '-1',
+                    aria: { disabled: 'true' },
+                    data: { attr: 'allow_cv_free_text' } %>
 <% end %>
           <%= t('samples.allow_free_text_checkbox_label') %> <%= allow_free_text_help_icon %>
         </label>
@@ -130,6 +133,8 @@
                      grouped_options_for_select(options,
                                         link_to_self ? 'self' : linked_sample_type_id),
                      include_blank: true,
+                     tabindex: (allow_type_change ? nil : '-1'),
+                     aria: { disabled: allow_type_change ? nil : 'true' },
                      class: "form-control linked-sample-type-selection#{allow_type_change ? '' : ' disabled'}" %>
     </div>
   </td>

--- a/app/views/sample_types/_sample_attribute_form.html.erb
+++ b/app/views/sample_types/_sample_attribute_form.html.erb
@@ -1,36 +1,47 @@
-<% sample_attribute ||= nil %>
-<% index ||= 'replace-me' %>
-<% id = sample_attribute&.id || '' %>
-<% title = sample_attribute&.title || '' %>
-<% description = sample_attribute&.description || '' %>
-<% pid = sample_attribute&.pid || '' %>
-<% pos = sample_attribute&.pos || '' %>
-<% required = sample_attribute&.required || false %>
-<% is_title = sample_attribute&.is_title || false %>
-<% attribute_type_id = sample_attribute&.sample_attribute_type_id %>
-<% sample_controlled_vocab_id = sample_attribute&.sample_controlled_vocab_id %>
-<% allow_cv_free_text = sample_attribute&.allow_cv_free_text || false %>
-<% linked_sample_type_id = sample_attribute ? sample_attribute.linked_sample_type_id : nil %>
-<% unit_id = sample_attribute ? sample_attribute.unit_id : nil %>
-<% template_column_index = sample_attribute ? sample_attribute.template_column_index : nil %>
-<% prefix ||= 'sample_type' %>
-<% field_name_prefix = "#{prefix}[sample_attributes_attributes][#{index}]" %>
-<% constraints = sample_type.editing_constraints %>
-<% allow_required = constraints.allow_required?(sample_attribute) %>
-<% allow_attribute_removal = constraints.allow_attribute_removal?(sample_attribute)  %>
-<% allow_type_change = constraints.allow_type_change?(sample_attribute) %>
-<% allow_unit_change = constraints.allow_unit_change?(sample_attribute) %>
-<% seek_sample_multi = sample_attribute&.seek_sample_multi? %>
-<% link_to_self = sample_attribute && sample_attribute.deferred_link_to_self %>
-<% display_isa_tag ||= false %>
-<% hide_seek_sample_multi = display_isa_tag ? (sample_attribute&.input_attribute? && displaying_single_page?) : false %>
-<% level = sample_type.level if display_isa_tag %>
-<% isa_tags_options = ISATag.allowed_isa_tags_for_level(level).map { |it| [it.title, it.id] } if display_isa_tag %>
-<% isa_tag_id = sample_attribute&.isa_tag_id %>
-<% template_attribute_id = sample_attribute&.template_attribute_id if display_isa_tag %>
-<% allow_isa_tag_change = constraints.allow_isa_tag_change?(sample_attribute) if display_isa_tag %>
-<% required_title_text = allow_required ? nil : "You are not allowed to make this attribute required.\nSome samples have no value for this attribute." %>
-<% is_title_title_text = allow_required ? nil : "You are not allowed to change this attribute's title field.\nSome samples have no value for this attribute." %>
+<%
+  sample_attribute ||= nil
+  display_isa_tag ||= false
+  index ||= 'replace-me'
+  id = sample_attribute&.id || ''
+  title = sample_attribute&.title || ''
+  description = sample_attribute&.description || ''
+  pid = sample_attribute&.pid || ''
+  pos = sample_attribute&.pos || ''
+  required = sample_attribute&.required || false
+  is_title = sample_attribute&.is_title || false
+  attribute_type_id = sample_attribute&.sample_attribute_type_id
+  sample_controlled_vocab_id = sample_attribute&.sample_controlled_vocab_id
+  allow_cv_free_text = sample_attribute&.allow_cv_free_text || false
+  linked_sample_type_id = sample_attribute ? sample_attribute.linked_sample_type_id : nil
+  unit_id = sample_attribute ? sample_attribute.unit_id : nil
+  template_column_index = sample_attribute ? sample_attribute.template_column_index : nil
+  prefix ||= 'sample_type'
+  field_name_prefix = "#{prefix}[sample_attributes_attributes][#{index}]"
+  seek_sample_multi = sample_attribute&.seek_sample_multi?
+  link_to_self = sample_attribute && sample_attribute.deferred_link_to_self
+  hide_seek_sample_multi = display_isa_tag ? (sample_attribute&.input_attribute? && displaying_single_page?) : false
+  level = sample_type.level if display_isa_tag
+  isa_tags_options = ISATag.allowed_isa_tags_for_level(level).map { |it| [it.title, it.id] } if display_isa_tag
+  isa_tag_id = sample_attribute&.isa_tag_id
+  template_attribute_id = sample_attribute&.template_attribute_id if display_isa_tag
+
+  ########
+  # Sample Type editing constraints
+  ########
+  # constraints = (display_isa_tag && sample_type.new_record?) ? sample_type.creation_constraints : sample_type.editing_constraints
+  constraints = sample_type.editing_constraints
+  allow_title_change = sample_type.new_record? ? constraints.allow_change_at_creation?(sample_attribute) : constraints.allow_type_change?(sample_attribute)
+  allow_required = sample_type.new_record? ? constraints.allow_change_at_creation?(sample_attribute) : constraints.allow_required?(sample_attribute)
+
+  # Attribute removal should not be different at creation time
+  allow_attribute_removal = constraints.allow_attribute_removal?(sample_attribute)
+
+  allow_type_change = sample_type.new_record? ? constraints.allow_change_at_creation?(sample_attribute) : constraints.allow_type_change?(sample_attribute)
+  allow_unit_change = sample_type.new_record? ? constraints.allow_change_at_creation?(sample_attribute) : constraints.allow_unit_change?(sample_attribute)
+  allow_isa_tag_change = sample_type.new_record? ? constraints.allow_change_at_creation?(sample_attribute) : constraints.allow_isa_tag_change?(sample_attribute) if display_isa_tag
+  required_title_text = allow_required ? nil : "You are not allowed to make this attribute required.\nSome samples have no value for this attribute."
+  is_title_title_text = allow_required ? nil : "You are not allowed to change this attribute's title field.\nSome samples have no value for this attribute."
+%>
 
 <tr class="sample-attribute <%= 'success' if sample_attribute.nil? -%><%='hidden' if hide_seek_sample_multi -%>" data-index="<%= index-%>">
   <th scope="row" class="attribute-position">

--- a/app/views/sample_types/_sample_attribute_form.html.erb
+++ b/app/views/sample_types/_sample_attribute_form.html.erb
@@ -133,7 +133,7 @@
                       options_for_select(isa_tags_options, isa_tag_id),
                       include_blank: true,
                       data: {attr: "isa_tag_id"},
-                      class: "form-control #{allow_isa_tag_change ? '' : ' disabled'}"%>
+                      class: "form-control#{allow_isa_tag_change ? '' : ' disabled'}" %>
     </td>
 
     <%= hidden_field_tag "#{field_name_prefix}[template_attribute_id]", template_attribute_id, data: { attr: "template_attribute_id" } %>

--- a/app/views/sample_types/_sample_attribute_form.html.erb
+++ b/app/views/sample_types/_sample_attribute_form.html.erb
@@ -74,21 +74,22 @@
                    options_for_select(displayed_sample_attribute_types.sort_by(&:title).sort_by { |t| t.default? ? 0 : 1 }.map do |t|
                      [t.title, t.id,{'data-use-cv': t.controlled_vocab? || t.seek_cv_list?, 'data-is-seek-sample': t.seek_sample? || t.seek_sample_multi? }]
                    end , attribute_type_id),
-                   class: 'form-control sample-type-attribute-type',
-                   disabled: !allow_type_change, data: { attr: "type" } %>
+                   class: "form-control sample-type-attribute-type#{allow_type_change ? '' : ' disabled'}",
+                   data: { attr: "type" } %>
     <div class='controlled-vocab-block' style="<%= 'display:none;' unless sample_attribute.try(:controlled_vocab?) %>">
       <br/>
       <%= select_tag "#{field_name_prefix}[sample_controlled_vocab_id]",
                      options_for_select(SampleControlledVocab.all.map { |scv| [scv.title, scv.id, {'data-editable': scv.can_edit?}] },
                                         sample_controlled_vocab_id),
                      include_blank: true,
-                     class: 'form-control controlled-vocab-selection',
-                     disabled: !allow_type_change, data: { attr: "cv_id" }%>
+                     class: "form-control controlled-vocab-selection#{allow_type_change ? '' : ' disabled'}",
+                     data: { attr: "cv_id" }%>
 
       <div>
         <label>
           <%= hidden_field_tag "#{field_name_prefix}[allow_cv_free_text]", '0'  %>
-          <%= check_box_tag "#{field_name_prefix}[allow_cv_free_text]", '1', allow_cv_free_text, data: { attr: 'allow_cv_free_text' } %>
+          <%= check_box_tag "#{field_name_prefix}[allow_cv_free_text]", '1', allow_cv_free_text,
+                            disabled: !allow_type_change, data: { attr: 'allow_cv_free_text' } %>
           <%= t('samples.allow_free_text_checkbox_label') %> <%= allow_free_text_help_icon %>
         </label>
       </div>
@@ -114,8 +115,7 @@
                      grouped_options_for_select(options,
                                         link_to_self ? 'self' : linked_sample_type_id),
                      include_blank: true,
-                     disabled: !allow_type_change,
-                     class: 'form-control linked-sample-type-selection' %>
+                     class: "form-control linked-sample-type-selection#{allow_type_change ? '' : ' disabled'}" %>
     </div>
   </td>
   <td>
@@ -145,9 +145,8 @@
                    options_for_select(Unit.order(:order).map { |u| ["#{u.symbol} #{u.title}", "#{u.id}"] },
                                       unit_id),
                    include_blank: true,
-                   class: 'form-control',
-                   data: { attr: "unit" },
-                   disabled: !allow_unit_change
+                   class: "form-control#{allow_unit_change ? '' : ' disabled'}",
+                   data: { attr: "unit" }
     %>
   </td>
 

--- a/app/views/sample_types/_sample_attribute_form.html.erb
+++ b/app/views/sample_types/_sample_attribute_form.html.erb
@@ -42,7 +42,7 @@
   </th>
   <td>
 
-    <%= text_field_tag "#{field_name_prefix}[title]", title, class: 'form-control',
+    <%= text_field_tag "#{field_name_prefix}[title]", title, class: "form-control#{allow_title_change ? '' : ' disabled'}",
                        placeholder: 'Attribute name', data: { attr: "title" } %>
   </td>
 

--- a/app/views/sample_types/_sample_attribute_form.html.erb
+++ b/app/views/sample_types/_sample_attribute_form.html.erb
@@ -86,7 +86,7 @@
 
       <div>
         <label>
-          <%= hidden_field_tag "#{field_name_prefix}[allow_cv_free_text]", '0'  %>
+          <%= hidden_field_tag "#{field_name_prefix}[allow_cv_free_text]", "#{ allow_cv_free_text ? '1' : '0' }"  %>
           <%= check_box_tag "#{field_name_prefix}[allow_cv_free_text]", '1', allow_cv_free_text,
                             disabled: !allow_type_change, data: { attr: 'allow_cv_free_text' } %>
           <%= t('samples.allow_free_text_checkbox_label') %> <%= allow_free_text_help_icon %>

--- a/app/views/sample_types/_sample_attribute_form.html.erb
+++ b/app/views/sample_types/_sample_attribute_form.html.erb
@@ -85,9 +85,15 @@
 
       <div>
         <label>
-          <%= hidden_field_tag "#{field_name_prefix}[allow_cv_free_text]", "#{ allow_cv_free_text ? '1' : '0' }"  %>
-          <%= check_box_tag "#{field_name_prefix}[allow_cv_free_text]", '1', allow_cv_free_text,
-                            disabled: !allow_type_change, data: { attr: 'allow_cv_free_text' } %>
+<% if allow_type_change %>
+  <%= hidden_field_tag "#{field_name_prefix}[allow_cv_free_text]", '0' %>
+  <%= check_box_tag "#{field_name_prefix}[allow_cv_free_text]", '1', allow_cv_free_text,
+                    data: { attr: 'allow_cv_free_text' } %>
+<% else %>
+  <%= hidden_field_tag "#{field_name_prefix}[allow_cv_free_text]", (allow_cv_free_text ? '1' : '0') %>
+  <%= check_box_tag "#{field_name_prefix}[allow_cv_free_text]", '1', allow_cv_free_text,
+                    disabled: true, data: { attr: 'allow_cv_free_text' } %>
+<% end %>
           <%= t('samples.allow_free_text_checkbox_label') %> <%= allow_free_text_help_icon %>
         </label>
       </div>

--- a/app/views/sample_types/_sample_attribute_form.html.erb
+++ b/app/views/sample_types/_sample_attribute_form.html.erb
@@ -133,7 +133,7 @@
                       options_for_select(isa_tags_options, isa_tag_id),
                       include_blank: true,
                       data: {attr: "isa_tag_id"},
-                      class: "form-control#{allow_isa_tag_change ? '' : ' disabled'}"%>
+                      class: "form-control #{allow_isa_tag_change ? '' : ' disabled'}"%>
     </td>
 
     <%= hidden_field_tag "#{field_name_prefix}[template_attribute_id]", template_attribute_id, data: { attr: "template_attribute_id" } %>

--- a/app/views/templates/_form.html.erb
+++ b/app/views/templates/_form.html.erb
@@ -139,15 +139,6 @@
         $j('#attribute-table .sample-type-attribute-type').trigger("change", [false]);
         $j('.templates').select2({theme: "bootstrap"});
 
-        // Change ISA Tag ID when ISA Tag title changes
-        $j('#attribute-table').on('change', 'select[data-attr="isa_tag_title"]', function() {
-            const hiddenInputName = $j(this).attr('name').replace('isa_tag_title', 'isa_tag_id');
-            const isa_tag_id_sel = $j(this).val();
-
-            $j(`input:hidden[name="${hiddenInputName}"]`).val(isa_tag_id_sel);
-
-        });
-
         initSelect2($j('.templates'), $j('#existing_templates'));
         Templates.clearContext();
         Templates.init($j('#template-attributes'));

--- a/app/views/templates/_template_attribute_form.html.erb
+++ b/app/views/templates/_template_attribute_form.html.erb
@@ -101,7 +101,7 @@
   </td>
 
   <td>
-    <%= select_tag "#{field_name_prefix}[isa_tag_title]",
+    <%= select_tag "#{field_name_prefix}[isa_tag_id]",
                     options_for_select(isa_tag_options, isa_tag_id),
                     include_blank: true,
                     data: {attr: "isa_tag_id"},
@@ -115,7 +115,6 @@
   </td>
   <td>
     <div class="btn-group" data-toggle="buttons">
-      <%= hidden_field_tag "#{field_name_prefix}[isa_tag_id]", isa_tag_id, data: { attr: "isa_tag_id" } %>
       <%= hidden_field_tag "#{field_name_prefix}[parent_attribute_id]", parent_attribute_id, data: { attr: "parent_attribute_id" } %>
       <%= hidden_field_tag "#{field_name_prefix}[_destroy]", '0', autocomplete: 'off' %>
       <label class="btn btn-danger">

--- a/app/views/templates/_template_attribute_form.html.erb
+++ b/app/views/templates/_template_attribute_form.html.erb
@@ -105,6 +105,8 @@
                     options_for_select(isa_tag_options, isa_tag_id),
                     include_blank: true,
                     data: {attr: "isa_tag_id"},
+                    tabindex: (allow_isa_tag_change ? nil : '-1'),
+                    aria: { disabled: allow_isa_tag_change ? nil : 'true' },
                     class: "form-control#{allow_isa_tag_change ? '' : ' disabled'}" %>
   </td>
 

--- a/app/views/templates/_template_attribute_form.html.erb
+++ b/app/views/templates/_template_attribute_form.html.erb
@@ -1,25 +1,27 @@
-<% template_attribute ||= nil %>
-<% index ||= 'replace-me' %>
-<% id = template_attribute ? template_attribute.id : '' %>
-<% title = template_attribute ? template_attribute.title : '' %>
-<% description = template_attribute ? template_attribute.description : '' %>
-<% pid = template_attribute ? template_attribute.pid : '' %>
-<% pos = template_attribute ? template_attribute.pos : '' %>
-<% required = template_attribute ? template_attribute.required : false %>
-<% attribute_type_id = template_attribute ? template_attribute.sample_attribute_type_id : nil %>
-<% sample_controlled_vocab_id = template_attribute ? template_attribute.sample_controlled_vocab_id : nil %>
-<% unit_id = template_attribute ? template_attribute.unit_id : nil %>
-<% linked_sample_type_id = template_attribute&.linked_sample_type_id %>
-<% field_name_prefix = "template[template_attributes_attributes][#{index}]" %>
-<% seek_sample_multi = template_attribute.try(:seek_sample_multi?) %>
-<% is_title = template_attribute ? template_attribute.is_title : false %>
-<% level = template&.level %>
-<% isa_tag_options = ISATag.allowed_isa_tags_for_level(level).map { |it| [it.title, it.id] } %>
-<% isa_tag_id = template_attribute&.isa_tag_id %>
-<% allow_cv_free_text = template_attribute&.allow_cv_free_text || false %>
-<% parent_attribute_id = template_attribute&.parent_attribute_id %>
-<% allow_isa_tag_change = template_attribute ? template_attribute.allow_isa_tag_change? : true %>
-<% hide_seek_sample_multi = template_attribute&.input_attribute? %>
+<%
+  template_attribute ||= nil
+  index ||= 'replace-me'
+  id = template_attribute&.id || ''
+  title = template_attribute&.title || ''
+  description = template_attribute&.description || ''
+  pid = template_attribute&.pid || ''
+  pos = template_attribute&.pos || ''
+  required = template_attribute ? template_attribute.required : false
+  attribute_type_id = template_attribute&.sample_attribute_type_id
+  sample_controlled_vocab_id = template_attribute&.sample_controlled_vocab_id
+  unit_id = template_attribute&.unit_id
+  linked_sample_type_id = template_attribute&.linked_sample_type_id
+  field_name_prefix = "template[template_attributes_attributes][#{index}]"
+  seek_sample_multi = template_attribute.try(:seek_sample_multi?)
+  is_title = template_attribute ? template_attribute.is_title : false
+  level = template&.level
+  isa_tag_options = ISATag.allowed_isa_tags_for_level(level).map { |it| [it.title, it.id] }
+  isa_tag_id = template_attribute&.isa_tag_id
+  allow_cv_free_text = template_attribute ? template_attribute.allow_cv_free_text : false
+  parent_attribute_id = template_attribute&.parent_attribute_id
+  allow_isa_tag_change = template_attribute ? template_attribute.allow_isa_tag_change? : true
+  hide_seek_sample_multi = template_attribute&.input_attribute?
+%>
 
 <tr class="sample-attribute <%= 'success' if template_attribute.nil? || template_attribute.new_record? -%><%='hidden' if hide_seek_sample_multi -%>" data-index="<%= index-%>">
   <th scope="row" class="attribute-position">

--- a/app/views/templates/_template_attribute_form.html.erb
+++ b/app/views/templates/_template_attribute_form.html.erb
@@ -21,7 +21,7 @@
 <% allow_isa_tag_change = template_attribute ? template_attribute.allow_isa_tag_change? : true %>
 <% hide_seek_sample_multi = template_attribute&.input_attribute? %>
 
-<tr class="sample-attribute <%= 'success' if template_attribute.nil? -%><%='hidden' if hide_seek_sample_multi -%>" data-index="<%= index-%>">
+<tr class="sample-attribute <%= 'success' if template_attribute.nil? || template_attribute.new_record? -%><%='hidden' if hide_seek_sample_multi -%>" data-index="<%= index-%>">
   <th scope="row" class="attribute-position">
     <div class="btn btn-info attribute-handle">
       <span class="glyphicon glyphicon-sort" aria-hidden="true"></span>

--- a/app/views/templates/_template_attribute_form.html.erb
+++ b/app/views/templates/_template_attribute_form.html.erb
@@ -44,7 +44,7 @@
    <td class="text-center">
     <div class="checkbox-inline">
       <%= hidden_field_tag "#{field_name_prefix}[is_title]", '0' %>
-      <%= check_box_tag "#{field_name_prefix}[is_title]", '1', is_title, class:'sample-type-is-title',disabled: seek_sample_multi %>
+      <%= check_box_tag "#{field_name_prefix}[is_title]", '1', is_title, class: "sample-type-is-title#{seek_sample_multi ? ' disabled' : ''}" %>
     </div>
   </td>
   <td>
@@ -69,10 +69,10 @@
         </label>
       </div>
 
-      <%= button_link_to('Edit', 'edit', '#', class:'cv-edit-button', disabled: true, target: :_blank) %>
+      <%= button_link_to('Edit', 'edit', '#', class:'cv-edit-button disabled', target: :_blank) %>
       <%= create_sample_controlled_vocab_modal_button  %>
 
-      <%= button_link_to('View current', 'show', '#', class:'cv-show-button', disabled: true, target: :_blank) %>
+      <%= button_link_to('View current', 'show', '#', class:'cv-show-button disabled', target: :_blank) %>
       <%= button_link_to('Browse', 'index', sample_controlled_vocabs_path, target: :_blank) %>
 
     </div>
@@ -104,9 +104,8 @@
     <%= select_tag "#{field_name_prefix}[isa_tag_title]",
                     options_for_select(isa_tag_options, isa_tag_id),
                     include_blank: true,
-                    class: 'form-control',
-                    data: {attr: "isa_tag_title"},
-                    disabled: !allow_isa_tag_change %>
+                    data: {attr: "isa_tag_id"},
+                    class: "form-control#{allow_isa_tag_change ? '' : ' disabled'}" %>
   </td>
 
   <td>

--- a/app/views/templates/_template_attribute_form.html.erb
+++ b/app/views/templates/_template_attribute_form.html.erb
@@ -115,7 +115,6 @@
   </td>
   <td>
     <div class="btn-group" data-toggle="buttons">
-      <%= hidden_field_tag "#{field_name_prefix}[parent_attribute_id]", parent_attribute_id, data: { attr: "parent_attribute_id" } %>
       <%= hidden_field_tag "#{field_name_prefix}[_destroy]", '0', autocomplete: 'off' %>
       <label class="btn btn-danger">
         Remove
@@ -124,6 +123,8 @@
       </label>
     </div>
   </td>
+
+  <%= hidden_field_tag "#{field_name_prefix}[parent_attribute_id]", parent_attribute_id, data: { attr: "parent_attribute_id" } %>
 
   <% if template_attribute %>
       <%= hidden_field_tag("#{field_name_prefix}[id]", id) %>

--- a/app/views/templates/edit.html.erb
+++ b/app/views/templates/edit.html.erb
@@ -7,8 +7,10 @@
     // Hide Input row
     $j('#attribute-table')
       .find('tr.sample-attribute')
-      .has('input[data-attr="title"][value="Input"]') // Has an input with value "Input"
-      .has('select[data-attr="isa_tag_id"]:not([value])') // Has a select with data-attr "isa_tag_id" but no value
+      .filter(function() {
+        return $j(this).find('input[data-attr="title"]').val() === 'Input' &&
+               !$j(this).find('select[data-attr="isa_tag_id"]').val();
+      })
       .first() // Take the first one in case there are more
       .addClass('hidden'); // Hide the row
   });

--- a/app/views/templates/edit.html.erb
+++ b/app/views/templates/edit.html.erb
@@ -8,7 +8,7 @@
     $j('#attribute-table')
       .find('tr.sample-attribute')
       .has('input[data-attr="title"][value="Input"]') // Has an input with value "Input"
-      .has('select[data-attr="isa_tag_id"]:not([value])') // Has a select with data-attr "isa_tag_title" but no value
+      .has('select[data-attr="isa_tag_id"]:not([value])') // Has a select with data-attr "isa_tag_id" but no value
       .first() // Take the first one in case there are more
       .addClass('hidden'); // Hide the row
   });

--- a/app/views/templates/edit.html.erb
+++ b/app/views/templates/edit.html.erb
@@ -8,7 +8,8 @@
     $j('#attribute-table')
       .find('tr.sample-attribute')
       .has('input[data-attr="title"][value="Input"]') // Has an input with value "Input"
-      .has('select[data-attr="isa_tag_title"]:not([value])') // Has a select with data-attr "isa_tag_title" but no value
+      .has('select[data-attr="isa_tag_id"]:not([value])') // Has a select with data-attr "isa_tag_title" but no value
       .first() // Take the first one in case there are more
       .addClass('hidden'); // Hide the row
+  });
 </script>

--- a/lib/seek/samples/sample_type_editing_constraints.rb
+++ b/lib/seek/samples/sample_type_editing_constraints.rb
@@ -16,6 +16,10 @@ module Seek
         samples.any?
       end
 
+      def allow_title_change?
+        true
+      end
+
       # an attribute can be changed to required, if no samples have that field blank
       # attr can be the attribute accessor name, or the attribute itself
       # if attr is nil, indicates a new attribute. required is not allowed if there are already samples

--- a/lib/seek/samples/sample_type_editing_constraints.rb
+++ b/lib/seek/samples/sample_type_editing_constraints.rb
@@ -16,10 +16,6 @@ module Seek
         samples.any?
       end
 
-      def allow_title_change?
-        true
-      end
-
       # an attribute can be changed to required, if no samples have that field blank
       # attr can be the attribute accessor name, or the attribute itself
       # if attr is nil, indicates a new attribute. required is not allowed if there are already samples

--- a/lib/seek/samples/sample_type_editing_constraints.rb
+++ b/lib/seek/samples/sample_type_editing_constraints.rb
@@ -118,7 +118,11 @@ module Seek
       private
 
       def inherited?(attr)
-        attr&.inherited_from_template_attribute? && is_isa_json_compliant?
+        if @sample_type.new_record?
+          attr&.inherited_from_template_attribute? && @sample_type.isa_template.present?
+        else
+          attr&.inherited_from_template_attribute? && is_isa_json_compliant?
+        end
       end
 
       def blanks?(attr)

--- a/lib/seek/samples/sample_type_editing_constraints.rb
+++ b/lib/seek/samples/sample_type_editing_constraints.rb
@@ -118,11 +118,7 @@ module Seek
       private
 
       def inherited?(attr)
-        if @sample_type.new_record?
-          attr&.inherited_from_template_attribute? && @sample_type.isa_template.present?
-        else
-          attr&.inherited_from_template_attribute? && is_isa_json_compliant?
-        end
+        attr&.inherited_from_template_attribute? && is_isa_json_compliant?
       end
 
       def blanks?(attr)

--- a/lib/seek/samples/sample_type_editing_constraints.rb
+++ b/lib/seek/samples/sample_type_editing_constraints.rb
@@ -103,6 +103,14 @@ module Seek
         end
       end
 
+      def allow_change_at_creation?(attr)
+        if @sample_type.new_record?
+          !(attr.is_a?(SampleAttribute) && inherited?(attr))
+        else
+          true
+        end
+      end
+
       def refresh_cache
         do_analysis
       end

--- a/test/functional/isa_assays_controller_test.rb
+++ b/test/functional/isa_assays_controller_test.rb
@@ -109,6 +109,77 @@ class ISAAssaysControllerTest < ActionController::TestCase
     assert_template :new
   end
 
+  test 'should preserve sample_attribute_type_id on re-render after validation failure with template-based attributes' do
+    projects = User.current_user.person.projects
+    inv = FactoryBot.create(:investigation, projects:, contributor: User.current_user.person)
+    study = FactoryBot.create(:isa_json_compliant_study, investigation_id: inv.id, contributor: User.current_user.person)
+    assay_stream = FactoryBot.create(:assay_stream, contributor: User.current_user.person, study:)
+    template = FactoryBot.create(:isa_assay_material_template)
+
+    policy_attributes = { access_type: Policy::ACCESSIBLE,
+                          permissions_attributes: project_permissions([projects.first], Policy::ACCESSIBLE) }
+
+    string_type = FactoryBot.create(:string_sample_attribute_type)
+    multi_type = FactoryBot.create(:sample_multi_sample_attribute_type)
+    t_attrs = template.template_attributes
+
+    # Simulate what JS applyTemplate produces: template_id on the sample type
+    # and template_attribute_id on each individual attribute
+    sample_type_attrs = {
+      title: 'Template-based Sample Type',
+      project_ids: [projects.first.id],
+      template_id: template.id,
+      sample_attributes_attributes: {
+        '0': { pos: '1', title: 'Extract Name', required: '1', is_title: '1', _destroy: '0',
+               sample_attribute_type_id: string_type.id,
+               isa_tag_id: FactoryBot.create(:other_material_isa_tag).id,
+               template_attribute_id: t_attrs.find { |a| a.title == 'Extract Name' }.id },
+        '1': { pos: '2', title: 'Protocol Assay 1', required: '1', is_title: '0', _destroy: '0',
+               sample_attribute_type_id: string_type.id,
+               isa_tag_id: FactoryBot.create(:protocol_isa_tag).id,
+               template_attribute_id: t_attrs.find { |a| a.title == 'Protocol Assay 1' }.id },
+        '2': { pos: '3', title: 'Input', required: '1', _destroy: '0',
+               sample_attribute_type_id: multi_type.id,
+               linked_sample_type_id: study.sample_types.second.id,
+               isa_tag_id: FactoryBot.create(:input_isa_tag).id,
+               template_attribute_id: t_attrs.find { |a| a.title == 'Input' }.id }
+      }
+    }
+
+    # POST without assay title to trigger validation failure
+    post :create, params: { isa_assay: { assay: { study_id: study.id,
+                                                  assay_class_id: AssayClass.experimental.id,
+                                                  assay_stream_id: assay_stream.id,
+                                                  position: 0,
+                                                  policy_attributes: },
+                                         input_sample_type_id: study.sample_types.second.id,
+                                         sample_type: sample_type_attrs } }
+
+    assert_response :unprocessable_entity
+    assert_template :new
+
+    isa_assay = assigns(:isa_assay)
+
+    # Errors should be about the missing title
+    assert_equal ["[Assay]: Title can't be blank"], isa_assay.errors.full_messages
+
+    # A new Sample Type only needs the `isa_template_id`to be ISA-JSON compliant.
+    assert isa_assay.sample_type.is_isa_json_compliant?
+
+    # All submitted sample_attribute_type_ids must survive the round-trip through
+    # the controller so the re-rendered form can show the correct selected values
+    isa_assay.sample_type.sample_attributes.each do |attr|
+      assert attr.sample_attribute_type_id.present?,
+             "#{attr.title}: sample_attribute_type_id should be preserved after validation failure"
+    end
+    assert_equal string_type.id, isa_assay.sample_type.sample_attributes.find { |a| a.title == 'Protocol Assay 1' }.sample_attribute_type_id
+    assert_equal multi_type.id, isa_assay.sample_type.sample_attributes.find { |a| a.title == 'Input' }.sample_attribute_type_id
+
+    # The re-rendered form must not carry the HTML disabled attribute on type
+    # selects — disabled fields are silently dropped on the next form submission
+    assert_select 'select[name*="sample_attribute_type_id"][disabled]', count: 0
+  end
+
   test 'should update isa assay' do
     person = User.current_user.person
     project = person.projects.first

--- a/test/functional/isa_assays_controller_test.rb
+++ b/test/functional/isa_assays_controller_test.rb
@@ -97,10 +97,6 @@ class ISAAssaysControllerTest < ActionController::TestCase
     inv = FactoryBot.create(:investigation, projects:, contributor: User.current_user.person)
     study = FactoryBot.create(:isa_json_compliant_study, investigation_id: inv.id, contributor: User.current_user.person)
 
-    # source_sample_type = study.sample_types.first
-    #
-    # sample_collection_sample_type = study.sample_types.second
-    #
     post :create, params: { isa_assay: {
       assay: { title: 'test', study_id: study.id,
                sop_ids: [FactoryBot.create(:sop, policy: FactoryBot.create(:public_policy)).id] },

--- a/test/functional/isa_studies_controller_test.rb
+++ b/test/functional/isa_studies_controller_test.rb
@@ -195,6 +195,61 @@ class ISAStudiesControllerTest < ActionController::TestCase
     assert_equal isa_study.sample_collection.title, "#{isa_study.study.title} - Sample Collection Sample Type"
   end
 
+  test 'should preserve sample_attribute_type_id on re-render after validation failure with template-based attributes' do
+    projects = User.current_user.person.projects
+    inv = FactoryBot.create(:investigation, projects:, contributor: User.current_user.person)
+    source_template = FactoryBot.create(:isa_source_template)
+
+    string_type = FactoryBot.create(:string_sample_attribute_type)
+    t_attrs = source_template.template_attributes
+
+    # Simulate what JS applyTemplate produces: template_id on the sample type
+    # and template_attribute_id on each individual attribute
+    source_attrs = {
+      title: 'Template-based Source',
+      project_ids: projects.map(&:id),
+      template_id: source_template.id,
+      sample_attributes_attributes: {
+        '0': { pos: '1', title: 'Source Name', required: '1', is_title: '1', _destroy: '0',
+               sample_attribute_type_id: string_type.id,
+               isa_tag_id: FactoryBot.create(:source_isa_tag).id,
+               template_attribute_id: t_attrs.find { |a| a.title == 'Source Name' }.id },
+        '1': { pos: '2', title: 'Source Characteristic 1', required: '1', is_title: '0', _destroy: '0',
+               sample_attribute_type_id: string_type.id,
+               isa_tag_id: FactoryBot.create(:source_characteristic_isa_tag).id,
+               template_attribute_id: t_attrs.find { |a| a.title == 'Source Characteristic 1' }.id }
+      }
+    }
+
+    # POST without study title to trigger validation failure
+    post :create, params: { isa_study: { study: { investigation_id: inv.id },
+                                         source_sample_type: source_attrs,
+                                         sample_collection_sample_type: sample_collection_attributes(projects) } }
+
+    assert_response :unprocessable_entity
+    assert_template :new
+
+    isa_study = assigns(:isa_study)
+
+    # Errors should be about the missing title
+    assert_equal ["[Study]: Title can't be blank"], isa_study.errors.full_messages
+
+    # A new Sample Type only needs the `isa_template_id` to be ISA-JSON compliant.
+    assert isa_study.source.is_isa_json_compliant?
+
+    # All submitted sample_attribute_type_ids must survive the round-trip through
+    # the controller so the re-rendered form can show the correct selected values
+    isa_study.source.sample_attributes.each do |attr|
+      assert attr.sample_attribute_type_id.present?,
+             "#{attr.title}: sample_attribute_type_id should be preserved after validation failure"
+    end
+    assert_equal string_type.id, isa_study.source.sample_attributes.find { |a| a.title == 'Source Name' }.sample_attribute_type_id
+
+    # The re-rendered form must not carry the HTML disabled attribute on type
+    # selects — disabled fields are silently dropped on the next form submission
+    assert_select 'select[name*="sample_attribute_type_id"][disabled]', count: 0
+  end
+
   private
 
   def sample_collection_attributes(projects=[])

--- a/test/functional/templates_controller_test.rb
+++ b/test/functional/templates_controller_test.rb
@@ -297,7 +297,7 @@ class TemplatesControllerTest < ActionController::TestCase
     assert_response :success
 
     inherited_template.template_attributes.each_with_index do |_ta, i|
-      id = "select#template_template_attributes_attributes_#{i}_isa_tag_title[disabled='disabled']"
+      id = "select#template_template_attributes_attributes_#{i}_isa_tag_id[disabled='disabled']"
       assert_select id
     end
 
@@ -314,10 +314,10 @@ class TemplatesControllerTest < ActionController::TestCase
     get :edit, params: { id: inherited_template.id }
     assert_response :success
 
-    assert_select "select#template_template_attributes_attributes_0_isa_tag_title[disabled='disabled']"
+    assert_select "select#template_template_attributes_attributes_0_isa_tag_id[disabled='disabled']"
     cnt_last_attribute = inherited_template.template_attributes.count - 1
 
-    assert_select "select#template_template_attributes_attributes_#{cnt_last_attribute}_isa_tag_title[disabled='disabled']", text: 'source_characteristic', count: 0
+    assert_select "select#template_template_attributes_attributes_#{cnt_last_attribute}_isa_tag_id[disabled='disabled']", text: 'source_characteristic', count: 0
 
   end
 

--- a/test/functional/templates_controller_test.rb
+++ b/test/functional/templates_controller_test.rb
@@ -297,8 +297,7 @@ class TemplatesControllerTest < ActionController::TestCase
     assert_response :success
 
     inherited_template.template_attributes.each_with_index do |_ta, i|
-      id = "select#template_template_attributes_attributes_#{i}_isa_tag_id[class='form-control disabled']"
-      assert_select id
+      assert_select "select#template_template_attributes_attributes_#{i}_isa_tag_id.disabled"
     end
 
     inherited_template.template_attributes << FactoryBot.create(:template_attribute, title: 'Extra attribute', isa_tag: FactoryBot.create(:source_characteristic_isa_tag), sample_attribute_type: FactoryBot.create(:string_sample_attribute_type), pos: 4)
@@ -314,10 +313,10 @@ class TemplatesControllerTest < ActionController::TestCase
     get :edit, params: { id: inherited_template.id }
     assert_response :success
 
-    assert_select "select#template_template_attributes_attributes_0_isa_tag_id[class='form-control disabled']"
+    assert_select "select#template_template_attributes_attributes_0_isa_tag_id.disabled"
     cnt_last_attribute = inherited_template.template_attributes.count - 1
 
-    assert_select "select#template_template_attributes_attributes_#{cnt_last_attribute}_isa_tag_id[class='form-control disabled']", text: 'source_characteristic', count: 0
+    assert_select "select#template_template_attributes_attributes_#{cnt_last_attribute}_isa_tag_id.disabled", text: 'source_characteristic', count: 0
 
   end
 

--- a/test/functional/templates_controller_test.rb
+++ b/test/functional/templates_controller_test.rb
@@ -297,7 +297,7 @@ class TemplatesControllerTest < ActionController::TestCase
     assert_response :success
 
     inherited_template.template_attributes.each_with_index do |_ta, i|
-      id = "select#template_template_attributes_attributes_#{i}_isa_tag_id[disabled='disabled']"
+      id = "select#template_template_attributes_attributes_#{i}_isa_tag_id[class='form-control disabled']"
       assert_select id
     end
 
@@ -314,10 +314,10 @@ class TemplatesControllerTest < ActionController::TestCase
     get :edit, params: { id: inherited_template.id }
     assert_response :success
 
-    assert_select "select#template_template_attributes_attributes_0_isa_tag_id[disabled='disabled']"
+    assert_select "select#template_template_attributes_attributes_0_isa_tag_id[class='form-control disabled']"
     cnt_last_attribute = inherited_template.template_attributes.count - 1
 
-    assert_select "select#template_template_attributes_attributes_#{cnt_last_attribute}_isa_tag_id[disabled='disabled']", text: 'source_characteristic', count: 0
+    assert_select "select#template_template_attributes_attributes_#{cnt_last_attribute}_isa_tag_id[class='form-control disabled']", text: 'source_characteristic', count: 0
 
   end
 

--- a/test/unit/sample_type_test.rb
+++ b/test/unit/sample_type_test.rb
@@ -1001,34 +1001,45 @@ class SampleTypeTest < ActiveSupport::TestCase
     assert sample_type.errors.added?(:'sample_attributes.unit', 'cannot be changed (weight)')
   end
 
-  test 'determin whether sample types are considered ISA-JSON compliant' do
-
+  test 'is_isa_json_compliant? on a existing (saved) sample type' do
     source_sample_type = FactoryBot.create(:isa_source_sample_type)
-    sample_collection_sample_type= FactoryBot.create(:isa_sample_collection_sample_type, linked_sample_type: source_sample_type)
+    sample_collection_sample_type = FactoryBot.create(:isa_sample_collection_sample_type, linked_sample_type: source_sample_type)
     assay_sample_type = FactoryBot.create(:isa_assay_material_sample_type, linked_sample_type: sample_collection_sample_type)
+
+    # No assay/study yet
+    refute assay_sample_type.is_isa_json_compliant?
+    [source_sample_type, sample_collection_sample_type].each { |st| refute st.is_isa_json_compliant? }
+
+    # Assay added, but investigation is NOT ISA-JSON compliant
+    # (the old code had a vacuous-truth bug that made this pass; the new code correctly returns false)
+    assay = FactoryBot.create(:assay, sample_type: assay_sample_type)
+    assay_sample_type.reload
+    refute assay.study.investigation.is_isa_json_compliant
     refute assay_sample_type.is_isa_json_compliant?
 
-    FactoryBot.create(:assay, sample_type: assay_sample_type)
+    # Make the investigation ISA-JSON compliant → assay sample type becomes compliant
+    assay.study.investigation.update_column(:is_isa_json_compliant, true)
+    assay_sample_type.reload
     assert assay_sample_type.is_isa_json_compliant?
 
-    [source_sample_type, sample_collection_sample_type].each do |st|
-      refute st.is_isa_json_compliant?
-    end
-
+    # ISA Study sample types: study exists but investigation is not yet ISA-JSON compliant
     study = FactoryBot.create(:study, sample_types: [source_sample_type, sample_collection_sample_type])
+    [source_sample_type, sample_collection_sample_type].each { |st| st.reload; refute st.is_isa_json_compliant? }
 
-    [source_sample_type, sample_collection_sample_type].each do |st|
-      refute st.is_isa_json_compliant?
-    end
-
+    # Once the investigation is flagged as ISA-JSON compliant, the study sample types comply too
     FactoryBot.create(:investigation, is_isa_json_compliant: true, studies: [study])
+    [source_sample_type, sample_collection_sample_type].each { |st| st.reload; assert st.is_isa_json_compliant? }
+  end
 
-    [source_sample_type, sample_collection_sample_type].each do |st|
-      st.reload
-      assert st.is_isa_json_compliant?
-    end
+  test 'is_isa_json_compliant? on a new (unsaved) sample type' do
+    # New record without a template is not ISA-JSON compliant
+    refute SampleType.new.is_isa_json_compliant?
 
-
+    # New record with a template is considered ISA-JSON compliant at creation time,
+    # because the assay/study links don't exist yet
+    template = FactoryBot.create(:isa_source_template)
+    new_type = SampleType.new(template_id: template.id)
+    assert new_type.is_isa_json_compliant?
   end
 
   test 'previous linked sample type' do

--- a/test/unit/samples/sample_type_editing_constraints_test.rb
+++ b/test/unit/samples/sample_type_editing_constraints_test.rb
@@ -219,9 +219,8 @@ class SampleTypeEditingConstraintsTest < ActiveSupport::TestCase
            'New sample type with template_id set should be ISA JSON compliant'
 
     # Inherited attributes should return false
-    new_type_with_template.sample_attributes.none? do |attribute|
-      c_template.allow_change_at_creation?(attribute)
-    end
+    assert new_type_with_template.sample_attributes.none? { |attribute| c_template.allow_change_at_creation?(attribute) },
+           'Inherited attributes should not be changeable at creation time'
 
     # nil or non-inherited attr is still allowed even on a template-linked sample type
     assert c_template.allow_change_at_creation?(nil)

--- a/test/unit/samples/sample_type_editing_constraints_test.rb
+++ b/test/unit/samples/sample_type_editing_constraints_test.rb
@@ -213,10 +213,15 @@ class SampleTypeEditingConstraintsTest < ActiveSupport::TestCase
     # new record, template_id set -> sample type is ISA JSON compliant
     # attribute with template_attribute_id -> NOT allowed (inherited from template)
     new_type_with_template = SampleType.new(template_id: template.id)
+    new_type_with_template.create_sample_attributes_from_isa_template(template)
     c_template = Seek::Samples::SampleTypeEditingConstraints.new(new_type_with_template)
     assert new_type_with_template.is_isa_json_compliant?,
            'New sample type with template_id set should be ISA JSON compliant'
-    assert new_type_with_template, 'New sample type with template_id is considered inherited'
+
+    # Inherited attributes should return false
+    new_type_with_template.sample_attributes.none? do |attribute|
+      c_template.allow_change_at_creation?(attribute)
+    end
 
     # nil or non-inherited attr is still allowed even on a template-linked sample type
     assert c_template.allow_change_at_creation?(nil)

--- a/test/unit/samples/sample_type_editing_constraints_test.rb
+++ b/test/unit/samples/sample_type_editing_constraints_test.rb
@@ -79,8 +79,12 @@ class SampleTypeEditingConstraintsTest < ActiveSupport::TestCase
     assert c.allow_required?(attr)
 
     # should refute if inherited from a template
+    person = c.sample_type.contributor
+    project = c.sample_type.projects.first
     template = FactoryBot.create(:isa_source_template)
-    sample_type_from_template = create_sample_type_from_template(template, c.sample_type.projects.first, c.sample_type.contributor)
+    inv = FactoryBot.create(:investigation, projects: [project], contributor: person, is_isa_json_compliant: true)
+    study = FactoryBot.create(:study, contributor: person, investigation: inv)
+    sample_type_from_template = create_sample_type_from_template(template, project, person, [study])
     sample_type_from_template.sample_attributes << FactoryBot.create(:sample_attribute, title: 'Extra Source Characteristic', sample_attribute_type: FactoryBot.create(:string_sample_attribute_type), required: false, isa_tag_id: FactoryBot.create(:source_characteristic_isa_tag).id, sample_type: sample_type_from_template)
 
     c_inherited = Seek::Samples::SampleTypeEditingConstraints.new(sample_type_from_template)
@@ -145,22 +149,24 @@ class SampleTypeEditingConstraintsTest < ActiveSupport::TestCase
   test 'allow editing isa tag' do
     person = FactoryBot.create(:person)
     project = person.projects.first
-    template = FactoryBot.create(:isa_source_template)
-    sample_type_from_template = create_sample_type_from_template(template, project, person)
+    template = FactoryBot.create(:isa_source_template, contributor: person, projects: [project])
+    inv = FactoryBot.create(:investigation, projects: [project], contributor: person, is_isa_json_compliant: true)
+    study = FactoryBot.create(:study, contributor: person, investigation: inv)
+    study_sample_type_from_template = create_sample_type_from_template(template, project, person, [study])
     sample_type = FactoryBot.create(:isa_source_sample_type, projects: [project], contributor: person)
 
     c = Seek::Samples::SampleTypeEditingConstraints.new(sample_type)
-    c_inherited = Seek::Samples::SampleTypeEditingConstraints.new(sample_type_from_template)
-    sample_type.sample_attributes.map { |attribute| refute c.send(:inherited?, attribute) }
-    sample_type_from_template.sample_attributes.map { |attribute| assert c_inherited.send(:inherited?, attribute) }
-    sample_type_from_template.sample_attributes.map { |attribute| refute c_inherited.allow_isa_tag_change?(attribute) }
-    sample_type.sample_attributes.map { |attribute| assert c.allow_isa_tag_change?(attribute) }
+    c_inherited = Seek::Samples::SampleTypeEditingConstraints.new(study_sample_type_from_template)
+    assert sample_type.sample_attributes.none? { |attribute| c.send(:inherited?, attribute) }
+    assert study_sample_type_from_template.sample_attributes.all? { |attribute| c_inherited.send(:inherited?, attribute) }
+    assert study_sample_type_from_template.sample_attributes.none? { |attribute| c_inherited.allow_isa_tag_change?(attribute) }
+    assert sample_type.sample_attributes.all? { |attribute| c.allow_isa_tag_change?(attribute) }
 
     # Adding an extra attribute to the sample_type
-    sample_type_from_template.sample_attributes << FactoryBot.create(:sample_attribute, title: 'Extra Source Characteristic', sample_attribute_type: FactoryBot.create(:string_sample_attribute_type), required: false, isa_tag_id: FactoryBot.create(:source_characteristic_isa_tag).id, sample_type: sample_type_from_template)
-    sample_type_from_template.reload
-    c_inherited = Seek::Samples::SampleTypeEditingConstraints.new(sample_type_from_template)
-    extra_source_characteristic = sample_type_from_template.sample_attributes.detect { |sa| sa.title == 'Extra Source Characteristic' }
+    study_sample_type_from_template.sample_attributes << FactoryBot.create(:sample_attribute, title: 'Extra Source Characteristic', sample_attribute_type: FactoryBot.create(:string_sample_attribute_type), required: false, isa_tag_id: FactoryBot.create(:source_characteristic_isa_tag).id, sample_type: study_sample_type_from_template)
+    study_sample_type_from_template.reload
+    c_inherited = Seek::Samples::SampleTypeEditingConstraints.new(study_sample_type_from_template)
+    extra_source_characteristic = study_sample_type_from_template.sample_attributes.detect { |sa| sa.title == 'Extra Source Characteristic' }
     refute extra_source_characteristic.nil?
     ## Extra source characteristic should be all blank, since there are no samples
     assert c_inherited.send(:all_blank?, extra_source_characteristic.accessor_name)
@@ -170,27 +176,61 @@ class SampleTypeEditingConstraintsTest < ActiveSupport::TestCase
     assert c_inherited.allow_isa_tag_change?(extra_source_characteristic)
 
     # Add sample to the sample type but leave the extra characteristic empty
-    isa_source_no_extra_char = FactoryBot.create(:isa_source, sample_type: sample_type_from_template, contributor: person)
-    sample_type_from_template.samples << isa_source_no_extra_char
-    sample_type_from_template.save
+    isa_source_no_extra_char = FactoryBot.create(:isa_source, sample_type: study_sample_type_from_template, contributor: person)
+    study_sample_type_from_template.samples << isa_source_no_extra_char
+    study_sample_type_from_template.save
     ## Extra source characteristic should be all blank
     assert c_inherited.send(:all_blank?, extra_source_characteristic.accessor_name)
     ## The first attribute has a sample which is filled in => Not allowed to change ISA tag
-    refute c_inherited.allow_isa_tag_change?(sample_type_from_template.sample_attributes.first)
+    refute c_inherited.allow_isa_tag_change?(study_sample_type_from_template.sample_attributes.first)
     ## Extra source characteristic is completely empty => Allowed to change ISA tag
     assert c_inherited.allow_isa_tag_change?(extra_source_characteristic)
 
     # Add sample to the sample type with an extra characteristic value
-    isa_source_with_extra_char = FactoryBot.create(:isa_source, sample_type: sample_type_from_template, contributor: person)
+    isa_source_with_extra_char = FactoryBot.create(:isa_source, sample_type: study_sample_type_from_template, contributor: person)
     isa_source_with_extra_char.set_attribute_value('Extra Source Characteristic', 'Blue')
     isa_source_with_extra_char.save
-    sample_type_from_template.samples << isa_source_with_extra_char
-    sample_type_from_template.save
-    c_inherited = Seek::Samples::SampleTypeEditingConstraints.new(sample_type_from_template)
+    study_sample_type_from_template.samples << isa_source_with_extra_char
+    study_sample_type_from_template.save
+    c_inherited = Seek::Samples::SampleTypeEditingConstraints.new(study_sample_type_from_template)
     ## Extra source characteristic isn't all blank anymore
     refute c_inherited.send(:all_blank?, extra_source_characteristic.accessor_name)
     ## Extra source characteristic is not empty => Not allowed to change ISA tag
     refute c_inherited.allow_isa_tag_change?(extra_source_characteristic)
+  end
+
+  test 'allow_change_at_creation?' do
+    template = FactoryBot.create(:isa_source_template)
+
+    # nil attr is always allowed (represents a brand-new attribute row)
+    c = Seek::Samples::SampleTypeEditingConstraints.new(SampleType.new)
+    assert c.allow_change_at_creation?(nil)
+
+    # new record, attribute without template_attribute_id -> allowed
+    non_inherited_attr = SampleAttribute.new(title: 'Custom')
+    assert c.allow_change_at_creation?(non_inherited_attr)
+
+    # new record, template_id set -> sample type is ISA JSON compliant
+    # attribute with template_attribute_id -> NOT allowed (inherited from template)
+    new_type_with_template = SampleType.new(template_id: template.id)
+    c_template = Seek::Samples::SampleTypeEditingConstraints.new(new_type_with_template)
+    assert new_type_with_template.is_isa_json_compliant?,
+           'New sample type with template_id set should be ISA JSON compliant'
+    assert new_type_with_template, 'New sample type with template_id is considered inherited'
+
+    # nil or non-inherited attr is still allowed even on a template-linked sample type
+    assert c_template.allow_change_at_creation?(nil)
+    assert c_template.allow_change_at_creation?(SampleAttribute.new(title: 'Custom'))
+
+    # existing (saved) record -> always returns true regardless of inheritance
+    person = FactoryBot.create(:person)
+    saved_type = create_sample_type_from_template(template, person.projects.first, person)
+    refute saved_type.new_record?
+    c_saved = Seek::Samples::SampleTypeEditingConstraints.new(saved_type)
+    saved_type.sample_attributes.each do |attr|
+      assert c_saved.allow_change_at_creation?(attr),
+             "#{attr.title}: allow_change_at_creation? should return true for an existing record"
+    end
   end
 
   test 'allow editing unit' do
@@ -271,7 +311,7 @@ class SampleTypeEditingConstraintsTest < ActiveSupport::TestCase
     sample_type
   end
 
-  def create_sample_type_from_template(template, project, person)
+  def create_sample_type_from_template(template, project, person, studies=[], assays=[])
     sample_attributes = template.template_attributes.map do |temp_attr|
       SampleAttribute.new(
         title: temp_attr.title,
@@ -292,7 +332,8 @@ class SampleTypeEditingConstraintsTest < ActiveSupport::TestCase
                       projects:[project],
                       contributor: person,
                       template_id: template.id,
-                      assays: [FactoryBot.build(:assay, contributor: person)],
+                      studies: studies,
+                      assays: assays,
                       sample_attributes: )
   end
 end


### PR DESCRIPTION
Fixes the discrepancy between new and new after error views when creating templates / sample types.
Closes #2566 
depends on #2648 