### PR TITLE
Use Redis for Rack::Attack throttle counters (#2689)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,9 @@ script/delete-docker-redis.sh         # Remove the stopped container and its dat
 
 `REDIS_MAXMEMORY` (default `256mb`) sets the `maxmemory` limit. For `docker-compose.yml` it is read
 from `docker/redis.env`; for the scripts and the other compose variants it is a host env var. Redis
-backs both `Rails.cache` and sessions on one instance (`allkeys-lru`).
+backs `Rails.cache`, sessions and the `Rack::Attack` throttle counters on one instance
+(`allkeys-lru`). `Seek::RedisConfig.url` (`lib/seek/redis_config.rb`) is the single source of truth
+for the connection URL.
 
 ### Linting
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,8 +1,8 @@
 require_relative '../../lib/seek/redis_config'
 
-# Throttle counts are kept in Redis rather than in-process memory so that they are shared across
-# all app instances (web workers, multiple containers). With a memory store each instance counted
-# separately, so the effective limit was multiplied by the number of instances.
+# Throttle counts are kept in Redis so that all app instances (web workers, multiple containers)
+# share one count and a limit applies across the deployment as a whole. An in-process store would
+# count per instance, multiplying the effective limit by the number of instances.
 #
 # Tests use an in-memory store to avoid depending on a running Redis server.
 Rack::Attack.cache.store = if Rails.env.test?

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,23 +1,16 @@
-require_relative '../../lib/seek/redis_config'
+require_relative '../../lib/seek/rack_attack_store'
 
 # Throttle counts are kept in Redis so that all app instances (web workers, multiple containers)
 # share one count and a limit applies across the deployment as a whole. An in-process store would
 # count per instance, multiplying the effective limit by the number of instances.
 #
-# Tests use an in-memory store to avoid depending on a running Redis server.
+# Unit and functional tests use an in-memory store, so they neither need a Redis server nor leave
+# counters behind in one. Integration tests run against the Redis store this builds - see
+# Seek::RackAttackStore and test/test_helper.rb.
 Rack::Attack.cache.store = if Rails.env.test?
                              ActiveSupport::Cache::MemoryStore.new(size: 4.megabytes)
                            else
-                             ActiveSupport::Cache::RedisCacheStore.new(
-                               url: Seek::RedisConfig.url,
-                               namespace: 'rack-attack',
-                               # If Redis is unavailable the store returns nil rather than raising,
-                               # so requests are allowed through instead of erroring.
-                               error_handler: lambda { |method:, returning:, exception:|
-                                 Rails.logger.warn("Rack::Attack Redis cache error in #{method} " \
-                                                   "(returning #{returning.inspect}): #{exception.message}")
-                               }
-                             )
+                             Seek::RackAttackStore.build
                            end
 
 if Rails.env.production?

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,4 +1,24 @@
-Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new(size: 4.megabytes)
+require_relative '../../lib/seek/redis_config'
+
+# Throttle counts are kept in Redis rather than in-process memory so that they are shared across
+# all app instances (web workers, multiple containers). With a memory store each instance counted
+# separately, so the effective limit was multiplied by the number of instances.
+#
+# Tests use an in-memory store to avoid depending on a running Redis server.
+Rack::Attack.cache.store = if Rails.env.test?
+                             ActiveSupport::Cache::MemoryStore.new(size: 4.megabytes)
+                           else
+                             ActiveSupport::Cache::RedisCacheStore.new(
+                               url: Seek::RedisConfig.url,
+                               namespace: 'rack-attack',
+                               # If Redis is unavailable the store returns nil rather than raising,
+                               # so requests are allowed through instead of erroring.
+                               error_handler: lambda { |method:, returning:, exception:|
+                                 Rails.logger.warn("Rack::Attack Redis cache error in #{method} " \
+                                                   "(returning #{returning.inspect}): #{exception.message}")
+                               }
+                             )
+                           end
 
 if Rails.env.production?
   Rack::Attack.throttle('logins/username', limit: 10, period: 5.minutes) do |req|

--- a/lib/seek/rack_attack_store.rb
+++ b/lib/seek/rack_attack_store.rb
@@ -1,0 +1,26 @@
+require_relative 'redis_config'
+
+module Seek
+  # Builds the cache store holding Rack::Attack's throttle counters. Extracted from the initializer
+  # so that integration tests can install exactly the store the app runs with, rather than a
+  # near-copy that could drift from it.
+  #
+  # Loaded via require_relative from config/initializers/rack_attack.rb, so as with
+  # Seek::RedisConfig this must not depend on Zeitwerk autoloading being available.
+  module RackAttackStore
+    NAMESPACE = 'rack-attack'.freeze
+
+    def self.build
+      ActiveSupport::Cache::RedisCacheStore.new(
+        url: Seek::RedisConfig.url,
+        namespace: NAMESPACE,
+        # If Redis is unavailable the store returns nil rather than raising, so requests are allowed
+        # through instead of erroring.
+        error_handler: lambda { |method:, returning:, exception:|
+          Rails.logger.warn("Rack::Attack Redis cache error in #{method} " \
+                            "(returning #{returning.inspect}): #{exception.message}")
+        }
+      )
+    end
+  end
+end

--- a/lib/seek/redis_config.rb
+++ b/lib/seek/redis_config.rb
@@ -2,10 +2,10 @@ require 'cgi'
 
 module Seek
   # Single source of truth for the Redis connection URL, built from REDIS_HOST and (optionally)
-  # REDIS_PASSWORD. The cache store, the settings cache and the session store all go through here so
-  # they connect to the same server and all authenticate when a password is set - previously the
-  # session store built an authenticated URL while the cache stores read a bare REDIS_URL, so a
-  # password-protected Redis broke the cache while leaving sessions working.
+  # REDIS_PASSWORD. The cache store, the settings cache, the session store and the Rack::Attack
+  # throttle counters all go through here, so they connect to the same server and all authenticate
+  # when a password is set. Anything else needing Redis should use this too rather than reading the
+  # environment directly, otherwise a password-protected Redis works for some of them and not others.
   #
   # Loaded via require_relative from config/environments/*.rb, which are evaluated before Zeitwerk
   # autoloading is available, so this must not reference autoloaded constants or ActiveSupport core

--- a/test/integration/rack_attack_redis_test.rb
+++ b/test/integration/rack_attack_redis_test.rb
@@ -11,13 +11,17 @@ require 'test_helper'
 class RackAttackRedisTest < ActionDispatch::IntegrationTest
   LIMIT = 3
   PERIOD = 1.minute
+  CLIENT_IP = '10.0.0.1'.freeze
+  OTHER_IP = '10.0.0.2'.freeze
 
   setup do
     skip('these tests need a running Redis server') unless redis_available?
     Rack::Attack.clear_configuration
     Rack::Attack.throttle('integration/ip', limit: LIMIT, period: PERIOD, &:ip)
-    # A distinct IP per test run, so a counter left by an earlier run cannot affect this one.
-    @ip = "10.#{rand(256)}.#{rand(256)}.#{rand(256)}"
+    # Counters outlive the request that wrote them, so clear any left by an earlier run - otherwise
+    # a count carried over within the same period would throttle a client these tests expect to be
+    # under the limit. Only the rack-attack namespace is touched, not the cache or session keys.
+    store.clear
   end
 
   teardown do
@@ -36,11 +40,11 @@ class RackAttackRedisTest < ActionDispatch::IntegrationTest
   end
 
   # Rack::Attack's own key format, so the assertions look at the keys the middleware really writes.
-  def counter_key
-    "#{Rack::Attack.cache.prefix}:#{Time.now.to_i / PERIOD.to_i}:integration/ip:#{@ip}"
+  def counter_key(ip = CLIENT_IP)
+    "#{Rack::Attack.cache.prefix}:#{Time.now.to_i / PERIOD.to_i}:integration/ip:#{ip}"
   end
 
-  def request_status(ip: @ip)
+  def request_status(ip: CLIENT_IP)
     get '/', headers: { 'REMOTE_ADDR' => ip }
     response.status
   end
@@ -72,6 +76,6 @@ class RackAttackRedisTest < ActionDispatch::IntegrationTest
     (LIMIT + 1).times { request_status }
     assert_equal 429, request_status
 
-    refute_equal 429, request_status(ip: '10.99.99.99')
+    refute_equal 429, request_status(ip: OTHER_IP)
   end
 end

--- a/test/integration/rack_attack_redis_test.rb
+++ b/test/integration/rack_attack_redis_test.rb
@@ -1,0 +1,77 @@
+require 'test_helper'
+
+# Exercises Rack::Attack throttling against the store the app is configured with - a real Redis via
+# Seek::RackAttackStore - rather than the injected MockRedis backends the unit tests use
+# (test/unit/rack_attack_test.rb). This is where the counters meet a genuine Redis, covering the
+# INCR/EXPIRE behaviour and TTLs a mock cannot vouch for.
+#
+# Integration tests are configured with this store by test_helper.rb, so Rack::Attack.cache.store is
+# already the Redis one here. A reachable Redis is needed (the CI workflow runs redis:8.6-alpine on
+# localhost:6379, and the session store needs it regardless) and the test skips without one.
+class RackAttackRedisTest < ActionDispatch::IntegrationTest
+  LIMIT = 3
+  PERIOD = 1.minute
+
+  setup do
+    skip('these tests need a running Redis server') unless redis_available?
+    Rack::Attack.clear_configuration
+    Rack::Attack.throttle('integration/ip', limit: LIMIT, period: PERIOD, &:ip)
+    # A distinct IP per test run, so a counter left by an earlier run cannot affect this one.
+    @ip = "10.#{rand(256)}.#{rand(256)}.#{rand(256)}"
+  end
+
+  teardown do
+    Rack::Attack.clear_configuration
+    load Rails.root.join('config/initializers/rack_attack.rb')
+  end
+
+  def store
+    Rack::Attack.cache.store
+  end
+
+  def redis_available?
+    store.redis.with(&:ping) == 'PONG'
+  rescue StandardError
+    false
+  end
+
+  # Rack::Attack's own key format, so the assertions look at the keys the middleware really writes.
+  def counter_key
+    "#{Rack::Attack.cache.prefix}:#{Time.now.to_i / PERIOD.to_i}:integration/ip:#{@ip}"
+  end
+
+  def request_status(ip: @ip)
+    get '/', headers: { 'REMOTE_ADDR' => ip }
+    response.status
+  end
+
+  test 'integration tests are configured with the redis-backed store' do
+    assert_instance_of ActiveSupport::Cache::RedisCacheStore, store.__getobj__
+    assert_equal Seek::RackAttackStore::NAMESPACE, store.__getobj__.options[:namespace]
+  end
+
+  test 'requests are throttled and the counter is held in redis with a ttl' do
+    LIMIT.times { refute_equal 429, request_status }
+    assert_equal 429, request_status
+
+    assert_equal LIMIT + 1, store.read(counter_key).to_i
+    ttl = store.__getobj__.redis.with { |redis| redis.ttl("#{Seek::RackAttackStore::NAMESPACE}:#{counter_key}") }
+    assert ttl.positive?, "expected the counter to expire, got a TTL of #{ttl}"
+    assert ttl <= PERIOD.to_i
+  end
+
+  test 'a second store against the same redis sees the count, so instances share a limit' do
+    LIMIT.times { request_status }
+
+    # Rack::Attack writes counters with raw: true, so read them the same way.
+    other_instance = Seek::RackAttackStore.build
+    assert_equal LIMIT, other_instance.read(counter_key, raw: true).to_i
+  end
+
+  test 'throttling is keyed on the client, so other addresses are unaffected' do
+    (LIMIT + 1).times { request_status }
+    assert_equal 429, request_status
+
+    refute_equal 429, request_status(ip: '10.99.99.99')
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -304,6 +304,20 @@ if File.expand_path(Seek::Config.filestore_path).start_with?(File.expand_path(Fi
   FileUtils.rm_r(Seek::Config.filestore_path)
 end
 
+# Integration tests exercise the full stack, so they use the Redis-backed throttle store the app
+# actually runs with (the CI workflow provides a Redis server, which the session store needs
+# regardless). Unit and functional tests keep the in-memory store set up by the initializer.
+class ActionDispatch::IntegrationTest
+  setup do
+    @rack_attack_memory_store = Rack::Attack.cache.store
+    Rack::Attack.cache.store = Seek::RackAttackStore.build
+  end
+
+  teardown do
+    Rack::Attack.cache.store = @rack_attack_memory_store
+  end
+end
+
 class ActionController::TestCase
   def self._get_base_host
     # Cache host_with_port in a variable to avoid adding lots of overhead to each test

--- a/test/unit/rack_attack_test.rb
+++ b/test/unit/rack_attack_test.rb
@@ -1,0 +1,116 @@
+require 'test_helper'
+require 'minitest/mock'
+require 'mock_redis'
+
+# Rack::Attack keeps its throttle counters in a cache store. That store used to be an in-process
+# MemoryStore, so each app instance counted independently and the effective limit was multiplied by
+# the number of instances (see config/initializers/rack_attack.rb). These tests drive the real
+# Rack::Attack middleware to check that a Redis-backed store shares counts across instances, and
+# that the initializer wires the store up the way each environment needs.
+class RackAttackTest < ActiveSupport::TestCase
+  LIMIT = 3
+
+  setup do
+    @original_store = Rack::Attack.cache.store
+    @mock_redis = MockRedis.new
+    Rack::Attack.clear_configuration
+  end
+
+  teardown do
+    Rack::Attack.clear_configuration
+    Rack::Attack.cache.store = @original_store
+    # Reload the initializer so the app-wide configuration survives this test.
+    load Rails.root.join('config/initializers/rack_attack.rb')
+  end
+
+  # A store of the kind a single app instance would hold - separate objects, one shared Redis.
+  def instance_store
+    ActiveSupport::Cache::RedisCacheStore.new(redis: @mock_redis, namespace: 'rack-attack')
+  end
+
+  def app
+    Rack::Builder.new do
+      use Rack::Attack
+      run ->(_env) { [200, { 'content-type' => 'text/plain' }, ['ok']] }
+    end.to_app
+  end
+
+  def throttle_by_ip
+    Rack::Attack.throttle('test/ip', limit: LIMIT, period: 1.minute, &:ip)
+  end
+
+  def get(path = '/', ip: '1.2.3.4')
+    app.call(Rack::MockRequest.env_for(path, 'REMOTE_ADDR' => ip)).first
+  end
+
+  test 'requests are throttled once the limit is exceeded' do
+    Rack::Attack.cache.store = instance_store
+    throttle_by_ip
+
+    LIMIT.times { assert_equal 200, get }
+    assert_equal 429, get
+  end
+
+  test 'throttle counts are shared across app instances using the same redis' do
+    throttle_by_ip
+
+    # Each request is served by a different instance, i.e. a different store object, but they all
+    # talk to the same Redis - so between them they exhaust the limit.
+    LIMIT.times do
+      Rack::Attack.cache.store = instance_store
+      assert_equal 200, get
+    end
+
+    Rack::Attack.cache.store = instance_store
+    assert_equal 429, get
+  end
+
+  test 'separate memory stores do not share counts, which is the behaviour being replaced' do
+    throttle_by_ip
+
+    (LIMIT + 1).times do
+      Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+      assert_equal 200, get
+    end
+  end
+
+  test 'throttling is keyed on the discriminator, so other clients are unaffected' do
+    Rack::Attack.cache.store = instance_store
+    throttle_by_ip
+
+    (LIMIT + 1).times { get(ip: '1.2.3.4') }
+    assert_equal 429, get(ip: '1.2.3.4')
+    assert_equal 200, get(ip: '5.6.7.8')
+  end
+
+  test 'requests are allowed through when redis is unreachable' do
+    # Port 1 has nothing listening, so every call to the store raises a connection error.
+    Rack::Attack.cache.store = ActiveSupport::Cache::RedisCacheStore.new(
+      url: 'redis://localhost:1/0',
+      connect_timeout: 0.1,
+      error_handler: ->(method:, returning:, exception:) {}
+    )
+    throttle_by_ip
+
+    (LIMIT + 1).times { assert_equal 200, get }
+  end
+
+  test 'the test environment uses an in-memory store so no redis server is needed' do
+    load Rails.root.join('config/initializers/rack_attack.rb')
+
+    assert_instance_of ActiveSupport::Cache::MemoryStore, Rack::Attack.cache.store
+  end
+
+  test 'other environments use a namespaced redis store built from the shared redis url' do
+    Rails.env.stub(:test?, false) do
+      load Rails.root.join('config/initializers/rack_attack.rb')
+    end
+
+    # Rack::Attack wraps the configured store in a delegating proxy.
+    store = Rack::Attack.cache.store.__getobj__
+    assert_instance_of ActiveSupport::Cache::RedisCacheStore, store
+    assert_equal 'rack-attack', store.options[:namespace]
+    expected = ActiveSupport::Cache::RedisCacheStore.new(url: Seek::RedisConfig.url)
+    assert_equal expected.redis.with(&:id), store.redis.with(&:id)
+  end
+end

--- a/test/unit/rack_attack_test.rb
+++ b/test/unit/rack_attack_test.rb
@@ -6,7 +6,11 @@ require 'mock_redis'
 # so that a limit applies across every app instance rather than per instance (see
 # config/initializers/rack_attack.rb). These tests drive the real Rack::Attack middleware to check
 # that a Redis-backed store shares counts between instances, and that the initializer wires the
-# store up the way each environment needs.
+# store up correctly.
+#
+# The throttling logic itself is backend-agnostic, so these run against an in-memory MockRedis and
+# need no Redis server. Coverage of the configured store against a live Redis - the store the app
+# and the integration tests actually run with - is in test/integration/rack_attack_redis_test.rb.
 class RackAttackTest < ActiveSupport::TestCase
   LIMIT = 3
 
@@ -97,13 +101,13 @@ class RackAttackTest < ActiveSupport::TestCase
     (LIMIT + 1).times { assert_equal 200, get }
   end
 
-  test 'the test environment uses an in-memory store so no redis server is needed' do
+  test 'unit and functional tests get an in-memory store, so they need no redis server' do
     load Rails.root.join('config/initializers/rack_attack.rb')
 
     assert_instance_of ActiveSupport::Cache::MemoryStore, Rack::Attack.cache.store
   end
 
-  test 'other environments use a namespaced redis store built from the shared redis url' do
+  test 'other environments get a namespaced redis store built from the shared redis url' do
     Rails.env.stub(:test?, false) do
       load Rails.root.join('config/initializers/rack_attack.rb')
     end
@@ -111,7 +115,7 @@ class RackAttackTest < ActiveSupport::TestCase
     # Rack::Attack wraps the configured store in a delegating proxy.
     store = Rack::Attack.cache.store.__getobj__
     assert_instance_of ActiveSupport::Cache::RedisCacheStore, store
-    assert_equal 'rack-attack', store.options[:namespace]
+    assert_equal Seek::RackAttackStore::NAMESPACE, store.options[:namespace]
     expected = ActiveSupport::Cache::RedisCacheStore.new(url: Seek::RedisConfig.url)
     assert_equal expected.redis.with(&:id), store.redis.with(&:id)
   end

--- a/test/unit/rack_attack_test.rb
+++ b/test/unit/rack_attack_test.rb
@@ -2,11 +2,11 @@ require 'test_helper'
 require 'minitest/mock'
 require 'mock_redis'
 
-# Rack::Attack keeps its throttle counters in a cache store. That store used to be an in-process
-# MemoryStore, so each app instance counted independently and the effective limit was multiplied by
-# the number of instances (see config/initializers/rack_attack.rb). These tests drive the real
-# Rack::Attack middleware to check that a Redis-backed store shares counts across instances, and
-# that the initializer wires the store up the way each environment needs.
+# Rack::Attack keeps its throttle counters in a cache store, which SEEK points at the shared Redis
+# so that a limit applies across every app instance rather than per instance (see
+# config/initializers/rack_attack.rb). These tests drive the real Rack::Attack middleware to check
+# that a Redis-backed store shares counts between instances, and that the initializer wires the
+# store up the way each environment needs.
 class RackAttackTest < ActiveSupport::TestCase
   LIMIT = 3
 
@@ -65,7 +65,9 @@ class RackAttackTest < ActiveSupport::TestCase
     assert_equal 429, get
   end
 
-  test 'separate memory stores do not share counts, which is the behaviour being replaced' do
+  # The failure mode a shared store avoids: per-instance stores let each instance grant the full
+  # limit, so the deployment as a whole allows LIMIT * instances.
+  test 'separate in-process stores do not share counts' do
     throttle_by_ip
 
     (LIMIT + 1).times do


### PR DESCRIPTION
Fixes #2689.

`Rack::Attack` kept its throttle counters in an in-process `MemoryStore`, so each app instance counted independently and the effective limit was multiplied by the number of instances (web workers, containers).

The counters now go to the shared Redis, using `Seek::RedisConfig.url` — the same connection the cache, settings cache and sessions already use, so a `REDIS_PASSWORD` is picked up automatically — under a `rack-attack` namespace. Store construction lives in `Seek::RackAttackStore` so the initializer and the tests build the same store rather than near-copies that could drift apart.

- Redis errors are logged and fail **open**: if Redis is unreachable requests are allowed through rather than erroring.
- The throttle rules themselves are unchanged and still `production`-only.

### Tests

Unit and functional tests keep an in-memory store, so they need no Redis server and leave no counters behind in one. Integration tests install the Redis-backed store via `test_helper.rb`, so the store the app is actually configured with gets exercised — CI already runs a Redis service for the test job, and the session store needs it regardless.

- `test/unit/rack_attack_test.rb` drives the real middleware against an injected MockRedis: throttling at the limit, counts shared between separate store objects backed by one Redis, per-instance stores failing to share counts, per-discriminator keying, fail-open when Redis is down, and the store each environment gets.
- `test/integration/rack_attack_redis_test.rb` covers the same against a live Redis: that integration tests really do get the Redis store, that the counter lands in Redis with a positive TTL bounded by the throttle period, that a second store built the same way sees the count, and per-client keying. It skips when no Redis is reachable, matching `redis_overflow_cache_test.rb`.

### On the shared Redis and its eviction policy

Redis now holds three workloads on one instance — cache, sessions and throttle counters — under `maxmemory-policy allkeys-lru`. That policy is deliberately left unchanged, and is the safest of the available options
