### PR TITLE
Handle JSON parse errors in SlideShare renderer

### DIFF
--- a/lib/seek/renderers/slideshare_renderer.rb
+++ b/lib/seek/renderers/slideshare_renderer.rb
@@ -13,6 +13,8 @@ module Seek
         api_url = "http://www.slideshare.net/api/oembed/2?url=#{blob.url}&format=json"
         json = JSON.parse(RestClient.get(api_url))
         json['html']
+      rescue RestClient::Exception, JSON::ParserError
+        nil
       end
 
       # if it is a slideshare url, which starts with www.slideshare.net, and is made up of 2 parts (params ignored)


### PR DESCRIPTION
Fixes #2629

Depending on the server's IP address, the SlideShare oEmbed API may respond with a Cloudflare client challenge HTML page instead of JSON. This causes a `JSON::ParserError` which results in an error notification email.

The fix rescues both `RestClient::Exception` and `JSON::ParserError` in `render_content`, returning `nil` so the presentation page degrades silently without raising an exception.