### PR TITLE
Fix nil return from SlideShare renderer causing NoMethodError

### DIFF
--- a/lib/seek/renderers/slideshare_renderer.rb
+++ b/lib/seek/renderers/slideshare_renderer.rb
@@ -14,7 +14,7 @@ module Seek
         json = JSON.parse(RestClient.get(api_url))
         json['html']
       rescue RestClient::Exception, JSON::ParserError
-        nil
+        ''
       end
 
       # if it is a slideshare url, which starts with www.slideshare.net, and is made up of 2 parts (params ignored)


### PR DESCRIPTION
## Summary

- Follow-up to #2631 (which fixed #2629)
- The rescue block in `SlideshareRenderer#render_content` returned `nil` on `RestClient::Exception` or `JSON::ParserError`, but two call sites call `.html_safe` directly on the result of `render`, which would raise `NoMethodError` if nil is returned
- Changed the rescue to return `''` instead, consistent with what `BlobRenderer#render` itself returns when catching exceptions