### PR TITLE
Add indexes on samples.originating_data_file_id and samples.sample_type_id

### DIFF
--- a/db/migrate/20260623150237_add_indexes_to_samples.rb
+++ b/db/migrate/20260623150237_add_indexes_to_samples.rb
@@ -1,0 +1,6 @@
+class AddIndexesToSamples < ActiveRecord::Migration[7.2]
+  def change
+    add_index :samples, :originating_data_file_id
+    add_index :samples, :sample_type_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_22_131727) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_23_150237) do
   create_table "activity_logs", id: :integer, force: :cascade do |t|
     t.string "action"
     t.string "format"
@@ -1897,6 +1897,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_22_131727) do
     t.string "deleted_contributor"
     t.bigint "observation_unit_id"
     t.string "external_identifier", limit: 2048
+    t.index ["originating_data_file_id"], name: "index_samples_on_originating_data_file_id"
+    t.index ["sample_type_id"], name: "index_samples_on_sample_type_id"
   end
 
   create_table "saved_searches", id: :integer, force: :cascade do |t|


### PR DESCRIPTION
## Summary

- Adds a missing index on `samples.originating_data_file_id`, which was introduced in 2016 without one
- Adds a missing index on `samples.sample_type_id`

Both columns are frequently used as WHERE filters but were causing full table scans on the `samples` table.

`originating_data_file_id` is queried on every DataFile show page (via the related items tab and asset buttons partial). `sample_type_id` is queried during sample extraction, metadata updates, and attribute resolution for linked samples.

Both values are set once at bulk import time (`Sample.import` with `batch_size: 2000`) and not subsequently changed, so the insert overhead is negligible.