### PR TITLE
Git `add_file` error handling

### DIFF
--- a/app/controllers/git_controller.rb
+++ b/app/controllers/git_controller.rb
@@ -75,9 +75,11 @@ class GitController < ApplicationController
     if file_params[:url].present?
       add_remote_file
       operation_response("Registered #{file_params[:url]}", status: 201)
-    else
+    elsif file_params[:data].present?
       add_local_file
       operation_response("Uploaded #{file_params[:path] || params[:path]}", status: 201)
+    else
+      render_git_error("Please select a file to upload or provide a URL to the data.", status: 422)
     end
   end
 

--- a/app/controllers/git_controller.rb
+++ b/app/controllers/git_controller.rb
@@ -75,7 +75,7 @@ class GitController < ApplicationController
     if file_params[:url].present?
       add_remote_file
       operation_response("Registered #{file_params[:url]}", status: 201)
-    elsif file_params[:data].present?
+    elsif file_params[:data].present? || file_params[:content].present?
       add_local_file
       operation_response("Uploaded #{file_params[:path] || params[:path]}", status: 201)
     else

--- a/test/functional/git_controller_test.rb
+++ b/test/functional/git_controller_test.rb
@@ -71,6 +71,17 @@ class GitControllerTest < ActionController::TestCase
     refute assigns(:git_version).file_exists?('new-file.txt')
   end
 
+  test 'displays error message if adding file without data or url' do
+    refute @git_version.file_exists?('little_file.txt')
+
+    post :add_file, params: { workflow_id: @workflow.id, version: @git_version.version,
+                              file: { path: 'new-file.tx' } }
+
+    assert_redirected_to workflow_path(@workflow, tab: 'files')
+    assert flash[:error].include?('select a file')
+    refute assigns(:git_version).file_exists?('new-file.txt')
+  end
+
   test 'move file' do
     assert @git_version.file_exists?('diagram.png')
     refute @git_version.file_exists?('cool-pic.png')

--- a/test/functional/git_controller_test.rb
+++ b/test/functional/git_controller_test.rb
@@ -72,7 +72,7 @@ class GitControllerTest < ActionController::TestCase
   end
 
   test 'displays error message if adding file without data or url' do
-    refute @git_version.file_exists?('little_file.txt')
+    refute @git_version.file_exists?('new-file.txt')
 
     post :add_file, params: { workflow_id: @workflow.id, version: @git_version.version,
                               file: { path: 'new-file.txt' } }

--- a/test/functional/git_controller_test.rb
+++ b/test/functional/git_controller_test.rb
@@ -75,7 +75,7 @@ class GitControllerTest < ActionController::TestCase
     refute @git_version.file_exists?('little_file.txt')
 
     post :add_file, params: { workflow_id: @workflow.id, version: @git_version.version,
-                              file: { path: 'new-file.tx' } }
+                              file: { path: 'new-file.txt' } }
 
     assert_redirected_to workflow_path(@workflow, tab: 'files')
     assert flash[:error].include?('select a file')

--- a/test/functional/git_controller_test.rb
+++ b/test/functional/git_controller_test.rb
@@ -617,6 +617,7 @@ class GitControllerTest < ActionController::TestCase
 
     assert_response :created
     assert workflow.git_version.file_exists?('new_file.txt')
+    assert_equal 'file contents', workflow.git_version.file_contents('new_file.txt')
   end
 
   test 'add a new remote file via API' do


### PR DESCRIPTION
Fixes 500 error when trying to add a Git file without selecting a file to upload or providing a URL.