### PR TITLE
Guard rendered_asset_view against a missing content blob file on disk

### DIFF
--- a/app/helpers/assets_helper.rb
+++ b/app/helpers/assets_helper.rb
@@ -43,6 +43,9 @@ module AssetsHelper
     if our_renderer.external_embed? && !cookie_consent.allow_embedding?
       # If embedding external content is not allowed, then server a link instead
       content = "This embedded content is blocked due to your cookie settings"
+    elsif !our_renderer.external_embed? && !asset.content_blob.file_exists?
+      # The renderer needs the local file content, but it is missing from the filestore
+      content = ''
     else
       content = Rails.cache.fetch("#{asset.cache_key}/#{asset.content_blob.cache_key}") do
         our_renderer.render

--- a/test/functional/data_files_controller_test.rb
+++ b/test/functional/data_files_controller_test.rb
@@ -386,7 +386,8 @@ class DataFilesControllerTest < ActionController::TestCase
   end
 
   test 'should show inline content preview for pdf data file' do
-    pdf_data_file = FactoryBot.create(:api_pdf_data_file, policy: FactoryBot.create(:downloadable_public_policy))
+    pdf_data_file = FactoryBot.create(:data_file, content_blob: FactoryBot.create(:pdf_content_blob),
+                                       policy: FactoryBot.create(:downloadable_public_policy))
     get :show, params: { id: pdf_data_file.id }
     assert_response :success
     assert_select 'div.renderer iframe', count: 1

--- a/test/functional/documents_controller_test.rb
+++ b/test/functional/documents_controller_test.rb
@@ -48,7 +48,8 @@ class DocumentsControllerTest < ActionController::TestCase
   end
 
   test 'should show inline content preview for pdf document' do
-    pdf_doc = FactoryBot.create(:api_pdf_document, policy: FactoryBot.create(:downloadable_public_policy))
+    pdf_doc = FactoryBot.create(:document, content_blob: FactoryBot.create(:pdf_content_blob),
+                                 policy: FactoryBot.create(:downloadable_public_policy))
     get :show, params: { id: pdf_doc.id }
     assert_response :success
     assert_select 'div.renderer iframe', count: 1

--- a/test/functional/file_templates_controller_test.rb
+++ b/test/functional/file_templates_controller_test.rb
@@ -48,7 +48,8 @@ class FileTemplatesControllerTest < ActionController::TestCase
   end
 
   test 'should show inline content preview for pdf file template' do
-    pdf_ft = FactoryBot.create(:api_pdf_file_template, policy: FactoryBot.create(:downloadable_public_policy))
+    pdf_ft = FactoryBot.create(:file_template, content_blob: FactoryBot.create(:pdf_content_blob),
+                                policy: FactoryBot.create(:downloadable_public_policy))
     get :show, params: { id: pdf_ft.id }
     assert_response :success
     assert_select 'div.renderer iframe', count: 1

--- a/test/unit/helpers/assets_helper_test.rb
+++ b/test/unit/helpers/assets_helper_test.rb
@@ -70,6 +70,22 @@ class AssetsHelperTest < ActionView::TestCase
     assert rendered_asset_view(pres).blank?
   end
 
+  test 'rendered_asset_view when the content blob file is missing on disk' do
+    person = FactoryBot.create(:admin)
+    User.current_user = person.user
+
+    df = FactoryBot.create(:data_file, content_blob: FactoryBot.create(:txt_content_blob),
+                            policy: FactoryBot.create(:public_policy))
+    assert df.content_blob.file_exists?
+    refute rendered_asset_view(df).blank?
+
+    File.delete(df.content_blob.filepath)
+    refute df.content_blob.file_exists?
+    assert_nothing_raised do
+      assert rendered_asset_view(df).blank?
+    end
+  end
+
   test 'authorised assets with lookup' do
     @assets = create_a_bunch_of_assets
     with_auth_lookup_enabled do


### PR DESCRIPTION
## Summary
- After deploying #2673, missing `.dat` files in the filestore were causing `Errno::ENOENT` background error emails when `rendered_asset_view` tried to render a preview.
- Renderers that need local file content (text, image, pdf, markdown, notebook, citation) now skip rendering (return blank) if the content blob's file is missing on disk, using the existing `ContentBlob#file_exists?` and `BlobRenderer#external_embed?`.
- Renderers that don't need local content (YouTube, Slideshare) are unaffected.