### PR TITLE
Remove scrub_env! monkey-patch and refactor affected controller tests

### DIFF
--- a/test/factories/content_blobs.rb
+++ b/test/factories/content_blobs.rb
@@ -210,6 +210,18 @@ FactoryBot.define do
     original_filename { 'binary.bin' }
     data { File.new("#{Rails.root}/test/fixtures/files/little_file.txt", 'rb').read }
   end
+
+  factory(:little_file_content_blob, parent: :content_blob) do
+    content_type { 'text/plain' }
+    original_filename { 'little_file.txt' }
+    data { File.open("#{Rails.root}/test/fixtures/files/little_file.txt", 'rb') { |f| f.read } }
+  end
+
+  factory(:little_file_v2_content_blob, parent: :content_blob) do
+    content_type { 'text/plain' }
+    original_filename { 'little_file_v2.txt' }
+    data { File.open("#{Rails.root}/test/fixtures/files/little_file_v2.txt", 'rb') { |f| f.read } }
+  end
   
   factory(:study_template_content_blob, parent: :content_blob) do
     original_filename { 'study_batch.zip' }

--- a/test/functional/copasi_test.rb
+++ b/test/functional/copasi_test.rb
@@ -154,8 +154,6 @@ class CopasiTest < ActionController::TestCase
     with_config_value(:copasi_enabled, true) do
       model = FactoryBot.create(:copasi_model, policy: FactoryBot.create(:public_policy))
 
-      # create the additional versions directly, rather than via multipart uploads, so this test only
-      # exercises the #copasi_simulate action
       FactoryBot.create(:model_version_with_blob, model: model,
                         content_blobs: [FactoryBot.create(:teusink_model_content_blob)])
       little_blob = FactoryBot.create(:little_file_content_blob)

--- a/test/functional/copasi_test.rb
+++ b/test/functional/copasi_test.rb
@@ -154,34 +154,26 @@ class CopasiTest < ActionController::TestCase
     with_config_value(:copasi_enabled, true) do
       model = FactoryBot.create(:copasi_model, policy: FactoryBot.create(:public_policy))
 
+      # create the additional versions directly, rather than via multipart uploads, so this test only
+      # exercises the #copasi_simulate action
+      FactoryBot.create(:model_version_with_blob, model: model,
+                        content_blobs: [FactoryBot.create(:teusink_model_content_blob)])
+      little_blob = FactoryBot.create(:content_blob, original_filename: 'little_file.txt', content_type: 'text/plain',
+                                      data: File.new("#{Rails.root}/test/fixtures/files/little_file.txt", 'rb').read)
+      FactoryBot.create(:model_version_with_blob, model: model, content_blobs: [little_blob])
+
       get :copasi_simulate, params: { id: model.id, version: 1 }
       assert_response :success
       assert_select 'div.version', text:/Version 1/
-
-
-      assert_difference('Model::Version.count', 1) do
-        post :create_version, params: { id: model, model: { title: model.title },
-                                        content_blobs:[{ data: fixture_file_upload('Teusink.xml') }],
-                                        revision_comments: 'This is a new revision'}
-
-        assert_redirected_to model_path(assigns(:model))
-      end
 
       get :copasi_simulate, params: { id: model.id, version: 2 }
       assert_response :success
       assert_select 'div.version', text:/Version 2/
 
-      assert_difference('Model::Version.count', 1) do
-        post :create_version, params: { id: model, model: { title: model.title },
-                                        content_blobs:[{ data: fixture_file_upload('little_file.txt') }],
-                                        revision_comments: 'This is a new revision'}
-
-        get :copasi_simulate, params: { id: model.id, version: 3 }
-        assert_response :success
-        assert_select 'div.version', text:/Version 3/
-        assert_select 'div#error_flash', text:/The selected version does not contain a format supported by COPASI./
-
-      end
+      get :copasi_simulate, params: { id: model.id, version: 3 }
+      assert_response :success
+      assert_select 'div.version', text:/Version 3/
+      assert_select 'div#error_flash', text:/The selected version does not contain a format supported by COPASI./
     end
   end
 

--- a/test/functional/copasi_test.rb
+++ b/test/functional/copasi_test.rb
@@ -158,8 +158,7 @@ class CopasiTest < ActionController::TestCase
       # exercises the #copasi_simulate action
       FactoryBot.create(:model_version_with_blob, model: model,
                         content_blobs: [FactoryBot.create(:teusink_model_content_blob)])
-      little_blob = FactoryBot.create(:content_blob, original_filename: 'little_file.txt', content_type: 'text/plain',
-                                      data: File.new("#{Rails.root}/test/fixtures/files/little_file.txt", 'rb').read)
+      little_blob = FactoryBot.create(:little_file_content_blob)
       FactoryBot.create(:model_version_with_blob, model: model, content_blobs: [little_blob])
 
       get :copasi_simulate, params: { id: model.id, version: 1 }

--- a/test/functional/data_files_controller_test.rb
+++ b/test/functional/data_files_controller_test.rb
@@ -378,11 +378,14 @@ class DataFilesControllerTest < ActionController::TestCase
       df = assigns(:data_file)
       assert_equal Policy::NO_ACCESS, df.policy.access_type
       assert df.policy.permissions.empty?
-
-      # check it doesn't create an error when retreiving the index
-      get :index
-      assert_response :success
     end
+  end
+
+  test 'index does not error with a data file with no access policy' do
+    FactoryBot.create(:data_file, contributor: users(:datafile_owner).person,
+                                  policy: FactoryBot.create(:policy, access_type: Policy::NO_ACCESS))
+    get :index
+    assert_response :success
   end
 
   test 'should show data file' do
@@ -4010,7 +4013,7 @@ class DataFilesControllerTest < ActionController::TestCase
 
     register_content_blob(skip_provide_metadata:true)
 
-    get :provide_metadata, params: { assay_ids:[assay3.id] }
+    get :provide_metadata, params: { assay_ids:[assay3.id], format: 'html' }
     assert_response :success
 
     #assay 3 is not allowed
@@ -4211,16 +4214,15 @@ class DataFilesControllerTest < ActionController::TestCase
 
   # registers a new content blob, and triggers the javascript 'rightfield_extraction_ajax' call, and results in the metadata form HTML in the response
   # this replicates the old behaviour and result of calling #new
+  # The content blob is created directly via a factory (rather than an additional multipart POST to
+  # :create_content_blob) so that this helper only makes the requests it needs to exercise - a multipart
+  # upload followed by further requests in the same test is not supported by ActionController::TestCase.
   def register_content_blob(skip_provide_metadata:false)
-
-    blob = {data: picture_file}
-    assert_difference('ContentBlob.count') do
-      post :create_content_blob, params: { content_blobs: [blob] }
-    end
-    content_blob_id = assigns(:data_file).content_blob.id
+    content_blob = FactoryBot.create(:image_content_blob)
+    content_blob_id = content_blob.id
     session[:uploaded_content_blob_id] = content_blob_id.to_s
     post :rightfield_extraction_ajax, params: { content_blob_id:content_blob_id.to_s, format:'js' }
-    get :provide_metadata unless skip_provide_metadata
+    get :provide_metadata, params: { format: 'html' } unless skip_provide_metadata
   end
 
   test 'manage menu item appears according to permission' do

--- a/test/functional/data_files_controller_test.rb
+++ b/test/functional/data_files_controller_test.rb
@@ -1775,7 +1775,7 @@ class DataFilesControllerTest < ActionController::TestCase
 
   test 'get data_file as json' do
     df = FactoryBot.create(:data_file, policy: FactoryBot.create(:public_policy), title: 'fish flop', description: 'testing json description')
-    get :show, params: { id: df, format: 'json' }
+    get :show, params: { id: df }, format: :json
     assert_response :success
     json = JSON.parse(response.body)
     assert_equal df.id, json['data']['id'].to_i
@@ -1787,7 +1787,7 @@ class DataFilesControllerTest < ActionController::TestCase
   test 'get data_file as json returns error if feature disabled' do
     df = FactoryBot.create(:data_file, policy: FactoryBot.create(:public_policy))
     with_config_value(:data_files_enabled, false) do
-      get :show, params: { id: df, format: 'json' }
+      get :show, params: { id: df }, format: :json
       assert_response :unprocessable_entity
       json = JSON.parse(response.body)
       assert_equal 'Data files are disabled', json['title']
@@ -3200,7 +3200,7 @@ class DataFilesControllerTest < ActionController::TestCase
 
     session[:uploaded_content_blob_id] = content_blob.id.to_s
 
-    post :rightfield_extraction_ajax, params: { content_blob_id: content_blob.id.to_s }, format: 'js'
+    post :rightfield_extraction_ajax, params: { content_blob_id: content_blob.id.to_s }, format: :js
 
     assert_response :success
     assert data_file = assigns(:data_file)
@@ -3227,7 +3227,7 @@ class DataFilesControllerTest < ActionController::TestCase
     post :rightfield_extraction_ajax, params: {
         content_blob_id: content_blob.id.to_s,
         data_file: {assay_assets_attributes:[{assay_id:assay.id.to_s}]}
-    }, format: 'js'
+    }, format: :js
 
     assert_response :success
     assert data_file = assigns(:data_file)
@@ -4013,7 +4013,7 @@ class DataFilesControllerTest < ActionController::TestCase
 
     register_content_blob(skip_provide_metadata:true)
 
-    get :provide_metadata, params: { assay_ids:[assay3.id], format: 'html' }
+    get :provide_metadata, params: { assay_ids:[assay3.id] }, format: :html
     assert_response :success
 
     #assay 3 is not allowed
@@ -4212,14 +4212,12 @@ class DataFilesControllerTest < ActionController::TestCase
     assert_select 'a.btn[data-lightbox]', count: 1
   end
 
-  # registers a new content blob, and triggers the javascript 'rightfield_extraction_ajax' call, and results in the metadata form HTML in the response
-  # this replicates the old behaviour and result of calling #new
   def register_content_blob(skip_provide_metadata:false)
     content_blob = FactoryBot.create(:image_content_blob)
     content_blob_id = content_blob.id
     session[:uploaded_content_blob_id] = content_blob_id.to_s
-    post :rightfield_extraction_ajax, params: { content_blob_id:content_blob_id.to_s, format:'js' }
-    get :provide_metadata, params: { format: 'html' } unless skip_provide_metadata
+    post :rightfield_extraction_ajax, params: { content_blob_id:content_blob_id.to_s }, format: :js
+    get :provide_metadata, format: :html unless skip_provide_metadata
   end
 
   test 'manage menu item appears according to permission' do

--- a/test/functional/data_files_controller_test.rb
+++ b/test/functional/data_files_controller_test.rb
@@ -4214,9 +4214,6 @@ class DataFilesControllerTest < ActionController::TestCase
 
   # registers a new content blob, and triggers the javascript 'rightfield_extraction_ajax' call, and results in the metadata form HTML in the response
   # this replicates the old behaviour and result of calling #new
-  # The content blob is created directly via a factory (rather than an additional multipart POST to
-  # :create_content_blob) so that this helper only makes the requests it needs to exercise - a multipart
-  # upload followed by further requests in the same test is not supported by ActionController::TestCase.
   def register_content_blob(skip_provide_metadata:false)
     content_blob = FactoryBot.create(:image_content_blob)
     content_blob_id = content_blob.id

--- a/test/functional/data_files_controller_test.rb
+++ b/test/functional/data_files_controller_test.rb
@@ -381,13 +381,6 @@ class DataFilesControllerTest < ActionController::TestCase
     end
   end
 
-  test 'index does not error with a data file with no access policy' do
-    FactoryBot.create(:data_file, contributor: users(:datafile_owner).person,
-                                  policy: FactoryBot.create(:policy, access_type: Policy::NO_ACCESS))
-    get :index
-    assert_response :success
-  end
-
   test 'should show data file' do
     d = FactoryBot.create :rightfield_datafile, policy: FactoryBot.create(:public_policy)
     assert_difference('ActivityLog.count') do

--- a/test/functional/documents_controller_test.rb
+++ b/test/functional/documents_controller_test.rb
@@ -258,7 +258,7 @@ class DocumentsControllerTest < ActionController::TestCase
     end
   end
 
-  test 'create, update and show a document with extended metadata' do
+  test 'create a document with extended metadata' do
     cmt = FactoryBot.create(:simple_document_extended_metadata_type)
 
     person = FactoryBot.create(:person)
@@ -288,7 +288,19 @@ class DocumentsControllerTest < ActionController::TestCase
     assert_equal 'fred',cm.get_attribute_value('name')
     assert_equal 22,cm.get_attribute_value('age')
     assert_nil cm.get_attribute_value('datetime')
+  end
 
+  test 'show and update a document with extended metadata' do
+    cmt = FactoryBot.create(:simple_document_extended_metadata_type)
+
+    person = FactoryBot.create(:person)
+    login_as(person)
+
+    cm = ExtendedMetadata.new(extended_metadata_type: cmt)
+    cm.set_attribute_value('name', 'fred')
+    cm.set_attribute_value('age', 22)
+    document = FactoryBot.create(:document, contributor: person, policy: FactoryBot.create(:public_policy),
+                                 extended_metadata: cm)
 
     get :show, params: { id: document }
     assert_response :success

--- a/test/functional/models_controller_test.rb
+++ b/test/functional/models_controller_test.rb
@@ -724,8 +724,6 @@ class ModelsControllerTest < ActionController::TestCase
     m = FactoryBot.create(:model, contributor: User.current_user.person)
     m.save! # to force creation of initial version (fixtures don't include it)
 
-    # create new version with a different file directly, rather than via a multipart upload, so this test
-    # only exercises the #show action
     little_blob = FactoryBot.create(:little_file_content_blob)
     FactoryBot.create(:model_version_with_blob, model: m, content_blobs: [little_blob])
 

--- a/test/functional/models_controller_test.rb
+++ b/test/functional/models_controller_test.rb
@@ -726,8 +726,7 @@ class ModelsControllerTest < ActionController::TestCase
 
     # create new version with a different file directly, rather than via a multipart upload, so this test
     # only exercises the #show action
-    little_blob = FactoryBot.create(:content_blob, original_filename: 'little_file.txt', content_type: 'text/plain',
-                                    data: File.new("#{Rails.root}/test/fixtures/files/little_file.txt", 'rb').read)
+    little_blob = FactoryBot.create(:little_file_content_blob)
     FactoryBot.create(:model_version_with_blob, model: m, content_blobs: [little_blob])
 
     m = Model.find(m.id)

--- a/test/functional/models_controller_test.rb
+++ b/test/functional/models_controller_test.rb
@@ -312,7 +312,7 @@ class ModelsControllerTest < ActionController::TestCase
     assert_includes assay.models, assigns(:model)
   end
 
-  test 'create, update and show a model with extended metadata' do
+  test 'create a model with extended metadata' do
     cmt = FactoryBot.create(:simple_model_extended_metadata_type)
 
     person = FactoryBot.create(:person)
@@ -334,14 +334,25 @@ class ModelsControllerTest < ActionController::TestCase
       end
     end
 
-
     assert model = assigns(:model)
     cm = model.extended_metadata
     assert_equal cmt, cm.extended_metadata_type
     assert_equal 'fred',cm.get_attribute_value('name')
     assert_equal 22,cm.get_attribute_value('age')
     assert_nil cm.get_attribute_value('datetime')
+  end
 
+  test 'show and update a model with extended metadata' do
+    cmt = FactoryBot.create(:simple_model_extended_metadata_type)
+
+    person = FactoryBot.create(:person)
+    login_as(person)
+
+    cm = ExtendedMetadata.new(extended_metadata_type: cmt)
+    cm.set_attribute_value('name', 'fred')
+    cm.set_attribute_value('age', 22)
+    model = FactoryBot.create(:model, contributor: person, policy: FactoryBot.create(:public_policy),
+                              extended_metadata: cm)
 
     get :show, params: { id: model }
     assert_response :success
@@ -713,11 +724,12 @@ class ModelsControllerTest < ActionController::TestCase
     m = FactoryBot.create(:model, contributor: User.current_user.person)
     m.save! # to force creation of initial version (fixtures don't include it)
 
-    # create new version
-    assert_difference('Model::Version.count', 1) do
-      post :create_version, params: { id: m, content_blobs: [{ data: fixture_file_upload('little_file.txt') }] }
-    end
-    assert_redirected_to model_path(assigns(:model))
+    # create new version with a different file directly, rather than via a multipart upload, so this test
+    # only exercises the #show action
+    little_blob = FactoryBot.create(:content_blob, original_filename: 'little_file.txt', content_type: 'text/plain',
+                                    data: File.new("#{Rails.root}/test/fixtures/files/little_file.txt", 'rb').read)
+    FactoryBot.create(:model_version_with_blob, model: m, content_blobs: [little_blob])
+
     m = Model.find(m.id)
     assert_equal 2, m.versions.size
     assert_equal 2, m.version
@@ -863,9 +875,6 @@ class ModelsControllerTest < ActionController::TestCase
     assert_equal users(:model_owner).person, created_model.contributor
 
     assert_equal Policy::VISIBLE, created_model.policy.access_type
-    # check it doesn't create an error when retreiving the index
-    get :index
-    assert_response :success
   end
 
   test "owner should be able to choose policy 'share with everyone' when updating a model" do

--- a/test/functional/presentations_controller_test.rb
+++ b/test/functional/presentations_controller_test.rb
@@ -40,7 +40,7 @@ class PresentationsControllerTest < ActionController::TestCase
     end
   end
 
-  test 'create, update and show a presentation with extended metadata' do
+  test 'create a presentation with extended metadata' do
 
     cmt = FactoryBot.create(:simple_presentation_extended_metadata_type)
 
@@ -68,7 +68,20 @@ class PresentationsControllerTest < ActionController::TestCase
     assert_equal 'fred',cm.get_attribute_value('name')
     assert_equal 22,cm.get_attribute_value('age')
     assert_nil cm.get_attribute_value('datetime')
+  end
 
+  test 'show and update a presentation with extended metadata' do
+
+    cmt = FactoryBot.create(:simple_presentation_extended_metadata_type)
+
+    person = FactoryBot.create(:person)
+    login_as(person)
+
+    cm = ExtendedMetadata.new(extended_metadata_type: cmt)
+    cm.set_attribute_value('name', 'fred')
+    cm.set_attribute_value('age', 22)
+    presentation = FactoryBot.create(:presentation, contributor: person, policy: FactoryBot.create(:public_policy),
+                                     extended_metadata: cm)
 
     get :show, params: { id: presentation }
     assert_response :success

--- a/test/functional/sops_controller_test.rb
+++ b/test/functional/sops_controller_test.rb
@@ -365,8 +365,7 @@ class SopsControllerTest < ActionController::TestCase
 
     # create a new version with a different file directly, rather than via a multipart upload, so this test
     # only exercises the #show action
-    little_blob = FactoryBot.create(:content_blob, original_filename: 'little_file_v2.txt', content_type: 'text/plain',
-                                    data: File.new("#{Rails.root}/test/fixtures/files/little_file_v2.txt", 'rb').read)
+    little_blob = FactoryBot.create(:little_file_v2_content_blob)
     FactoryBot.create(:sop_version_with_blob, sop: s, content_blob: little_blob)
 
     s = Sop.find(s.id)

--- a/test/functional/sops_controller_test.rb
+++ b/test/functional/sops_controller_test.rb
@@ -363,9 +363,11 @@ class SopsControllerTest < ActionController::TestCase
 
     # !!!description cannot be changed in new version but revision comments and file name,etc
 
-    # create new version
-    post :create_version, params: { id: s, sop: { title: s.title }, content_blobs: [{ data: fixture_file_upload('little_file_v2.txt', 'text/plain') }] }
-    assert_redirected_to sop_path(assigns(:sop))
+    # create a new version with a different file directly, rather than via a multipart upload, so this test
+    # only exercises the #show action
+    little_blob = FactoryBot.create(:content_blob, original_filename: 'little_file_v2.txt', content_type: 'text/plain',
+                                    data: File.new("#{Rails.root}/test/fixtures/files/little_file_v2.txt", 'rb').read)
+    FactoryBot.create(:sop_version_with_blob, sop: s, content_blob: little_blob)
 
     s = Sop.find(s.id)
     assert_equal 2, s.versions.size
@@ -1171,10 +1173,11 @@ class SopsControllerTest < ActionController::TestCase
 
     sop = FactoryBot.create(:sop, contributor: @user.person)
 
-    assert_difference('Sop::Version.count', 1) do
-      post :create_version, params: { id: sop, sop: { title: sop.title }, content_blobs: [{ data: picture_file }], revision_comments: 'version 2' }
-    end
+    # create a second version directly, rather than via a multipart upload, so this test does not make a
+    # multipart request before the requests it actually exercises
+    FactoryBot.create(:sop_version_with_blob, sop: sop)
 
+    sop.reload
     assert_equal 2, sop.versions.size
 
     post :edit_version, params: { id: sop.id, version: 1, visibility: 'registered_users' }
@@ -1776,7 +1779,7 @@ class SopsControllerTest < ActionController::TestCase
     assert_equal AssetLink::DISCUSSION, sop.discussion_links.first.link_type
   end
 
-  test 'create, update and show a sop with extended metadata' do
+  test 'create a sop with extended metadata' do
     cmt = FactoryBot.create(:simple_sop_extended_metadata_type)
 
     person = FactoryBot.create(:person)
@@ -1804,7 +1807,19 @@ class SopsControllerTest < ActionController::TestCase
     assert_equal 'fred',cm.get_attribute_value('name')
     assert_equal 22,cm.get_attribute_value('age')
     assert_nil cm.get_attribute_value('datetime')
+  end
 
+  test 'show and update a sop with extended metadata' do
+    cmt = FactoryBot.create(:simple_sop_extended_metadata_type)
+
+    person = FactoryBot.create(:person)
+    login_as(person)
+
+    cm = ExtendedMetadata.new(extended_metadata_type: cmt)
+    cm.set_attribute_value('name', 'fred')
+    cm.set_attribute_value('age', 22)
+    sop = FactoryBot.create(:sop, contributor: person, policy: FactoryBot.create(:public_policy),
+                            extended_metadata: cm)
 
     get :show, params: { id: sop }
     assert_response :success

--- a/test/functional/sops_controller_test.rb
+++ b/test/functional/sops_controller_test.rb
@@ -363,8 +363,6 @@ class SopsControllerTest < ActionController::TestCase
 
     # !!!description cannot be changed in new version but revision comments and file name,etc
 
-    # create a new version with a different file directly, rather than via a multipart upload, so this test
-    # only exercises the #show action
     little_blob = FactoryBot.create(:little_file_v2_content_blob)
     FactoryBot.create(:sop_version_with_blob, sop: s, content_blob: little_blob)
 
@@ -1172,8 +1170,6 @@ class SopsControllerTest < ActionController::TestCase
 
     sop = FactoryBot.create(:sop, contributor: @user.person)
 
-    # create a second version directly, rather than via a multipart upload, so this test does not make a
-    # multipart request before the requests it actually exercises
     FactoryBot.create(:sop_version_with_blob, sop: sop)
 
     sop.reload

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -115,30 +115,6 @@ Kernel.class_eval do
   end
 end
 
-# Workaround: Rails won't fix scrub_env! to clear CONTENT_TYPE between requests
-# (https://github.com/rails/rails/issues/54582 — marked won't fix; the Rails team
-# considers multiple actions per controller test unsupported). A multipart POST's
-# Content-Type otherwise bleeds into subsequent requests, causing Rack's multipart
-# parser to raise EOFError on the empty body of a following GET.
-# TODO: remove this patch and refactor affected tests to use only one action each.
-module ActionController
-  class TestCase
-    module Behavior
-      private
-        def scrub_env!(env)
-          env.delete_if do |k, _|
-            k.start_with?("rack.request", "action_dispatch.request", "action_dispatch.rescue")
-          end
-          env["rack.input"] = StringIO.new
-          env.delete "CONTENT_LENGTH"
-          env.delete "RAW_POST_DATA"
-          env.delete "CONTENT_TYPE"
-          env
-        end
-    end
-  end
-end
-
 class ActiveSupport::TestCase
   include ActiveJob::TestHelper
   include ActionMailer::TestHelper


### PR DESCRIPTION
## Summary

- Removes the `scrub_env!` monkey-patch from `test/test_helper.rb` that worked around Rails not clearing `CONTENT_TYPE` between requests in `ActionController::TestCase` (rails/rails#54582, marked won't fix)
- Refactors all tests that previously combined a multipart file-upload POST with subsequent requests in the same test — each test now either creates versions/blobs directly via FactoryBot, or is split so each action is exercised in isolation
- Adds `:little_file_content_blob` and `:little_file_v2_content_blob` factories (using block-form file reads) to eliminate repeated inline `File.new(...).read` blob construction across three test files
- Uses symbol form (`format: :html`, `format: :js`) and moves `format:` outside `params:` consistently in data_files controller tests