### PR TITLE
Fix dynamic table for public items

### DIFF
--- a/app/controllers/single_pages_controller.rb
+++ b/app/controllers/single_pages_controller.rb
@@ -10,7 +10,7 @@ class SinglePagesController < ApplicationController
                 only: %i[show index project_folders]
   before_action :isa_json_compliance_enabled?
   before_action :check_user_logged_in,
-                except: %i[ show index ]
+                except: %i[ show index dynamic_table_data ]
   respond_to :html, :js
 
   def show

--- a/app/controllers/single_pages_controller.rb
+++ b/app/controllers/single_pages_controller.rb
@@ -27,12 +27,15 @@ class SinglePagesController < ApplicationController
   def dynamic_table_data
     data = []
     if params[:sample_type_id]
-      sample_type = SampleType.find(params[:sample_type_id]) if params[:sample_type_id]
+      sample_type = SampleType.authorized_for('view').detect { |st| st.id.to_s == params[:sample_type_id].to_s } if params[:sample_type_id]
       data = helpers.dt_data(sample_type)[:rows]
     elsif params[:study_id]
-      study = Study.find(params[:study_id]) if params[:study_id]
-      assay = Assay.find(params[:assay_id]) if params[:assay_id]
-      data = helpers.dt_aggregated(study, assay)[:rows]
+      study = Study.authorized_for('view').detect { |s| s.id.to_s == params[:study_id].to_s } if params[:study_id]
+      assay = Assay.authorized_for('view').detect { |a| a.id.to_s == params[:assay_id].to_s } if params[:assay_id]
+
+      unless study.nil? and assay.nil?
+        data = helpers.dt_aggregated(study, assay)[:rows]
+      end
     end
     data = data.map { |row| row.unshift('') } if params[:rows_pad]
     render json: { data: }

--- a/app/controllers/single_pages_controller.rb
+++ b/app/controllers/single_pages_controller.rb
@@ -29,14 +29,20 @@ class SinglePagesController < ApplicationController
     if params[:sample_type_id]
       # Sample type must belong to the current project
       # User must have at least viewing permission
-      sample_type = SampleType.where(id: params[:sample_type_id]).joins(:projects)
-                              .where(projects: { id: params[:id] }).authorized_for('view').first
+      sample_type = SampleType.where(id: params[:sample_type_id])
+                              .joins(:projects)
+                              .where(projects: { id: params[:id] })
+                              .authorized_for('view')
+                              .first
       data = helpers.dt_data(sample_type)[:rows] unless sample_type.nil?
     elsif params[:study_id]
       # Study must belong to the current project
       # User must have at least viewing permission
-      study = Study.where(id: params[:study_id]).joins(:projects)
-                   .where(projects: { id: params[:id] }).authorized_for('view').first
+      study = Study.where(id: params[:study_id])
+                   .joins(:projects)
+                   .where(projects: { id: params[:id] })
+                   .authorized_for('view')
+                   .first
 
       if params[:assay_id]
         # Assay must belong to the current study

--- a/app/controllers/single_pages_controller.rb
+++ b/app/controllers/single_pages_controller.rb
@@ -31,10 +31,12 @@ class SinglePagesController < ApplicationController
       data = helpers.dt_data(sample_type)[:rows] unless sample_type.nil?
     elsif params[:study_id]
       study = Study.where(id: params[:study_id]).authorized_for('view').first
-      assay = Assay.where(id: params[:assay_id]).authorized_for('view').first if params[:assay_id]
 
-      unless study.nil? and assay.nil?
-        data = helpers.dt_aggregated(study, assay)[:rows]
+      if params[:assay_id]
+        assay = Assay.where(id: params[:assay_id]).authorized_for('view').first
+        data = helpers.dt_aggregated(study, assay)[:rows] unless assay.nil?
+      elsif !study.nil?
+        data = helpers.dt_aggregated(study)[:rows]
       end
     end
     data = data.map { |row| row.unshift('') } if params[:rows_pad]

--- a/app/controllers/single_pages_controller.rb
+++ b/app/controllers/single_pages_controller.rb
@@ -27,11 +27,11 @@ class SinglePagesController < ApplicationController
   def dynamic_table_data
     data = []
     if params[:sample_type_id]
-      sample_type = SampleType.authorized_for('view').detect { |st| st.id.to_s == params[:sample_type_id].to_s } if params[:sample_type_id]
-      data = helpers.dt_data(sample_type)[:rows]
+      sample_type = SampleType.where(id: params[:sample_type_id]).authorized_for('view').first
+      data = helpers.dt_data(sample_type)[:rows] unless sample_type.nil?
     elsif params[:study_id]
-      study = Study.authorized_for('view').detect { |s| s.id.to_s == params[:study_id].to_s } if params[:study_id]
-      assay = Assay.authorized_for('view').detect { |a| a.id.to_s == params[:assay_id].to_s } if params[:assay_id]
+      study = Study.where(id: params[:study_id]).authorized_for('view').first
+      assay = Assay.where(id: params[:assay_id]).authorized_for('view').first if params[:assay_id]
 
       unless study.nil? and assay.nil?
         data = helpers.dt_aggregated(study, assay)[:rows]

--- a/app/controllers/single_pages_controller.rb
+++ b/app/controllers/single_pages_controller.rb
@@ -27,13 +27,23 @@ class SinglePagesController < ApplicationController
   def dynamic_table_data
     data = []
     if params[:sample_type_id]
-      sample_type = SampleType.where(id: params[:sample_type_id]).authorized_for('view').first
+      # Sample type must belong to the current project
+      # User must have at least viewing permission
+      sample_type = SampleType.where(id: params[:sample_type_id]).joins(:projects)
+                              .where(projects: { id: params[:id] }).authorized_for('view').first
       data = helpers.dt_data(sample_type)[:rows] unless sample_type.nil?
     elsif params[:study_id]
-      study = Study.where(id: params[:study_id]).authorized_for('view').first
+      # Study must belong to the current project
+      # User must have at least viewing permission
+      study = Study.where(id: params[:study_id]).joins(:projects)
+                   .where(projects: { id: params[:id] }).authorized_for('view').first
 
       if params[:assay_id]
-        assay = Assay.where(id: params[:assay_id]).authorized_for('view').first
+        # Assay must belong to the current study
+        # Assay must belong to the current project
+        # User must have at least viewing permission
+        assay = Assay.where(id: params[:assay_id], study_id: params[:study_id]).joins(:projects)
+                     .where(projects: { id: params[:id] }).authorized_for('view').first
         data = helpers.dt_aggregated(study, assay)[:rows] unless assay.nil?
       elsif !study.nil?
         data = helpers.dt_aggregated(study)[:rows]

--- a/test/factories/assays.rb
+++ b/test/factories/assays.rb
@@ -117,8 +117,8 @@ FactoryBot.define do
     sequence(:title) { |n| "ISA JSON compliant material assay #{n}" }
     description { 'An assay linked to an ISA JSON compliant study and a sample type' }
     after(:build) do |assay, eval|
-      assay.study ||= FactoryBot.create(:isa_json_compliant_study)
-      assay.sample_type = FactoryBot.create(:isa_assay_material_sample_type, linked_sample_type: eval.linked_sample_type)
+      assay.study ||= FactoryBot.create(:isa_json_compliant_study, contributor: assay.contributor)
+      assay.sample_type = FactoryBot.create(:isa_assay_material_sample_type, policy: assay.policy, contributor: assay.contributor, projects: assay.study.projects, linked_sample_type: eval.linked_sample_type)
     end
   end
 
@@ -129,8 +129,8 @@ FactoryBot.define do
     sequence(:title) { |n| "ISA JSON compliant data file assay #{n}" }
     description { 'An assay linked to an ISA JSON compliant study and a sample type' }
     after(:build) do |assay, eval|
-      assay.study ||= FactoryBot.create(:isa_json_compliant_study)
-      assay.sample_type = FactoryBot.create(:isa_assay_data_file_sample_type, linked_sample_type: eval.linked_sample_type)
+      assay.study ||= FactoryBot.create(:isa_json_compliant_study, contributor: assay.contributor)
+      assay.sample_type = FactoryBot.create(:isa_assay_data_file_sample_type, policy: assay.policy, projects: assay.study.projects, linked_sample_type: eval.linked_sample_type, contributor: assay.contributor)
     end
   end
 

--- a/test/factories/studies.rb
+++ b/test/factories/studies.rb
@@ -43,8 +43,8 @@ FactoryBot.define do
     description { 'A study which is linked to an ISA JSON compliant investigation and has two sample types linked to it.' }
     after(:build) do |study|
       study.investigation ||= FactoryBot.create(:investigation, is_isa_json_compliant: true)
-      source_st = FactoryBot.create(:isa_source_sample_type)
-      sample_collection_st = FactoryBot.create(:isa_sample_collection_sample_type, linked_sample_type: source_st)
+      source_st = FactoryBot.create(:isa_source_sample_type, policy: study.policy, projects: study.projects, contributor: study.contributor)
+      sample_collection_st = FactoryBot.create(:isa_sample_collection_sample_type, policy: study.policy, projects: study.projects, linked_sample_type: source_st, contributor: study.contributor)
       study.sample_types = [source_st, sample_collection_st]
     end
   end

--- a/test/functional/sample_types_controller_test.rb
+++ b/test/functional/sample_types_controller_test.rb
@@ -989,7 +989,8 @@ class SampleTypesControllerTest < ActionController::TestCase
       login_as(person)
       assert source_sample_type.is_isa_json_compliant?
       get :manage, params: { id: source_sample_type }
-      assert_redirected_to sample_type_path
+      assert_redirected_to sample_types_path
+      assert_equal 'This sample type is ISA JSON compliant and cannot be managed.', flash[:error]
 
       refute project_sample_type.is_isa_json_compliant?
       get :manage, params: { id: project_sample_type }

--- a/test/functional/single_pages_controller_test.rb
+++ b/test/functional/single_pages_controller_test.rb
@@ -146,4 +146,90 @@ class SinglePagesControllerTest < ActionController::TestCase
     assert visible_row.none? { |value| value == '#HIDDEN' }
     assert hidden_row.all? { |value| value == '#HIDDEN' || value.blank? }
   end
+
+  test 'dynamic table data should return an empty array when the requested assay is unauthorized' do
+    investigation = FactoryBot.create(:investigation, is_isa_json_compliant: true, policy: FactoryBot.create(:public_policy))
+    study = FactoryBot.create(:isa_json_compliant_study, investigation: investigation, policy: FactoryBot.create(:public_policy))
+    source_sample_type = study.sample_types.first
+    sample_collection_sample_type = study.sample_types.second
+
+    assay_stream = FactoryBot.create(:assay_stream, study: study, policy: FactoryBot.create(:private_policy))
+    assay = FactoryBot.create(:isa_json_compliant_material_assay, assay_stream: assay_stream, study: study,
+                              linked_sample_type: sample_collection_sample_type,
+                              policy: FactoryBot.create(:private_policy), position: 0)
+    material_assay_sample_type = assay.sample_type
+
+    source = FactoryBot.create(:isa_source, sample_type: source_sample_type, policy: FactoryBot.create(:public_policy))
+    sample = FactoryBot.create(:isa_sample, sample_type: sample_collection_sample_type, linked_samples: [source],
+                      policy: FactoryBot.create(:public_policy))
+    FactoryBot.create(:isa_material_assay_sample, sample_type: material_assay_sample_type, linked_samples: [sample],
+                      policy: FactoryBot.create(:public_policy))
+
+    logout
+
+    get :dynamic_table_data, params: { id: @project.id, study_id: study.id, assay_id: assay.id }
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    refute json.key?('error')
+    # The assay itself is unauthorized, so no data should be returned, even though the parent study is public.
+    assert_equal [], json['data']
+  end
+
+  test 'dynamic table data for a public assay is unaffected by an unauthorized parent study' do
+    investigation = FactoryBot.create(:investigation, is_isa_json_compliant: true, policy: FactoryBot.create(:private_policy))
+    study = FactoryBot.create(:isa_json_compliant_study, investigation: investigation, policy: FactoryBot.create(:private_policy))
+    source_sample_type = study.sample_types.first
+    sample_collection_sample_type = study.sample_types.second
+
+    assay_stream = FactoryBot.create(:assay_stream, study: study, policy: FactoryBot.create(:public_policy))
+    assay = FactoryBot.create(:isa_json_compliant_material_assay, assay_stream: assay_stream, study: study,
+                              linked_sample_type: sample_collection_sample_type,
+                              policy: FactoryBot.create(:public_policy), position: 0)
+    source = FactoryBot.create(:isa_source, sample_type: source_sample_type, policy: FactoryBot.create(:public_policy))
+    sample = FactoryBot.create(:isa_sample, sample_type: sample_collection_sample_type, linked_samples: [source],
+                               policy: FactoryBot.create(:public_policy))
+    FactoryBot.create(:isa_material_assay_sample, sample_type: assay.sample_type, linked_samples: [sample],
+                      policy: FactoryBot.create(:public_policy))
+
+    logout
+
+    get :dynamic_table_data, params: { id: @project.id, study_id: study.id, assay_id: assay.id }
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    refute json.key?('error')
+    # The assay's own policy is public and assay-level aggregation doesn't depend on the parent study,
+    # so its data is still returned even though the study itself is private.
+    assert_equal 1, json['data'].length
+    refute json['data'].flatten.include?('#HIDDEN')
+  end
+
+  test 'should return dynamic table data for a public sample type' do
+    sample_type = FactoryBot.create(:isa_source_sample_type, policy: FactoryBot.create(:public_policy))
+    FactoryBot.create(:isa_source, sample_type: sample_type, policy: FactoryBot.create(:public_policy))
+
+    logout
+
+    get :dynamic_table_data, params: { id: @project.id, sample_type_id: sample_type.id }
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    refute json.key?('error')
+    assert_equal 1, json['data'].length
+  end
+
+  test 'dynamic table data should not error out for an unauthorized sample type' do
+    sample_type = FactoryBot.create(:isa_source_sample_type, policy: FactoryBot.create(:private_policy))
+    FactoryBot.create(:isa_source, sample_type: sample_type, policy: FactoryBot.create(:private_policy))
+
+    logout
+
+    get :dynamic_table_data, params: { id: @project.id, sample_type_id: sample_type.id }
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    refute json.key?('error')
+    assert_equal [], json['data']
+  end
 end

--- a/test/functional/single_pages_controller_test.rb
+++ b/test/functional/single_pages_controller_test.rb
@@ -10,6 +10,19 @@ class SinglePagesControllerTest < ActionController::TestCase
     login_as @member
     @initial_isa_json_compliance_enabled = Seek::Config.isa_json_compliance_enabled
     Seek::Config.isa_json_compliance_enabled = true
+    @investigation = FactoryBot.create(:investigation, is_isa_json_compliant: true, policy: FactoryBot.create(:public_policy),
+                                      projects: [@project], contributor: @member)
+    @study = FactoryBot.create(:isa_json_compliant_study, investigation: @investigation,
+                              policy: FactoryBot.create(:public_policy), contributor: @member)
+    @source_sample_type = @study.sample_types.first
+    @sample_collection_sample_type = @study.sample_types.second
+
+    @assay_stream = FactoryBot.create(:assay_stream, study: @study, policy: FactoryBot.create(:public_policy), contributor: @member)
+    @assay = FactoryBot.create(:isa_json_compliant_material_assay, assay_stream: @assay_stream, study: @study,
+                              linked_sample_type: @sample_collection_sample_type, contributor: @member,
+                              policy: FactoryBot.create(:public_policy), position: 0)
+    @material_assay_sample_type = @assay.sample_type
+
   end
 
   def teardown
@@ -24,32 +37,28 @@ class SinglePagesControllerTest < ActionController::TestCase
   end
 
   test 'should hide inaccessible items in treeview' do
-    FactoryBot.create(:investigation, contributor: @member.person, policy: FactoryBot.create(:private_policy),
-                      projects: [@project])
-
-    login_as(FactoryBot.create(:user))
-    inv_two = FactoryBot.create(:investigation, contributor: User.current_user.person, policy: FactoryBot.create(:private_policy),
+    # Another user creates an investigation under the same project
+    other_user = FactoryBot.create(:user)
+    FactoryBot.create(:investigation, contributor: other_user.person, policy: FactoryBot.create(:private_policy),
                                 projects: [@project])
 
+    # @member visualises the treeview of the project
     controller = TreeviewBuilder.new @project, nil
     result = controller.send(:build_tree_data)
 
     json = JSON.parse(result)[0]
 
-    assert_equal 'hidden item', json['children'][0]['text']
-    assert_equal inv_two.title, json['children'][1]['text']
+    # @member sees his / her investigation but not the one made by other_user
+    assert_equal @investigation.title, json['children'][0]['text']
+    assert_equal 'hidden item', json['children'][1]['text']
   end
 
-  test 'should return dynamic table data when ISA-study is public' do
-    investigation = FactoryBot.create(:investigation, is_isa_json_compliant: true, policy: FactoryBot.create(:public_policy))
-    study = FactoryBot.create(:isa_json_compliant_study, investigation: investigation,
-                              policy: FactoryBot.create(:public_policy))
-    source_sample_type = study.sample_types.first
-    FactoryBot.create(:isa_source, sample_type: source_sample_type, policy: FactoryBot.create(:public_policy))
+  test 'should return dynamic table data to an unauthenticated user when ISA-study is public' do
+    FactoryBot.create(:isa_source, sample_type: @source_sample_type, contributor: @member, policy: FactoryBot.create(:public_policy))
 
     logout
 
-    get :dynamic_table_data, params: { id: @project.id, study_id: study.id }
+    get :dynamic_table_data, params: { id: @project.id, study_id: @study.id }
 
     assert_response :success
     json = JSON.parse(response.body)
@@ -59,26 +68,15 @@ class SinglePagesControllerTest < ActionController::TestCase
   end
 
   test 'should return dynamic table data when ISA-assay is public' do
-    investigation = FactoryBot.create(:investigation, is_isa_json_compliant: true, policy: FactoryBot.create(:public_policy))
-    study = FactoryBot.create(:isa_json_compliant_study, investigation: investigation,
-                              policy: FactoryBot.create(:public_policy))
-    source_sample_type = study.sample_types.first
-    sample_collection_sample_type = study.sample_types.second
-
-    assay_stream = FactoryBot.create(:assay_stream, study: study, policy: FactoryBot.create(:public_policy))
-    assay = FactoryBot.create(:isa_json_compliant_material_assay, assay_stream: assay_stream, study: study,
-                              linked_sample_type: sample_collection_sample_type,
-                              policy: FactoryBot.create(:public_policy), position: 0)
-    material_assay_sample_type = assay.sample_type
-    source = FactoryBot.create(:isa_source, sample_type: source_sample_type, policy: FactoryBot.create(:public_policy))
-    sample = FactoryBot.create(:isa_sample, sample_type: sample_collection_sample_type, linked_samples: [source],
+    source = FactoryBot.create(:isa_source, sample_type: @source_sample_type, policy: FactoryBot.create(:public_policy))
+    sample = FactoryBot.create(:isa_sample, sample_type: @sample_collection_sample_type, linked_samples: [source],
                                policy: FactoryBot.create(:public_policy))
-    FactoryBot.create(:isa_material_assay_sample, sample_type: material_assay_sample_type, linked_samples: [sample],
+    FactoryBot.create(:isa_material_assay_sample, sample_type: @material_assay_sample_type, linked_samples: [sample],
                       policy: FactoryBot.create(:public_policy))
 
     logout
 
-    get :dynamic_table_data, params: { id: @project.id, study_id: study.id, assay_id: assay.id }
+    get :dynamic_table_data, params: { id: @project.id, study_id: @study.id, assay_id: @assay.id }
 
     assert_response :success
     json = JSON.parse(response.body)
@@ -88,26 +86,15 @@ class SinglePagesControllerTest < ActionController::TestCase
   end
 
   test 'dynamic table data should not have unauthorized items' do
-    investigation = FactoryBot.create(:investigation, is_isa_json_compliant: true, policy: FactoryBot.create(:private_policy))
-    study = FactoryBot.create(:isa_json_compliant_study, investigation: investigation,
-                              policy: FactoryBot.create(:private_policy))
-    source_sample_type = study.sample_types.first
-    sample_collection_sample_type = study.sample_types.second
-
-    assay_stream = FactoryBot.create(:assay_stream, study: study, policy: FactoryBot.create(:private_policy))
-    assay = FactoryBot.create(:isa_json_compliant_material_assay, assay_stream: assay_stream, study: study,
-                              linked_sample_type: sample_collection_sample_type,
-                              policy: FactoryBot.create(:private_policy), position: 0)
-    material_assay_sample_type = assay.sample_type
-    source = FactoryBot.create(:isa_source, sample_type: source_sample_type, policy: FactoryBot.create(:private_policy))
-    sample = FactoryBot.create(:isa_sample, sample_type: sample_collection_sample_type, linked_samples: [source],
+    source = FactoryBot.create(:isa_source, sample_type: @source_sample_type, policy: FactoryBot.create(:private_policy))
+    sample = FactoryBot.create(:isa_sample, sample_type: @sample_collection_sample_type, linked_samples: [source],
                                policy: FactoryBot.create(:private_policy))
-    FactoryBot.create(:isa_material_assay_sample, sample_type: material_assay_sample_type, linked_samples: [sample],
+    FactoryBot.create(:isa_material_assay_sample, sample_type: @material_assay_sample_type, linked_samples: [sample],
                       policy: FactoryBot.create(:private_policy))
 
     logout
 
-    get :dynamic_table_data, params: { id: @project.id, study_id: study.id }
+    get :dynamic_table_data, params: { id: @project.id, study_id: @study.id }
 
     assert_response :success
     json = JSON.parse(response.body)
@@ -120,19 +107,14 @@ class SinglePagesControllerTest < ActionController::TestCase
   test 'dynamic table data should not contain unauthorized samples' do
     other_person = FactoryBot.create(:person)
 
-    investigation = FactoryBot.create(:investigation, is_isa_json_compliant: true, policy: FactoryBot.create(:public_policy))
-    study = FactoryBot.create(:isa_json_compliant_study, investigation: investigation,
-                              policy: FactoryBot.create(:public_policy))
-    source_sample_type = study.sample_types.first
-
-    visible_source = FactoryBot.create(:isa_source, title: 'visible source', sample_type: source_sample_type,
+    visible_source = FactoryBot.create(:isa_source, title: 'visible source', sample_type: @source_sample_type,
                                        contributor: @member, policy: FactoryBot.create(:public_policy))
-    FactoryBot.create(:isa_source, title: 'hidden source', sample_type: source_sample_type,
+    FactoryBot.create(:isa_source, title: 'hidden source', sample_type: @source_sample_type,
                       contributor: other_person, policy: FactoryBot.create(:private_policy))
 
     logout
 
-    get :dynamic_table_data, params: { id: @project.id, study_id: study.id }
+    get :dynamic_table_data, params: { id: @project.id, study_id: @study.id }
 
     assert_response :success
     json = JSON.parse(response.body)
@@ -148,26 +130,15 @@ class SinglePagesControllerTest < ActionController::TestCase
   end
 
   test 'dynamic table data should return an empty array when the requested assay is unauthorized' do
-    investigation = FactoryBot.create(:investigation, is_isa_json_compliant: true, policy: FactoryBot.create(:public_policy))
-    study = FactoryBot.create(:isa_json_compliant_study, investigation: investigation, policy: FactoryBot.create(:public_policy))
-    source_sample_type = study.sample_types.first
-    sample_collection_sample_type = study.sample_types.second
-
-    assay_stream = FactoryBot.create(:assay_stream, study: study, policy: FactoryBot.create(:private_policy))
-    assay = FactoryBot.create(:isa_json_compliant_material_assay, assay_stream: assay_stream, study: study,
-                              linked_sample_type: sample_collection_sample_type,
-                              policy: FactoryBot.create(:private_policy), position: 0)
-    material_assay_sample_type = assay.sample_type
-
-    source = FactoryBot.create(:isa_source, sample_type: source_sample_type, policy: FactoryBot.create(:public_policy))
-    sample = FactoryBot.create(:isa_sample, sample_type: sample_collection_sample_type, linked_samples: [source],
+    source = FactoryBot.create(:isa_source, sample_type: @source_sample_type, policy: FactoryBot.create(:public_policy))
+    sample = FactoryBot.create(:isa_sample, sample_type: @sample_collection_sample_type, linked_samples: [source],
                       policy: FactoryBot.create(:public_policy))
-    FactoryBot.create(:isa_material_assay_sample, sample_type: material_assay_sample_type, linked_samples: [sample],
+    FactoryBot.create(:isa_material_assay_sample, sample_type: @material_assay_sample_type, linked_samples: [sample],
                       policy: FactoryBot.create(:public_policy))
 
     logout
 
-    get :dynamic_table_data, params: { id: @project.id, study_id: study.id, assay_id: assay.id }
+    get :dynamic_table_data, params: { id: @project.id, study_id: @study.id, assay_id: @assay.id }
 
     assert_response :success
     json = JSON.parse(response.body)
@@ -177,24 +148,15 @@ class SinglePagesControllerTest < ActionController::TestCase
   end
 
   test 'dynamic table data for a public assay is unaffected by an unauthorized parent study' do
-    investigation = FactoryBot.create(:investigation, is_isa_json_compliant: true, policy: FactoryBot.create(:private_policy))
-    study = FactoryBot.create(:isa_json_compliant_study, investigation: investigation, policy: FactoryBot.create(:private_policy))
-    source_sample_type = study.sample_types.first
-    sample_collection_sample_type = study.sample_types.second
-
-    assay_stream = FactoryBot.create(:assay_stream, study: study, policy: FactoryBot.create(:public_policy))
-    assay = FactoryBot.create(:isa_json_compliant_material_assay, assay_stream: assay_stream, study: study,
-                              linked_sample_type: sample_collection_sample_type,
-                              policy: FactoryBot.create(:public_policy), position: 0)
-    source = FactoryBot.create(:isa_source, sample_type: source_sample_type, policy: FactoryBot.create(:public_policy))
-    sample = FactoryBot.create(:isa_sample, sample_type: sample_collection_sample_type, linked_samples: [source],
+    source = FactoryBot.create(:isa_source, sample_type: @source_sample_type, policy: FactoryBot.create(:public_policy))
+    sample = FactoryBot.create(:isa_sample, sample_type: @sample_collection_sample_type, linked_samples: [source],
                                policy: FactoryBot.create(:public_policy))
-    FactoryBot.create(:isa_material_assay_sample, sample_type: assay.sample_type, linked_samples: [sample],
+    FactoryBot.create(:isa_material_assay_sample, sample_type: @material_assay_sample_type, linked_samples: [sample],
                       policy: FactoryBot.create(:public_policy))
 
     logout
 
-    get :dynamic_table_data, params: { id: @project.id, study_id: study.id, assay_id: assay.id }
+    get :dynamic_table_data, params: { id: @project.id, study_id: @study.id, assay_id: @assay.id }
 
     assert_response :success
     json = JSON.parse(response.body)
@@ -206,12 +168,11 @@ class SinglePagesControllerTest < ActionController::TestCase
   end
 
   test 'should return dynamic table data for a public sample type' do
-    sample_type = FactoryBot.create(:isa_source_sample_type, policy: FactoryBot.create(:public_policy))
-    FactoryBot.create(:isa_source, sample_type: sample_type, policy: FactoryBot.create(:public_policy))
+    FactoryBot.create(:isa_source, sample_type: @source_sample_type, policy: FactoryBot.create(:public_policy))
 
     logout
 
-    get :dynamic_table_data, params: { id: @project.id, sample_type_id: sample_type.id }
+    get :dynamic_table_data, params: { id: @project.id, sample_type_id: @source_sample_type.id }
 
     assert_response :success
     json = JSON.parse(response.body)
@@ -220,12 +181,88 @@ class SinglePagesControllerTest < ActionController::TestCase
   end
 
   test 'dynamic table data should not error out for an unauthorized sample type' do
-    sample_type = FactoryBot.create(:isa_source_sample_type, policy: FactoryBot.create(:private_policy))
-    FactoryBot.create(:isa_source, sample_type: sample_type, policy: FactoryBot.create(:private_policy))
+    FactoryBot.create(:isa_source, sample_type: @source_sample_type, projects: [@project], policy: FactoryBot.create(:private_policy), contributor: @member)
 
+    # Authorized person
+    get :dynamic_table_data, params: { id: @project.id, sample_type_id: @source_sample_type.id }
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    refute json.key?('error')
+    assert_equal 1, json['data'].size
+
+    # Unauthenticated user
     logout
 
-    get :dynamic_table_data, params: { id: @project.id, sample_type_id: sample_type.id }
+    get :dynamic_table_data, params: { id: @project.id, sample_type_id: @source_sample_type.id }
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    refute json.key?('error')
+    assert_equal [], json['data']
+
+    unauthorized_person = FactoryBot.create(:person)
+
+    # Unauthorized user
+    login_as(unauthorized_person)
+    get :dynamic_table_data, params: { id: @project.id, sample_type_id: @source_sample_type.id }
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    refute json.key?('error')
+    assert_equal [], json['data']
+  end
+
+  test 'dynamic table data should not return a sample type belonging to a different project' do
+    other_project = FactoryBot.create(:project)
+    FactoryBot.create(:isa_source, sample_type: @source_sample_type, policy: FactoryBot.create(:public_policy))
+
+    get :dynamic_table_data, params: { id: @project.id, sample_type_id: @source_sample_type.id }
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    refute json.key?('error')
+    assert_equal [], json['data']
+  end
+
+  test 'dynamic table data should not return a study belonging to a different project' do
+    other_project = FactoryBot.create(:project)
+    other_investigation = FactoryBot.create(:investigation, is_isa_json_compliant: true, policy: FactoryBot.create(:public_policy),
+                                      projects: [other_project])
+    other_study = FactoryBot.create(:isa_json_compliant_study, investigation: other_investigation, policy: FactoryBot.create(:public_policy))
+    FactoryBot.create(:isa_source, sample_type: other_study.sample_types.first, policy: FactoryBot.create(:public_policy))
+
+    get :dynamic_table_data, params: { id: @project.id, study_id: other_study.id }
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    refute json.key?('error')
+    assert_equal [], json['data']
+  end
+
+  test 'dynamic table data should not return an assay that does not belong to the requested study' do
+    other_investigation = FactoryBot.create(:investigation, is_isa_json_compliant: true, policy: FactoryBot.create(:public_policy),
+                                            projects: [@project])
+    other_study = FactoryBot.create(:isa_json_compliant_study, investigation: other_investigation, policy: FactoryBot.create(:public_policy))
+    other_study.sample_types.each { |st| st.update!(projects: [@project]) }
+
+    other_source_sample_type = other_study.sample_types.first
+    other_sample_collection_sample_type = other_study.sample_types.second
+
+    other_source = FactoryBot.create(:isa_source, sample_type: other_source_sample_type, policy: FactoryBot.create(:public_policy))
+    other_sample = FactoryBot.create(:isa_sample, sample_type: other_sample_collection_sample_type, linked_samples: [other_source],
+                                     policy: FactoryBot.create(:public_policy), linked_samples: [other_source])
+
+    source = FactoryBot.create(:isa_source, sample_type: @source_sample_type, policy: FactoryBot.create(:public_policy))
+    sample = FactoryBot.create(:isa_sample, sample_type: @sample_collection_sample_type, linked_samples: [source],
+                               policy: FactoryBot.create(:public_policy))
+
+    FactoryBot.create(:isa_material_assay_sample, sample_type: @material_assay_sample_type, linked_samples: [sample],
+                      policy: FactoryBot.create(:public_policy))
+
+    # The assay belongs to `study`, not the requested `other_study`, so it should be rejected
+    # even though both are public and in the same project.
+    get :dynamic_table_data, params: { id: @project.id, study_id: other_study.id, assay_id: @assay.id }
 
     assert_response :success
     json = JSON.parse(response.body)

--- a/test/functional/single_pages_controller_test.rb
+++ b/test/functional/single_pages_controller_test.rb
@@ -149,7 +149,7 @@ class SinglePagesControllerTest < ActionController::TestCase
 
     logout
 
-    get :dynamic_table_data, params: { id: @project.id, study_id: @study.id, assay_id: @assay.id }
+    get :dynamic_table_data, params: { id: @project.id, study_id: @study.id, assay_id: private_assay.id }
 
     assert_response :success
     json = JSON.parse(response.body)
@@ -165,6 +165,7 @@ class SinglePagesControllerTest < ActionController::TestCase
     FactoryBot.create(:isa_material_assay_sample, sample_type: @material_assay_sample_type, linked_samples: [sample],
                       policy: FactoryBot.create(:public_policy))
 
+    @study.update!(policy: FactoryBot.create(:private_policy))
     logout
 
     get :dynamic_table_data, params: { id: @project.id, study_id: @study.id, assay_id: @assay.id }
@@ -265,7 +266,7 @@ class SinglePagesControllerTest < ActionController::TestCase
 
     other_source = FactoryBot.create(:isa_source, sample_type: other_source_sample_type, policy: FactoryBot.create(:public_policy))
     other_sample = FactoryBot.create(:isa_sample, sample_type: other_sample_collection_sample_type, linked_samples: [other_source],
-                                     policy: FactoryBot.create(:public_policy), linked_samples: [other_source])
+                                     policy: FactoryBot.create(:public_policy))
 
     source = FactoryBot.create(:isa_source, sample_type: @source_sample_type, policy: FactoryBot.create(:public_policy))
     sample = FactoryBot.create(:isa_sample, sample_type: @sample_collection_sample_type, linked_samples: [source],

--- a/test/functional/single_pages_controller_test.rb
+++ b/test/functional/single_pages_controller_test.rb
@@ -25,11 +25,11 @@ class SinglePagesControllerTest < ActionController::TestCase
 
   test 'should hide inaccessible items in treeview' do
     FactoryBot.create(:investigation, contributor: @member.person, policy: FactoryBot.create(:private_policy),
-                                      projects: [@project])
+                      projects: [@project])
 
     login_as(FactoryBot.create(:user))
     inv_two = FactoryBot.create(:investigation, contributor: User.current_user.person, policy: FactoryBot.create(:private_policy),
-                                                projects: [@project])
+                                projects: [@project])
 
     controller = TreeviewBuilder.new @project, nil
     result = controller.send(:build_tree_data)
@@ -38,5 +38,112 @@ class SinglePagesControllerTest < ActionController::TestCase
 
     assert_equal 'hidden item', json['children'][0]['text']
     assert_equal inv_two.title, json['children'][1]['text']
+  end
+
+  test 'should return dynamic table data when ISA-study is public' do
+    investigation = FactoryBot.create(:investigation, is_isa_json_compliant: true, policy: FactoryBot.create(:public_policy))
+    study = FactoryBot.create(:isa_json_compliant_study, investigation: investigation,
+                              policy: FactoryBot.create(:public_policy))
+    source_sample_type = study.sample_types.first
+    FactoryBot.create(:isa_source, sample_type: source_sample_type, policy: FactoryBot.create(:public_policy))
+
+    logout
+
+    get :dynamic_table_data, params: { id: @project.id, study_id: study.id }
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    refute json.key?('error')
+    assert_equal 1, json['data'].length
+    refute json['data'].flatten.include?('#HIDDEN')
+  end
+
+  test 'should return dynamic table data when ISA-assay is public' do
+    investigation = FactoryBot.create(:investigation, is_isa_json_compliant: true, policy: FactoryBot.create(:public_policy))
+    study = FactoryBot.create(:isa_json_compliant_study, investigation: investigation,
+                              policy: FactoryBot.create(:public_policy))
+    source_sample_type = study.sample_types.first
+    sample_collection_sample_type = study.sample_types.second
+
+    assay_stream = FactoryBot.create(:assay_stream, study: study, policy: FactoryBot.create(:public_policy))
+    assay = FactoryBot.create(:isa_json_compliant_material_assay, assay_stream: assay_stream, study: study,
+                              linked_sample_type: sample_collection_sample_type,
+                              policy: FactoryBot.create(:public_policy), position: 0)
+    material_assay_sample_type = assay.sample_type
+    source = FactoryBot.create(:isa_source, sample_type: source_sample_type, policy: FactoryBot.create(:public_policy))
+    sample = FactoryBot.create(:isa_sample, sample_type: sample_collection_sample_type, linked_samples: [source],
+                               policy: FactoryBot.create(:public_policy))
+    FactoryBot.create(:isa_material_assay_sample, sample_type: material_assay_sample_type, linked_samples: [sample],
+                      policy: FactoryBot.create(:public_policy))
+
+    logout
+
+    get :dynamic_table_data, params: { id: @project.id, study_id: study.id, assay_id: assay.id }
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    refute json.key?('error')
+    assert_equal 1, json['data'].length
+    refute json['data'].flatten.include?('#HIDDEN')
+  end
+
+  test 'dynamic table data should not have unauthorized items' do
+    investigation = FactoryBot.create(:investigation, is_isa_json_compliant: true, policy: FactoryBot.create(:private_policy))
+    study = FactoryBot.create(:isa_json_compliant_study, investigation: investigation,
+                              policy: FactoryBot.create(:private_policy))
+    source_sample_type = study.sample_types.first
+    sample_collection_sample_type = study.sample_types.second
+
+    assay_stream = FactoryBot.create(:assay_stream, study: study, policy: FactoryBot.create(:private_policy))
+    assay = FactoryBot.create(:isa_json_compliant_material_assay, assay_stream: assay_stream, study: study,
+                              linked_sample_type: sample_collection_sample_type,
+                              policy: FactoryBot.create(:private_policy), position: 0)
+    material_assay_sample_type = assay.sample_type
+    source = FactoryBot.create(:isa_source, sample_type: source_sample_type, policy: FactoryBot.create(:private_policy))
+    sample = FactoryBot.create(:isa_sample, sample_type: sample_collection_sample_type, linked_samples: [source],
+                               policy: FactoryBot.create(:private_policy))
+    FactoryBot.create(:isa_material_assay_sample, sample_type: material_assay_sample_type, linked_samples: [sample],
+                      policy: FactoryBot.create(:private_policy))
+
+    logout
+
+    get :dynamic_table_data, params: { id: @project.id, study_id: study.id }
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    refute json.key?('error')
+    # Since Study and Assay are unauthorized, nothing should be returned
+    assert_equal 0, json['data'].length
+    assert json['data'].flatten.all? { |value| value == '#HIDDEN' }
+  end
+
+  test 'dynamic table data should not contain unauthorized samples' do
+    other_person = FactoryBot.create(:person)
+
+    investigation = FactoryBot.create(:investigation, is_isa_json_compliant: true, policy: FactoryBot.create(:public_policy))
+    study = FactoryBot.create(:isa_json_compliant_study, investigation: investigation,
+                              policy: FactoryBot.create(:public_policy))
+    source_sample_type = study.sample_types.first
+
+    visible_source = FactoryBot.create(:isa_source, title: 'visible source', sample_type: source_sample_type,
+                                       contributor: @member, policy: FactoryBot.create(:public_policy))
+    FactoryBot.create(:isa_source, title: 'hidden source', sample_type: source_sample_type,
+                      contributor: other_person, policy: FactoryBot.create(:private_policy))
+
+    logout
+
+    get :dynamic_table_data, params: { id: @project.id, study_id: study.id }
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    refute json.key?('error')
+    assert_equal 2, json['data'].length
+
+    visible_row = json['data'].detect { |row| row.include?(visible_source.id) }
+    hidden_row = json['data'].detect { |row| row != visible_row }
+
+    refute_nil visible_row
+    assert visible_row.none? { |value| value == '#HIDDEN' }
+    assert hidden_row.all? { |value| value == '#HIDDEN' || value.blank? }
   end
 end

--- a/test/functional/single_pages_controller_test.rb
+++ b/test/functional/single_pages_controller_test.rb
@@ -86,22 +86,31 @@ class SinglePagesControllerTest < ActionController::TestCase
   end
 
   test 'dynamic table data should not have unauthorized items' do
-    source = FactoryBot.create(:isa_source, sample_type: @source_sample_type, policy: FactoryBot.create(:private_policy))
-    sample = FactoryBot.create(:isa_sample, sample_type: @sample_collection_sample_type, linked_samples: [source],
+    first_source = FactoryBot.create(:isa_source, contributor: @member, sample_type: @source_sample_type, policy: FactoryBot.create(:private_policy))
+    _second_source = FactoryBot.create(:isa_source, contributor: @member, sample_type: @source_sample_type, policy: FactoryBot.create(:private_policy))
+    sample = FactoryBot.create(:isa_sample, contributor: @member, sample_type: @sample_collection_sample_type, linked_samples: [first_source],
                                policy: FactoryBot.create(:private_policy))
-    FactoryBot.create(:isa_material_assay_sample, sample_type: @material_assay_sample_type, linked_samples: [sample],
+    FactoryBot.create(:isa_material_assay_sample, contributor: @member, sample_type: @material_assay_sample_type, linked_samples: [sample],
                       policy: FactoryBot.create(:private_policy))
 
     logout
+
+    # Since Study and Assay samples are private, nothing should be returned
+    get :dynamic_table_data, params: { id: @project.id, study_id: @study.id, assay_id: @assay.id }
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    refute json.key?('error')
+    assert_equal 1, json['data'].length
+    assert json['data'].flatten.all? { |value| value == '#HIDDEN' }
 
     get :dynamic_table_data, params: { id: @project.id, study_id: @study.id }
 
     assert_response :success
     json = JSON.parse(response.body)
     refute json.key?('error')
-    # Since Study and Assay are unauthorized, nothing should be returned
-    assert_equal 0, json['data'].length
-    assert json['data'].flatten.all? { |value| value == '#HIDDEN' }
+    assert_equal 2, json['data'].length
+    assert json['data'].flatten.all? { |value| value == '#HIDDEN' || value.blank? }
   end
 
   test 'dynamic table data should not contain unauthorized samples' do
@@ -133,7 +142,9 @@ class SinglePagesControllerTest < ActionController::TestCase
     source = FactoryBot.create(:isa_source, sample_type: @source_sample_type, policy: FactoryBot.create(:public_policy))
     sample = FactoryBot.create(:isa_sample, sample_type: @sample_collection_sample_type, linked_samples: [source],
                       policy: FactoryBot.create(:public_policy))
-    FactoryBot.create(:isa_material_assay_sample, sample_type: @material_assay_sample_type, linked_samples: [sample],
+    private_assay = FactoryBot.create(:isa_json_compliant_material_assay, study: @study, assay_stream: @assay.assay_stream, linked_sample_type: @sample_collection_sample_type, contributor: @member, policy: FactoryBot.create(:private_policy))
+    private_assay_sample_type = private_assay.sample_type
+    FactoryBot.create(:isa_material_assay_sample, sample_type: private_assay_sample_type, linked_samples: [sample],
                       policy: FactoryBot.create(:public_policy))
 
     logout
@@ -168,7 +179,7 @@ class SinglePagesControllerTest < ActionController::TestCase
   end
 
   test 'should return dynamic table data for a public sample type' do
-    FactoryBot.create(:isa_source, sample_type: @source_sample_type, policy: FactoryBot.create(:public_policy))
+    FactoryBot.create(:isa_source, contributor: @member, sample_type: @source_sample_type, policy: FactoryBot.create(:public_policy))
 
     logout
 
@@ -181,31 +192,34 @@ class SinglePagesControllerTest < ActionController::TestCase
   end
 
   test 'dynamic table data should not error out for an unauthorized sample type' do
-    FactoryBot.create(:isa_source, sample_type: @source_sample_type, projects: [@project], policy: FactoryBot.create(:private_policy), contributor: @member)
+    private_study = FactoryBot.create(:isa_json_compliant_study, contributor: @member, investigation: @investigation, policy: FactoryBot.create(:private_policy))
+    private_source_sample_type = private_study.sample_types.first
+    FactoryBot.create(:isa_source, sample_type: private_source_sample_type, projects: [@project], policy: FactoryBot.create(:private_policy), contributor: @member)
 
-    # Authorized person
-    get :dynamic_table_data, params: { id: @project.id, sample_type_id: @source_sample_type.id }
+    # Authorized person sees the source with its metadata
+    get :dynamic_table_data, params: { id: @project.id, sample_type_id: private_source_sample_type.id }
 
     assert_response :success
     json = JSON.parse(response.body)
     refute json.key?('error')
     assert_equal 1, json['data'].size
+    refute json['data'].flatten.include?('#HIDDEN')
 
-    # Unauthenticated user
+    # Unauthenticated user does not get to see any sources
     logout
 
-    get :dynamic_table_data, params: { id: @project.id, sample_type_id: @source_sample_type.id }
+    get :dynamic_table_data, params: { id: @project.id, sample_type_id: private_source_sample_type.id }
 
     assert_response :success
     json = JSON.parse(response.body)
     refute json.key?('error')
     assert_equal [], json['data']
 
+    # Unauthorized user does not get to see any sources
     unauthorized_person = FactoryBot.create(:person)
 
-    # Unauthorized user
     login_as(unauthorized_person)
-    get :dynamic_table_data, params: { id: @project.id, sample_type_id: @source_sample_type.id }
+    get :dynamic_table_data, params: { id: @project.id, sample_type_id: private_source_sample_type.id }
 
     assert_response :success
     json = JSON.parse(response.body)
@@ -217,7 +231,7 @@ class SinglePagesControllerTest < ActionController::TestCase
     other_project = FactoryBot.create(:project)
     FactoryBot.create(:isa_source, sample_type: @source_sample_type, policy: FactoryBot.create(:public_policy))
 
-    get :dynamic_table_data, params: { id: @project.id, sample_type_id: @source_sample_type.id }
+    get :dynamic_table_data, params: { id: other_project.id, sample_type_id: @source_sample_type.id }
 
     assert_response :success
     json = JSON.parse(response.body)


### PR DESCRIPTION
- Fixes `dynamic_table_data` method for public items.
- closes #2674 
- Adds some permission checks
- Adds tests for the `dynamic_table_data` endpoint