### PR TITLE
Thread-safety for `User.current_user` and `disable_authorization_checks`

### DIFF
--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -226,7 +226,7 @@ class Sample < ApplicationRecord
 
   # checks and validates whether new linked samples have view permission, but ignores existing ones
   def validate_added_linked_sample_permissions
-    return if $authorization_checks_disabled
+    return if authorization_checks_disabled?
     return if linked_samples.empty?
     previous_linked_samples = []
     previous_linked_samples = Sample.find(id).referenced_samples unless new_record?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -61,8 +61,6 @@ class User < ApplicationRecord
 
   acts_as_uniquely_identifiable
 
-  cattr_accessor :current_user
-
   delegate :is_admin?, to: :person, allow_nil: true
   delegate :is_project_administrator?, to: :person, allow_nil: true
   delegate :is_admin_or_project_administrator?, to: :person, allow_nil: true
@@ -274,6 +272,14 @@ class User < ApplicationRecord
     ensure
       User.current_user = previous
     end
+  end
+
+  def self.current_user= user
+    Thread.current[:current_user] = user
+  end
+
+  def self.current_user
+    Thread.current[:current_user]
   end
 
   def reset_password

--- a/app/validators/projects_validator.rb
+++ b/app/validators/projects_validator.rb
@@ -16,7 +16,7 @@
 #
 class ProjectsValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    return if $authorization_checks_disabled
+    return if authorization_checks_disabled?
     return if value.nil?
     return if record.contributor.nil?
     # For new resources, only allow the contributor's CURRENT projects.

--- a/lib/extensions/object.rb
+++ b/lib/extensions/object.rb
@@ -2,11 +2,23 @@ module Extensions
   module Object
     # Disables all authorization enforcement within the block passed to this method.
     def disable_authorization_checks
-      saved = $authorization_checks_disabled
-      $authorization_checks_disabled = true
+      saved = Thread.current[:authorization_checks_disabled]
+      Thread.current[:authorization_checks_disabled] = true
       yield
     ensure
-      $authorization_checks_disabled = saved
+      Thread.current[:authorization_checks_disabled] = saved
+    end
+
+    def authorization_checks_disabled?
+      !!Thread.current[:authorization_checks_disabled]
+    end
+
+    def disable_authorization_checks!
+      Thread.current[:authorization_checks_disabled] = true
+    end
+
+    def enable_authorization_checks!
+      Thread.current[:authorization_checks_disabled] = false
     end
   end
 end

--- a/lib/seek/permissions/authorization_enforcement.rb
+++ b/lib/seek/permissions/authorization_enforcement.rb
@@ -65,7 +65,7 @@ module Seek
       end
 
       def authorization_checks_enabled
-        !$authorization_checks_disabled && Seek::Config.authorization_checks_enabled
+        !authorization_checks_disabled? && Seek::Config.authorization_checks_enabled
       end
 
       def destroy_authorized?

--- a/test/unit/workflow_class_test.rb
+++ b/test/unit/workflow_class_test.rb
@@ -2,11 +2,11 @@ require 'test_helper'
 
 class WorkflowClassTest < ActiveSupport::TestCase
   setup do
-    $authorization_checks_disabled = true
+    disable_authorization_checks!
   end
 
   teardown do
-    $authorization_checks_disabled = false
+    enable_authorization_checks!
   end
 
   test 'validate uniqueness of workflow class title' do


### PR DESCRIPTION
Uses `Thread.current` to hold state instead of global/class vars.