### PR TITLE
Fail fast instead of silently using default settings when the database is unavailable (#2667)

### DIFF
--- a/lib/seek/config.rb
+++ b/lib/seek/config.rb
@@ -497,19 +497,21 @@ module Seek
 
     # Whether the settings database table exists and should be read from.
     #
-    # Returns true if the table exists (memoized once found), or false if it is legitimately absent - i.e.
-    # the database is reachable but the table has not been created yet, as during db:setup before the schema
-    # is loaded - in which case defaults are used. If the database itself is unreachable, Settings.table_exists?
-    # raises and the error is allowed to propagate, so a process never silently serves default configuration
-    # values in place of the real stored settings (which could, for example, expose disabled features or apply
-    # the wrong policy). A boot that hits this simply fails and is retried, rather than being poisoned for its
-    # whole lifetime; and because a failed check is not memoized, reads recover on their own once the database
-    # is reachable again.
+    # Defaults are used only when there are provably no stored settings to lose: either the database is
+    # reachable but the table has not been created yet (table_exists? returns false, as during db:setup before
+    # the schema is loaded), or the database itself does not exist yet (NoDatabaseError, e.g. a fresh checkout
+    # before db:create). Any other failure means the database exists but is unreachable, and is allowed to
+    # propagate, so a process never silently serves default configuration values in place of the real stored
+    # settings (which could, for example, expose disabled features or apply the wrong policy). A boot that hits
+    # this simply fails and is retried, rather than being poisoned for its whole lifetime; and because neither
+    # falsey case is memoized, reads recover on their own once the database is reachable again.
     def settings_table_available?
       return true if @settings_table_available
 
       @settings_table_available = true if Settings.table_exists?
       !!@settings_table_available
+    rescue ActiveRecord::NoDatabaseError
+      false
     end
 
     def get_value(setting, conversion = nil)

--- a/lib/seek/config.rb
+++ b/lib/seek/config.rb
@@ -503,13 +503,10 @@ module Seek
     # before db:create). Any other failure means the database exists but is unreachable, and is allowed to
     # propagate, so a process never silently serves default configuration values in place of the real stored
     # settings (which could, for example, expose disabled features or apply the wrong policy). A boot that hits
-    # this simply fails and is retried, rather than being poisoned for its whole lifetime; and because neither
-    # falsey case is memoized, reads recover on their own once the database is reachable again.
+    # this simply fails and is retried, rather than being poisoned for its whole lifetime; and because a false
+    # result never sticks (only true is memoized), reads recover on their own once the database is reachable again.
     def settings_table_available?
-      return true if @settings_table_available
-
-      @settings_table_available = true if Settings.table_exists?
-      !!@settings_table_available
+      @settings_table_available ||= Settings.table_exists?
     rescue ActiveRecord::NoDatabaseError
       false
     end

--- a/lib/seek/config.rb
+++ b/lib/seek/config.rb
@@ -495,41 +495,47 @@ module Seek
       val
     end
 
-    use_db = begin
-      Settings.table_exists?
-    rescue StandardError
-      false
+    # Whether the settings database table exists and should be read from.
+    #
+    # Returns true if the table exists (memoized once found), or false if it is legitimately absent - i.e.
+    # the database is reachable but the table has not been created yet, as during db:setup before the schema
+    # is loaded - in which case defaults are used. If the database itself is unreachable, Settings.table_exists?
+    # raises and the error is allowed to propagate, so a process never silently serves default configuration
+    # values in place of the real stored settings (which could, for example, expose disabled features or apply
+    # the wrong policy). A boot that hits this simply fails and is retried, rather than being poisoned for its
+    # whole lifetime; and because a failed check is not memoized, reads recover on their own once the database
+    # is reachable again.
+    def settings_table_available?
+      return true if @settings_table_available
+
+      @settings_table_available = true if Settings.table_exists?
+      !!@settings_table_available
     end
 
-    if use_db
-      def get_value(setting, conversion = nil)
-        val = Settings.defaults[setting.to_s]
-        if Thread.current[:use_settings_cache]
-          begin
-            result = settings_cache[setting]
-          rescue Errno::ENOENT => e
-            Rails.logger.warn("Errno::ENOENT error reading the settings cache - #{e.message}")
-            result = Settings.global.fetch(setting)
-          end
-        else
+    def get_value(setting, conversion = nil)
+      return get_default_value(setting, conversion) unless settings_table_available?
+
+      val = Settings.defaults[setting.to_s]
+      if Thread.current[:use_settings_cache]
+        begin
+          result = settings_cache[setting]
+        rescue Errno::ENOENT => e
+          Rails.logger.warn("Errno::ENOENT error reading the settings cache - #{e.message}")
           result = Settings.global.fetch(setting)
         end
-        val = result.value if result
-        val = val.send(conversion) if conversion && val
-        val
+      else
+        result = Settings.global.fetch(setting)
       end
+      val = result.value if result
+      val = val.send(conversion) if conversion && val
+      val
+    end
 
-      def set_value(setting, val, conversion = nil)
-        val = val.send(conversion) if conversion && val
+    def set_value(setting, val, conversion = nil)
+      val = val.send(conversion) if conversion && val
+      if settings_table_available?
         Settings.global[setting] = val
-      end
-    else
-      def get_value(setting, conversion = nil)
-        get_default_value(setting, conversion)
-      end
-
-      def set_value(setting, val, conversion = nil)
-        val = val.send(conversion) if conversion && val
+      else
         Settings.defaults[setting.to_sym] = val
       end
     end

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -665,4 +665,58 @@ class ConfigTest < ActiveSupport::TestCase
     result = Seek::Config.external_search_adaptors
     assert_equal setting, result
   end
+
+  test 'settings default whilst the table is legitimately absent, then read from the database once it exists' do
+    Seek::Config.default :test_bootstrap_setting, 'the default'
+
+    # Simulate the pre-schema state during db:setup: the database is reachable but the table does not exist
+    reset_settings_table_memo
+    Settings.define_singleton_method(:table_exists?) { false }
+    begin
+      refute Seek::Config.settings_table_available?
+      # reads use the default, and writes update the in-memory defaults rather than hitting the database
+      assert_equal 'the default', Seek::Config.get_value(:test_bootstrap_setting)
+      Seek::Config.set_value(:test_bootstrap_setting, 'set during bootstrap')
+      assert_equal 'set during bootstrap', Seek::Config.get_default_value(:test_bootstrap_setting)
+    ensure
+      Settings.singleton_class.send(:remove_method, :table_exists?)
+    end
+
+    # Once the table exists, values come from the database
+    Seek::Config.set_value(:test_bootstrap_setting, 'the stored value')
+    assert Seek::Config.settings_table_available?
+    assert_equal 'the stored value', Seek::Config.get_value(:test_bootstrap_setting)
+  end
+
+  test 'reads fail fast when the database is unreachable, rather than silently serving defaults' do
+    Seek::Config.default :test_bootstrap_setting, 'the default'
+
+    reset_settings_table_memo
+    Settings.define_singleton_method(:table_exists?) { raise ActiveRecord::ConnectionNotEstablished, 'boom' }
+    begin
+      # a genuine outage must raise, not return the default, so wrong settings are never served or saved
+      assert_raises(ActiveRecord::ConnectionNotEstablished) { Seek::Config.settings_table_available? }
+      assert_raises(ActiveRecord::ConnectionNotEstablished) { Seek::Config.get_value(:test_bootstrap_setting) }
+      assert_raises(ActiveRecord::ConnectionNotEstablished) { Seek::Config.set_value(:test_bootstrap_setting, 'x') }
+      # the failed check must not be memoized, so the process recovers once the database is back
+      refute Seek::Config.instance_variable_get(:@settings_table_available)
+    ensure
+      Settings.singleton_class.send(:remove_method, :table_exists?)
+    end
+
+    assert Seek::Config.settings_table_available?
+  end
+
+  private
+
+  # @settings_table_available is a process-level instance variable on Seek::Config, so reset it between tests
+  # that simulate an outage to avoid leaking into other tests.
+  def reset_settings_table_memo
+    Seek::Config.instance_variable_set(:@settings_table_available, nil)
+  end
+
+  def teardown
+    reset_settings_table_memo
+    super
+  end
 end

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -707,6 +707,23 @@ class ConfigTest < ActiveSupport::TestCase
     assert Seek::Config.settings_table_available?
   end
 
+  test 'settings default when the database itself does not exist yet, rather than failing' do
+    Seek::Config.default :test_bootstrap_setting, 'the default'
+
+    # A fresh checkout before db:create: the database does not exist, so there are no stored settings to lose
+    reset_settings_table_memo
+    Settings.define_singleton_method(:table_exists?) { raise ActiveRecord::NoDatabaseError, 'no database' }
+    begin
+      refute Seek::Config.settings_table_available?
+      assert_equal 'the default', Seek::Config.get_value(:test_bootstrap_setting)
+    ensure
+      Settings.singleton_class.send(:remove_method, :table_exists?)
+    end
+
+    # Once the database and table exist, values come from the database again
+    assert Seek::Config.settings_table_available?
+  end
+
   private
 
   # @settings_table_available is a process-level instance variable on Seek::Config, so reset it between tests


### PR DESCRIPTION
Fixes #2667.

## Problem

`Seek::Config` decided **once, at class-load time**, whether settings were backed by the database:

```ruby
use_db = begin
  Settings.table_exists?
rescue StandardError
  false
end
```

If `Settings.table_exists?` raised during boot (e.g. the database was briefly unreachable under heavy load), the rescue silently switched the process to in-memory **defaults for its entire lifetime**. Saved settings were ignored until a restart, with no logging. With Passenger smart spawning a single failed check in the preloader could poison every forked worker.

Worse, such a process could overwrite the stored settings: it rendered the admin settings/features form pre-filled with default values, and submitting that form wrote those defaults straight back into the database.

## Approach

Defaults are used only when there are **provably no stored settings to lose**, which can be told apart from an outage by *how* `Settings.table_exists?` fails:

- **returns `false`** — the database is reachable but the table has not been created yet (as during `db:setup`, before the schema is loaded). This is a legitimate bootstrap, and continues to use defaults.
- **raises `ActiveRecord::NoDatabaseError`** — the database itself does not exist yet (e.g. a fresh checkout before `db:create`). There are no settings to lose, so this also uses defaults.
- **raises anything else** — the database exists but is unreachable. This is the incident case, and the error is now allowed to propagate instead of being swallowed.

A process never silently serves (or persists) default values in place of the real stored settings: during a genuine outage a request fails honestly (the app can't render meaningful pages without the database anyway), and a boot that hits it fails and is retried rather than being poisoned. Because a false result never sticks (only success is memoized), reads recover on their own once the database is reachable again — no restart needed.

This also removes the whole class of clobber described above: if reads never hand out defaults during an outage, a form can never render defaults to be written back.

Every SEEK bootstrap path reaches the environment with the database already reachable or covered by the cases above (`db:create` precedes the environment in `db:setup`; the container entrypoint runs `wait_for_mysql` before precompiling assets; the Docker build runs `db:setup` before precompile), so no legitimate scenario relies on the old swallow-and-default behaviour.

## Changes

`Seek::Config` gains a small `settings_table_available?` — true when the table exists (memoized), false when it is legitimately absent or the database does not exist yet (`NoDatabaseError`), and it lets any other connection error propagate. `get_value` returns defaults only when settings are legitimately unavailable; `set_value` writes to the database when the table exists and to the in-memory defaults during bootstrap.

## Tests

Added unit tests in `test/unit/config_test.rb` covering all three paths: settings default whilst the table is absent and then read from the database once it exists (the `db:setup` path); reads/writes fail fast (raise) when the database is unreachable, with the failed check not memoized so the process recovers; and settings default when the database itself does not exist yet (`NoDatabaseError`). Existing config and admin controller tests (which write settings) pass.
