### PR TITLE
Scraper fixes

### DIFF
--- a/app/models/git/repository.rb
+++ b/app/models/git/repository.rb
@@ -27,7 +27,8 @@ module Git
     end
 
     def fetch
-      git_base.remotes['origin'].fetch
+      remote = git_base.remotes['origin']
+      remote.fetch(remote.fetch_refspecs + ['+refs/tags/*:refs/tags/*'])
       touch(:last_fetch)
     end
 

--- a/app/models/git/repository.rb
+++ b/app/models/git/repository.rb
@@ -32,6 +32,12 @@ module Git
       touch(:last_fetch)
     end
 
+    def close
+      git_base.close
+      @git_base = nil
+      self
+    end
+
     def remote_refs
       @remote_refs ||= if remote.present?
                          refs = { branches: [], tags: [] }

--- a/lib/scrapers/github_scraper.rb
+++ b/lib/scrapers/github_scraper.rb
@@ -119,6 +119,9 @@ module Scrapers
       end
 
       workflow
+    rescue ROCrate::ReadException => e
+      output.puts "    RO-Crate read error: #{e.message}"
+      nil
     end
 
     def main_branch(repo)

--- a/lib/scrapers/github_scraper.rb
+++ b/lib/scrapers/github_scraper.rb
@@ -79,7 +79,9 @@ module Scrapers
             next
           end
         end
-        tags.map { |tag| create_resource(repo, tag) }
+        resources = tags.map { |tag| create_resource(repo, tag) }
+        repo.git_base.close
+        resources
       end.flatten.compact
     end
 
@@ -143,7 +145,10 @@ module Scrapers
     def clone_repositories(repo_list)
       repos = repo_list.map { |repo| Git::Repository.find_or_create_by(remote: repo['clone_url']) }
 
-      repos.each(&:fetch)
+      repos.each do |r|
+        r.fetch
+        r.git_base.close # Close open files
+      end
 
       repos
     end

--- a/lib/scrapers/github_scraper.rb
+++ b/lib/scrapers/github_scraper.rb
@@ -64,24 +64,28 @@ module Scrapers
 
     def create_resources(repositories)
       repositories.map do |repo|
-        output.puts "  Considering #{repo.remote.chomp('.git')}..."
-        if @only_latest
-          tag = latest_tag(repo)
-          if tag.nil?
-            output.puts "    Error while getting latest tag - wrong branch name?"
-            next
+        begin
+          output.puts "  Considering #{repo.remote.chomp('.git')}..."
+          if @only_latest
+            tag = latest_tag(repo)
+            if tag.nil?
+              output.puts "    Error while getting latest tag - wrong branch name?"
+              next
+            end
+            tags = [tag]
+          else
+            tags = all_tags(repo)
+            if tags.empty?
+              output.puts "    No tags found to register"
+              next
+            end
           end
-          tags = [tag]
-        else
-          tags = all_tags(repo)
-          if tags.empty?
-            output.puts "    No tags found to register"
-            next
-          end
+          resources = tags.map { |tag| create_resource(repo, tag) }
+
+          resources
+        ensure
+          repo.close
         end
-        resources = tags.map { |tag| create_resource(repo, tag) }
-        repo.git_base.close
-        resources
       end.flatten.compact
     end
 
@@ -149,8 +153,11 @@ module Scrapers
       repos = repo_list.map { |repo| Git::Repository.find_or_create_by(remote: repo['clone_url']) }
 
       repos.each do |r|
-        r.fetch
-        r.git_base.close # Close open files
+        begin
+          r.fetch
+        ensure
+          r.close # Close open files
+        end
       end
 
       repos

--- a/test/integration/github_scraper_test.rb
+++ b/test/integration/github_scraper_test.rb
@@ -139,6 +139,59 @@ class GithubScraperTest < ActionDispatch::IntegrationTest
                         3.11.0 3.11.1 3.11.2 3.12.0 3.13.0 3.13.1 3.13.2 3.14.0], scraper.send(:all_tags, repo)
   end
 
+  test 'handles and logs RO-Crate read exception when scraping' do
+    project = Scrapers::Util.bot_project(title: 'test')
+    bot = Scrapers::Util.bot_account
+    project_admin = FactoryBot.create(:project_administrator)
+    disable_authorization_checks do
+      project.default_policy = FactoryBot.create(:private_policy)
+      project.default_policy.permissions << Permission.new(contributor: project, access_type: Policy::EDITING)
+      project.default_policy.permissions << Permission.new(contributor: project_admin, access_type: Policy::MANAGING)
+      project.default_policy.save!
+      project.use_default_policy = true
+      project.save!
+    end
+    output = StringIO.new
+    scraper = Scrapers::GithubScraper.new(project, bot, organization: 'test-123', main_branch: 'master', output: output)
+
+    repos = [
+      FactoryBot.create(:remote_workflow_ro_crate_repository, remote: 'https://github.com/crs4/sort-and-change-case-workflow.git'),
+      FactoryBot.create(:remote_workflow_ro_crate_repository, remote: 'https://github.com/crs4/sort-and-change-case-workflow2.git')
+    ]
+
+    failed = false
+    scraper.stub(:topics, -> (*) { [] }) do
+      scraper.stub(:list_repositories, -> () { repos.map { |r| { 'clone_url' => r.remote } } }) do
+        scraper.stub(:clone_repositories, -> (_) { repos }) do
+          # Stub this method as a hacky way to trigger an ROCrate::ReadException, but only on the first repository.
+          scraper.stub(:existing_resource, -> (*_) {
+            unless failed
+              failed = true
+              raise ROCrate::ReadException, 'uh oh'
+            end
+            nil
+          }) do
+            assert_difference('Workflow.count', 1) do
+              assert_difference('Workflow::Git::Version.count', 1) do
+                assert_difference('Git::Annotation.count', 1) do
+                  assert_no_difference('Git::Repository.count') do
+                    scraped = scraper.scrape
+                    wf = scraped.first
+                    assert_equal 'sort-and-change-case', wf.title
+
+                    output.rewind
+                    log = output.read
+                    assert_includes log, 'RO-Crate read error: uh oh'
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
   private
 
   def login_as(user)


### PR DESCRIPTION
- Closes repositories after cloning/creating resources to avoid an excess number of files being left open and hitting the OS limit.
- Ensures all tags are fetched, even if they point to orphaned commits.
- Catch and log RO-Crate read exceptions without the entire scrape failing.

Fixes #2619 