### PR TITLE
Fix crash in LinkingSamplesUpdateJob for singly-linked sample attributes

### DIFF
--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -153,7 +153,7 @@ class Sample < ApplicationRecord
       _linking_samples.each do |linking_sample|
         changed = false
         potential_linking_attributes.each do |attr|
-          Array(linking_sample.get_attribute_value(attr)).each do |linked_sample_data|
+          Array.wrap(linking_sample.get_attribute_value(attr)).each do |linked_sample_data|
             next unless linked_sample_data['id'] == id
             next if linked_sample_data['title'] == title
             linked_sample_data['title'] = title

--- a/test/unit/jobs/linking_samples_update_job_test.rb
+++ b/test/unit/jobs/linking_samples_update_job_test.rb
@@ -39,6 +39,27 @@ class LinkingSamplesUpdateJobTest < ActiveSupport::TestCase
     end
   end
 
+  test 'perform with a singly linked (non-multi) sample attribute' do
+    project = @person.projects.first
+    linked_type = FactoryBot.create(:linked_sample_type, project_ids: [project.id])
+    patient_type = linked_type.sample_attributes.detect { |a| a.title == 'patient' }.linked_sample_type
+
+    patient, linking_sample = disable_authorization_checks do
+      patient = Sample.create!(sample_type: patient_type, project_ids: [project.id],
+                                data: { 'full name' => 'Fred Bloggs', age: 44 })
+      linking_sample = Sample.create!(sample_type: linked_type, project_ids: [project.id],
+                                       data: { title: 'linking_sample', patient: patient.id })
+      [patient, linking_sample]
+    end
+
+    patient.set_attribute_value('full name', 'Dolly Parton')
+    disable_authorization_checks { patient.save! }
+
+    LinkingSamplesUpdateJob.perform_now(patient)
+
+    assert_equal 'Dolly Parton', Sample.find(linking_sample.id).get_attribute_value(:patient)[:title]
+  end
+
   def create_linked_samples
     project = @person.projects.first
 


### PR DESCRIPTION
## Summary
- Fixes #2652 — `LinkingSamplesUpdateJob` crashed with `TypeError: no implicit conversion of String into Integer` when refreshing a linking sample that has a singular (non-multi) "Registered Sample" attribute.
- Root cause: `Array(hash)` explodes a Hash into `[key, value]` pairs instead of wrapping it as a single-element array, so `refresh_linking_samples` iterated over pairs like `["id", 26]` and then called `[]` on that array with a String key. Switched to `Array.wrap`, matching the existing correct usage in `Sample#referenced_resources`.

## Test plan
- Added a regression test in `test/unit/jobs/linking_samples_update_job_test.rb` covering a singly-linked (non-multi) sample attribute, which reproduces the crash prior to the fix and passes after.
- Full `test/unit/sample_test.rb` and `test/unit/jobs/linking_samples_update_job_test.rb` suites pass locally.
- CI run green: https://github.com/seek4science/seek/actions/runs/28856457083