### PR TITLE
Fix search adaptor showing as enabled when disabled on features enabled page

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -5,7 +5,7 @@ module AdminHelper
 
     safe_join(adaptors.collect do |adaptor|
       key = adaptor.key
-      enabled = current.dig(key, 'enabled') || true
+      enabled = (current[key] || {}).with_indifferent_access.fetch('enabled', true)
       description = "Whether the #{adaptor.name} external search is active"
       admin_checkbox_setting("external_search_adaptors[#{key}][enabled]", 1, enabled, adaptor.name, description)
     end)

--- a/test/functional/admin_controller_test.rb
+++ b/test/functional/admin_controller_test.rb
@@ -796,5 +796,22 @@ class AdminControllerTest < ActionController::TestCase
     end
   end
 
+  test 'features enabled page shows disabled search adaptors as unchecked' do
+    adaptors = Seek::ExternalSearch.instance.search_adaptors('all', include_disabled: true)
+    fail 'No adaptors configured' if adaptors.empty?
+
+    setting = adaptors.each_with_object({}) { |a, h| h[a.key] = { 'enabled' => false } }
+    with_config_value(:external_search_adaptors, setting) do
+      get :features_enabled
+      assert_response :success
+
+      assert_select 'div#external-search-details' do
+        adaptors.each do |adaptor|
+          assert_select "input[type='checkbox'][name='external_search_adaptors[#{adaptor.key}][enabled]'][checked]", count: 0
+        end
+      end
+    end
+  end
+
 
 end


### PR DESCRIPTION
## Summary

- Fixes a bug where disabled search adaptors (BioModels, TeSS) always appeared checked on the Features Enabled settings page
- `false || true` always evaluates to `true`, so the `enabled` flag was always truthy regardless of the stored value
- Changed to use `fetch` with a default of `true` (enabled by default when no setting is stored), consistent with the pattern in `AbstractSearchAdaptor`
- Added a regression test to assert disabled adaptors render as unchecked

Fixes #2628