### PR TITLE
Add inline content preview to SOP, Document, DataFile and FileTemplate pages

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -307,6 +307,13 @@ div.renderer {
   text-align:center;
 }
 
+/* Cap the height of inline text/CSV previews so large files don't blow up the page */
+div.renderer > pre {
+  max-height: 40em;
+  overflow: auto;
+  text-align: left;
+}
+
 #snapshot-citation {
   font-size: small;
 }

--- a/app/helpers/assets_helper.rb
+++ b/app/helpers/assets_helper.rb
@@ -37,7 +37,7 @@ module AssetsHelper
 
   # will render a view of the asset, if available. For example, a slideshare based asset could give a embedded slideshare view
   def rendered_asset_view(asset)
-    return '' unless asset.can_download?
+    return '' unless asset.content_blob && asset.can_download?
 
     our_renderer = Seek::Renderers::RendererFactory.instance.renderer(asset.content_blob)
     if our_renderer.external_embed? && !cookie_consent.allow_embedding?

--- a/app/views/data_files/show.html.erb
+++ b/app/views/data_files/show.html.erb
@@ -36,6 +36,9 @@
             <%= render :partial => 'nels/data_sheet', locals: { displayed_resource: @display_data_file } if @data_file.nels? %>
           </div>
         </div>
+
+        <%= rendered_asset_view(@display_data_file) %>
+
         <%= render :partial=>"general/isa_graph", :locals => {:root_item => @data_file, :deep => true, :include_parents => true} %>
       </div>
 

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -23,6 +23,8 @@
           </div>
         </div>
 
+        <%= rendered_asset_view(@display_document) %>
+
         <%= render partial: 'extended_metadata/extended_metadata_attribute_values', locals: { resource: @document } %>
         <%= render :partial=>"general/isa_graph", :locals => {:root_item => @document, :deep => true, :include_parents => true} %>
       </div>

--- a/app/views/file_templates/show.html.erb
+++ b/app/views/file_templates/show.html.erb
@@ -30,6 +30,9 @@
             <%= render :partial => "assets/asset_doi", :locals => {:displayed_resource=>@display_file_template} %>
 	  </div>
 	</div>
+
+	<%= rendered_asset_view(@display_file_template) %>
+
 	<%= render :partial=>"general/isa_graph", :locals => {:root_item => @file_template, :deep => true, :include_parents => true} %>
       </div>
 

--- a/app/views/sops/show.html.erb
+++ b/app/views/sops/show.html.erb
@@ -24,6 +24,8 @@
           </div>
         </div>
 
+        <%= rendered_asset_view(@display_sop) %>
+
         <%= render partial: 'extended_metadata/extended_metadata_attribute_values', locals: { resource: @sop } %>
 
         <%= render :partial=>"general/isa_graph", :locals => {:root_item => @sop, :deep => true, :include_parents => true} %>

--- a/test/functional/data_files_controller_test.rb
+++ b/test/functional/data_files_controller_test.rb
@@ -385,6 +385,13 @@ class DataFilesControllerTest < ActionController::TestCase
     end
   end
 
+  test 'should show inline content preview for pdf data file' do
+    pdf_data_file = FactoryBot.create(:api_pdf_data_file, policy: FactoryBot.create(:downloadable_public_policy))
+    get :show, params: { id: pdf_data_file.id }
+    assert_response :success
+    assert_select 'div.renderer iframe', count: 1
+  end
+
   test 'should show data file' do
     d = FactoryBot.create :rightfield_datafile, policy: FactoryBot.create(:public_policy)
     assert_difference('ActivityLog.count') do

--- a/test/functional/documents_controller_test.rb
+++ b/test/functional/documents_controller_test.rb
@@ -47,6 +47,13 @@ class DocumentsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test 'should show inline content preview for pdf document' do
+    pdf_doc = FactoryBot.create(:api_pdf_document, policy: FactoryBot.create(:downloadable_public_policy))
+    get :show, params: { id: pdf_doc.id }
+    assert_response :success
+    assert_select 'div.renderer iframe', count: 1
+  end
+
   test 'should not show hidden document' do
     hidden_doc = FactoryBot.create(:private_document)
 

--- a/test/functional/file_templates_controller_test.rb
+++ b/test/functional/file_templates_controller_test.rb
@@ -47,6 +47,13 @@ class FileTemplatesControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test 'should show inline content preview for pdf file template' do
+    pdf_ft = FactoryBot.create(:api_pdf_file_template, policy: FactoryBot.create(:downloadable_public_policy))
+    get :show, params: { id: pdf_ft.id }
+    assert_response :success
+    assert_select 'div.renderer iframe', count: 1
+  end
+
   test 'should not show hidden file template' do
     hidden_ft = FactoryBot.create(:private_file_template)
 

--- a/test/functional/sops_controller_test.rb
+++ b/test/functional/sops_controller_test.rb
@@ -765,6 +765,20 @@ class SopsControllerTest < ActionController::TestCase
     Seek::Config.pdf_conversion_enabled = tmp
   end
 
+  test 'should show inline content preview for pdf sop' do
+    pdf_sop = FactoryBot.create(:pdf_sop, policy: FactoryBot.create(:all_sysmo_downloadable_policy))
+    get :show, params: { id: pdf_sop.id }
+    assert_response :success
+    assert_select 'div.renderer iframe', count: 1
+  end
+
+  test 'should not show inline content preview when sop cannot be downloaded' do
+    pdf_sop = FactoryBot.create(:pdf_sop, policy: FactoryBot.create(:publicly_viewable_policy))
+    get :show, params: { id: pdf_sop.id }
+    assert_response :success
+    assert_select 'div.renderer', count: 0
+  end
+
   test 'show explore button' do
     sop = FactoryBot.create(:small_test_spreadsheet_sop)
     login_as(sop.contributor.user)


### PR DESCRIPTION
Fixes #2661

The inline content preview — which embeds a document's content directly on the show page (converting Office files to PDF when `pdf_conversion_enabled`) — previously only appeared on **Presentation** pages. Other single-downloadable-content types only offered the popup "View content" button.

## Changes

- Add `rendered_asset_view` to the show pages of **SOP**, **Document**, **DataFile** and **FileTemplate**, placed in the same position as Presentations (Models and Workflows are excluded, per the issue).
- Cap the height of inline text/CSV previews with a scrollable, fixed-height box, so large text files don't blow up the page. Scoped to the `<pre>` output so the PDF iframe preview is unaffected.
- Guard `rendered_asset_view` against a nil content blob (a DataFile can have none), which would otherwise raise in the renderer factory.

Non-previewable content (spreadsheets, binaries) falls back to the `BlankRenderer` and renders nothing, so no empty preview box appears. A DataFile's existing "explore" spreadsheet viewer is untouched.

Tests added for the inline PDF preview on each type, plus a negative case confirming no preview shows when the item can't be downloaded.
