### PR TITLE
Always register searchable blocks so search indexes correctly on Docker (#2682)

### DIFF
--- a/app/models/assay.rb
+++ b/app/models/assay.rb
@@ -4,13 +4,11 @@ class Assay < ApplicationRecord
   belongs_to :assignee, class_name: 'Person'
 
   # needs to before acts_as_isa - otherwise auto_index=>false is overridden by Seek::Search::CommonFields
-  if Seek::Config.solr_enabled
-    searchable(auto_index: false) do
-      text :organism_terms, :human_disease_terms, :assay_type_label, :technology_type_label
+  searchable(auto_index: false) do
+    text :organism_terms, :human_disease_terms, :assay_type_label, :technology_type_label
 
-      text :strains do
-        strains.compact.map(&:title)
-      end
+    text :strains do
+      strains.compact.map(&:title)
     end
   end
 

--- a/app/models/concerns/has_controlled_vocabulary_annotations.rb
+++ b/app/models/concerns/has_controlled_vocabulary_annotations.rb
@@ -42,8 +42,6 @@ module HasControlledVocabularyAnnotations
     private
 
     def define_controlled_vocab_annotation_search_indexing(property)
-      return unless Seek::Config.solr_enabled
-
       searchable(auto_index: false) do
         text "#{property.to_s.singularize}_annotations".to_sym do
           controlled_vocab_annotation_labels(property)

--- a/app/models/concerns/has_extended_metadata.rb
+++ b/app/models/concerns/has_extended_metadata.rb
@@ -14,14 +14,12 @@ module HasExtendedMetadata
       has_one :extended_metadata, as: :item, dependent: :destroy, autosave: true
       accepts_nested_attributes_for :extended_metadata
 
-      if Seek::Config.solr_enabled
-        searchable(auto_index: false) do
-          text :extended_metadata_attribute_values do
-            extended_metadata_attribute_values_for_search
-          end
-          text :extended_metadata_type do
-            extended_metadata.extended_metadata_type.title if extended_metadata.present?
-          end
+      searchable(auto_index: false) do
+        text :extended_metadata_attribute_values do
+          extended_metadata_attribute_values_for_search
+        end
+        text :extended_metadata_type do
+          extended_metadata.extended_metadata_type.title if extended_metadata.present?
         end
       end
     end

--- a/app/models/concerns/has_external_identifier.rb
+++ b/app/models/concerns/has_external_identifier.rb
@@ -10,10 +10,8 @@ module HasExternalIdentifier
       include HasExternalIdentifier::InstanceMethods
       validate :check_external_identifier_unique_for_project
 
-      if Seek::Config.solr_enabled
-        searchable(auto_index: false) do
-          text :external_identifier
-        end
+      searchable(auto_index: false) do
+        text :external_identifier
       end
     end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -22,7 +22,7 @@ class Event < ApplicationRecord
 
   searchable(ignore_attribute_changes_of: [:updated_at], auto_index: false) do
     text :address, :city, :country, :url
-  end if Seek::Config.solr_enabled
+  end
 
   acts_as_authorized
   acts_as_uniquely_identifiable

--- a/app/models/external_asset.rb
+++ b/app/models/external_asset.rb
@@ -20,7 +20,7 @@ class ExternalAsset < ApplicationRecord
 
   after_initialize :options_from_json
 
-  after_save(:trigger_reindexing) if Seek::Config.solr_enabled
+  after_save(:trigger_reindexing)
 
   # as there is no callback for reload
   def reload

--- a/app/models/human_disease.rb
+++ b/app/models/human_disease.rb
@@ -60,12 +60,10 @@ class HumanDisease < ApplicationRecord
     end
   end
 
-  if Seek::Config.solr_enabled
-    searchable(auto_index: false) do
-      text :title
-      text :searchable_terms
-      text :doid_id
-    end
+  searchable(auto_index: false) do
+    text :title
+    text :searchable_terms
+    text :doid_id
   end
 
   def can_delete?(user = User.current_user)

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -22,7 +22,7 @@ class Institution < ApplicationRecord
 
   searchable(auto_index: false) do
     text :city, :address
-  end if Seek::Config.solr_enabled
+  end
 
 
   def title

--- a/app/models/isa_tag.rb
+++ b/app/models/isa_tag.rb
@@ -1,9 +1,7 @@
 class ISATag < ApplicationRecord
 
-  if Seek::Config.solr_enabled
-    searchable(auto_index: false) do
-      text :title
-    end
+  searchable(auto_index: false) do
+    text :title
   end
 
   validates :title, presence: true

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -14,7 +14,7 @@ class Model < ApplicationRecord
     text :recommended_environment do
       recommended_environment.try(:title)
     end
-  end if Seek::Config.solr_enabled
+  end
 
   acts_as_asset
 

--- a/app/models/organism.rb
+++ b/app/models/organism.rb
@@ -34,12 +34,10 @@ class Organism < ApplicationRecord
     end
   end
 
-  if Seek::Config.solr_enabled
-    searchable(auto_index: false) do
-      text :title
-      text :searchable_terms
-      text :ncbi_id
-    end
+  searchable(auto_index: false) do
+    text :title
+    text :searchable_terms
+    text :ncbi_id
   end
 
   def can_delete?(user = User.current_user)

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -103,13 +103,11 @@ class Person < ApplicationRecord
 
   has_many :sent_message_logs, class_name: 'MessageLog', foreign_key: :sender_id, dependent: :destroy
 
-  if Seek::Config.solr_enabled
-    searchable(auto_index: false) do
-      text :expertise
-      text :tools
-      text :disciplines do
-        disciplines.map(&:title)
-      end
+  searchable(auto_index: false) do
+    text :expertise
+    text :tools
+    text :disciplines do
+      disciplines.map(&:title)
     end
   end
 

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -2,12 +2,10 @@ class Programme < ApplicationRecord
   include Seek::Annotatable
   include Seek::Roles::Scope
 
-  if Seek::Config.solr_enabled
-    searchable(auto_index: false) do
-      text :funding_details
-      text :institutions do
-        institutions.compact.map(&:title)
-      end
+  searchable(auto_index: false) do
+    text :funding_details
+    text :institutions do
+      institutions.compact.map(&:title)
     end
   end
 

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -12,15 +12,13 @@ class Publication < ApplicationRecord
   alias_attribute :description, :abstract
 
   # searchable must come before acts_as_asset is called
-  if Seek::Config.solr_enabled
-    searchable(auto_index: false) do
-      text :journal, :pubmed_id, :doi, :published_date, :human_disease_terms
-      text :publication_authors do
-        seek_authors.map(&:person).collect(&:name)
-      end
-      text :non_seek_authors do
-        non_seek_authors.compact.map(&:first_name) | non_seek_authors.compact.map(&:last_name)
-      end
+  searchable(auto_index: false) do
+    text :journal, :pubmed_id, :doi, :published_date, :human_disease_terms
+    text :publication_authors do
+      seek_authors.map(&:person).collect(&:name)
+    end
+    text :non_seek_authors do
+      non_seek_authors.compact.map(&:first_name) | non_seek_authors.compact.map(&:last_name)
     end
   end
 

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -3,14 +3,12 @@ class Sample < ApplicationRecord
   include Seek::BioSchema::Support
   include Seek::JSONMetadata::Serialization
 
-  if Seek::Config.solr_enabled
-    searchable(auto_index: false) do
-      text :attribute_values do
-        attribute_values_for_search
-      end
-      text :sample_type do
-        sample_type.title
-      end
+  searchable(auto_index: false) do
+    text :attribute_values do
+      attribute_values_for_search
+    end
+    text :sample_type do
+      sample_type.title
     end
   end
 

--- a/app/models/sample_type.rb
+++ b/app/models/sample_type.rb
@@ -2,10 +2,8 @@ class SampleType < ApplicationRecord
   # attr_accessible :title, :uuid, :sample_attributes_attributes,
   #                 :description, :uploaded_template, :project_ids, :tags
 
-  if Seek::Config.solr_enabled
-    searchable(auto_index: false) do
-      text :attribute_search_terms
-    end
+  searchable(auto_index: false) do
+    text :attribute_search_terms
   end
 
   include Seek::ActsAsAsset::Searching

--- a/app/models/strain.rb
+++ b/app/models/strain.rb
@@ -55,7 +55,7 @@ class Strain < ApplicationRecord
       text :provider_id do
         provider_id
       end
-  end if Seek::Config.solr_enabled
+  end
 
   def is_default?
     title=="default" && is_dummy==true

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -4,7 +4,7 @@ class Study < ApplicationRecord
 
   searchable(:auto_index => false) do
     text :experimentalists
-  end if Seek::Config.solr_enabled
+  end
 
   belongs_to :investigation
   has_many :projects, through: :investigation

--- a/docker/seek_local_search_enabled.rb
+++ b/docker/seek_local_search_enabled.rb
@@ -1,19 +1,5 @@
-# Enables Solr search for the Docker image.
-#
-# This is set in two places on purpose. The `searchable ... if Seek::Config.solr_enabled`
-# guards in the models are evaluated at class-load time, which in production (eager_load)
-# happens *before* the main config defaults (config/initializers/seek_configuration.rb) run,
-# since those are loaded from an after_initialize block. If solr_enabled is not already true
-# at that point, nothing gets registered as searchable and search silently returns everything.
-#
-# before_eager_load runs after autoloading is set up but before the models are eager loaded,
-# so set the default there to ensure the searchable definitions are registered.
-Rails.application.config.before_eager_load do
-  Seek::Config.default :solr_enabled, true
-end
-
-# The main defaults run later (in after_initialize) and reset solr_enabled to false, so
-# re-assert it here afterwards so it also wins at runtime.
-Rails.application.config.after_initialize do
-  Seek::Config.default :solr_enabled, true
+Rails.configuration.after_initialize do
+  SEEK::Application.configure do
+    Seek::Config.default :solr_enabled, true
+  end
 end

--- a/docker/seek_local_search_enabled.rb
+++ b/docker/seek_local_search_enabled.rb
@@ -1,6 +1,19 @@
-Rails.configuration.after_initialize do
-  SEEK::Application.configure do
-    Seek::Config.default :solr_enabled, true
-  end
+# Enables Solr search for the Docker image.
+#
+# This is set in two places on purpose. The `searchable ... if Seek::Config.solr_enabled`
+# guards in the models are evaluated at class-load time, which in production (eager_load)
+# happens *before* the main config defaults (config/initializers/seek_configuration.rb) run,
+# since those are loaded from an after_initialize block. If solr_enabled is not already true
+# at that point, nothing gets registered as searchable and search silently returns everything.
+#
+# before_eager_load runs after autoloading is set up but before the models are eager loaded,
+# so set the default there to ensure the searchable definitions are registered.
+Rails.application.config.before_eager_load do
+  Seek::Config.default :solr_enabled, true
 end
 
+# The main defaults run later (in after_initialize) and reset solr_enabled to false, so
+# re-assert it here afterwards so it also wins at runtime.
+Rails.application.config.after_initialize do
+  Seek::Config.default :solr_enabled, true
+end

--- a/lib/seek/acts_as_asset/searching.rb
+++ b/lib/seek/acts_as_asset/searching.rb
@@ -33,7 +33,7 @@ module Seek
           text :git_content do
             git_search_terms if is_git_versioned?
           end
-        end if Seek::Config.solr_enabled
+        end
       end
     end
   end

--- a/lib/seek/acts_as_yellow_pages.rb
+++ b/lib/seek/acts_as_yellow_pages.rb
@@ -33,7 +33,7 @@ module Seek #:nodoc:
               locations
             end
           end
-        end if Seek::Config.solr_enabled
+        end
 
         class_eval do
           extend Seek::ActsAsYellowPages::SingletonMethods

--- a/lib/seek/doi/acts_as_doi_parent.rb
+++ b/lib/seek/doi/acts_as_doi_parent.rb
@@ -21,7 +21,7 @@ module Seek
             text :doi do
               dois
             end
-          end if Seek::Config.solr_enabled
+          end
 
           include Seek::Doi::ActsAsDoiParent::InstanceMethods
         end

--- a/lib/seek/research_objects/acts_as_snapshottable.rb
+++ b/lib/seek/research_objects/acts_as_snapshottable.rb
@@ -14,7 +14,7 @@ module Seek #:nodoc:
             text :doi do
               snapshots.map(&:doi).compact
             end
-          end if Seek::Config.solr_enabled
+          end
 
           include Seek::ResearchObjects::ActsAsSnapshottable::InstanceMethods
 

--- a/lib/seek/search/common_fields.rb
+++ b/lib/seek/search/common_fields.rb
@@ -4,30 +4,28 @@ module Seek
 
       def self.included(klass)
         klass.class_eval do
-          if Seek::Config.solr_enabled
-            searchable(auto_index: false) do
-              text :title do
-                title if respond_to?(:title)
-              end
-              text :description do
-                strip_markdown(description) if respond_to?(:description)
-              end
-              text :searchable_tags do
-                searchable_tags if respond_to?(:searchable_tags)
-              end
-              text :contributor do
-                contributor.try(:person).try(:name) if respond_to?(:contributor)
-              end
-              text :projects do
-                projects.collect(&:title) if respond_to?(:projects)
-              end
-              text :programmes do
-                programmes.collect(&:title) if respond_to?(:programmes)
-              end
+          searchable(auto_index: false) do
+            text :title do
+              title if respond_to?(:title)
+            end
+            text :description do
+              strip_markdown(description) if respond_to?(:description)
+            end
+            text :searchable_tags do
+              searchable_tags if respond_to?(:searchable_tags)
+            end
+            text :contributor do
+              contributor.try(:person).try(:name) if respond_to?(:contributor)
+            end
+            text :projects do
+              projects.collect(&:title) if respond_to?(:projects)
+            end
+            text :programmes do
+              programmes.collect(&:title) if respond_to?(:programmes)
+            end
 
-              text :external_asset do
-                external_asset_search_terms if respond_to?(:external_asset_search_terms)
-              end
+            text :external_asset do
+              external_asset_search_terms if respond_to?(:external_asset_search_terms)
             end
           end
 


### PR DESCRIPTION
Fixes #2682.

## Problem

On Docker/Docker-Compose deployments (where `solr_enabled` is true only via the code default, with no persisted `Settings` row), full-text search misbehaves: on the web side it returned **every viewable item** regardless of the query, and once that was worked around, the search index stayed **empty** and queries returned nothing.

## Root cause

Every `searchable` block was guarded by a class-load-time `if Seek::Config.solr_enabled` check. Sunspot's `searchable` is what defines `solr_index`/`solr_reindex`. In any process where `solr_enabled` isn't already true when the model class loads, the block never registers:

- **Web/puma** (eager load): nothing registered → `ApplicationRecord.with_search_query` fell through to its `else all` branch → search returned all viewable items.
- **delayed_job worker daemons**: the block still didn't register there, so `solr_index`/`solr_reindex` were undefined → every `ReindexingJob`/`ReindexAllJob` raised `NoMethodError`, which `BatchJob` swallows after `ReindexingQueue.dequeue` has already destroyed the queue entry → items were silently lost and Solr stayed empty.

## Fix

Always register the `searchable` blocks (remove the class-load `if Seek::Config.solr_enabled` guards) across the affected models and concerns, plus `ExternalAsset`'s `after_save(:trigger_reindexing)`. Everything that actually touches Solr remains gated at runtime by `Seek::Config.solr_enabled` (`with_search_query`, `SearchController`, `ReindexingJob#perform`, `Seek::Workers.active_queues`), so always defining the searchable setup costs nothing when Solr is disabled but guarantees the methods exist in every process.

This is the "always register" alternative described in the issue, and it supersedes the earlier `before_eager_load` workaround (which only fixed the web process, not the workers) — so `docker/seek_local_search_enabled.rb` is back to simply defaulting `solr_enabled` to true.

## Verification

Reproduced and verified against a running Docker-Compose stack:

- `rake seek:reindex_all` now populates the index with no errors (previously threw `undefined method 'solr_reindex'` for every type and indexed nothing).
- A save flows through the worker daemon and is indexed (previously `undefined method 'solr_index'`, swallowed).
- `/search?q=<term>` returns the matching item; a non-matching query returns an empty result set instead of everything.
