### PR TITLE
Add "did you mean" spelling suggestions to the search (#2690)

### DIFF
--- a/app/assets/stylesheets/indexes.scss
+++ b/app/assets/stylesheets/indexes.scss
@@ -26,7 +26,7 @@
 
 /* "Did you mean ...?" spelling suggestion at the top of the search results */
 .spelling-suggestion {
-  font-size: 20px;
+  font-size: 16px;
   margin-bottom: 15px;
 
   .glyphicon {

--- a/app/assets/stylesheets/indexes.scss
+++ b/app/assets/stylesheets/indexes.scss
@@ -24,6 +24,22 @@
   width: 9em;
 }
 
+/* "Did you mean ...?" spelling suggestion at the top of the search results */
+.spelling-suggestion {
+  font-size: 20px;
+  margin-bottom: 15px;
+
+  .glyphicon {
+    color: $gray-light;
+    margin-right: 4px;
+  }
+
+  a {
+    font-weight: bold;
+    font-style: italic;
+  }
+}
+
 .list_item_content {
   font-size: 85%;
 }

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -30,18 +30,16 @@ class SearchController < ApplicationController
   end
 
   def perform_search(sources)
-    downcase_query = @search_query.downcase
-
     sources.each do |source|
-      @results[source.to_s] = source.with_search_query(downcase_query).authorized_for('view')
+      @results[source.to_s] = source.with_search_query(@search_query).authorized_for('view')
     end
 
     if search_params[:include_external_search] == '1'
       @include_external_search = true
-      @external_results = Seek::ExternalSearch.instance.external_search(downcase_query, @search_type&.downcase)
+      @external_results = Seek::ExternalSearch.instance.external_search(@search_query, @search_type&.downcase)
     end
 
-    @spelling_suggestion = spelling_suggestion(downcase_query, sources) unless request.format.json?
+    @spelling_suggestion = spelling_suggestion(@search_query, sources) unless request.format.json?
 
     @results
   end
@@ -59,7 +57,7 @@ class SearchController < ApplicationController
     search.execute
 
     collation = Array(search.solr_spellcheck['collations']).last
-    collation if collation.present? && collation.downcase != query
+    collation if collation.present? && collation.downcase != query.downcase
   rescue RSolr::Error::Http => e
     Rails.logger.warn("Unable to fetch spelling suggestions from Solr: #{e.message}")
     nil

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -58,7 +58,7 @@ class SearchController < ApplicationController
 
     collation = Array(search.solr_spellcheck['collations']).last
     collation if collation.present? && collation.downcase != query.downcase
-  rescue RSolr::Error::Http, RSolr::Error::ConnectionRefused => e
+  rescue StandardError => e
     Rails.logger.warn("Unable to fetch spelling suggestions from Solr: #{e.message}")
     nil
   end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -41,10 +41,29 @@ class SearchController < ApplicationController
       @external_results = Seek::ExternalSearch.instance.external_search(downcase_query, @search_type&.downcase)
     end
 
+    @spelling_suggestion = spelling_suggestion(downcase_query, sources) unless request.format.json?
+
     @results
   end
 
   private
+
+  # Asks Solr for a corrected spelling of the query, returning it only if it differs from what was typed.
+  # A suggestion is a nicety, so any problem talking to Solr is logged and ignored rather than failing the search.
+  def spelling_suggestion(query, sources)
+    search = Sunspot.new_search(*sources) do |s|
+      s.keywords(query)
+      s.spellcheck(q: query, collate: true)
+      s.paginate(page: 1, per_page: 1)
+    end
+    search.execute
+
+    collation = Array(search.solr_spellcheck['collations']).last
+    collation if collation.present? && collation.downcase != query
+  rescue RSolr::Error::Http => e
+    Rails.logger.warn("Unable to fetch spelling suggestions from Solr: #{e.message}")
+    nil
+  end
 
   def jump_straight_to_filtered_view?(sources)
     !request.format.json? && sources.count == 1 && search_params[:include_external_search] != '1'

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -58,7 +58,7 @@ class SearchController < ApplicationController
 
     collation = Array(search.solr_spellcheck['collations']).last
     collation if collation.present? && collation.downcase != query.downcase
-  rescue RSolr::Error::Http => e
+  rescue RSolr::Error::Http, RSolr::Error::ConnectionRefused => e
     Rails.logger.warn("Unable to fetch spelling suggestions from Solr: #{e.message}")
     nil
   end

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -9,6 +9,17 @@
   any = resource_hash.any? { |key, res| res[:items_count] > 0 || res[:hidden_count] > 0 }
 %>
 
+<% if @spelling_suggestion.present? %>
+  <p class="spelling-suggestion">
+    <span class="glyphicon glyphicon-search"></span>
+    Did you mean
+    <%= link_to @spelling_suggestion,
+                search_path(search_query: @spelling_suggestion,
+                            search_type: params[:search_type],
+                            include_external_search: params[:include_external_search]) %>?
+  </p>
+<% end %>
+
 <% unless !logged_in? || params[:saved_search] %>
   <%= alert_box do %>
     <%= savable_search_icon(search_path, 24, { search_query: params[:search_query] || params[:q],

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -11,7 +11,7 @@
 
 <% if @spelling_suggestion.present? %>
   <p class="spelling-suggestion">
-    <span class="glyphicon glyphicon-search"></span>
+    <span class="glyphicon glyphicon-search" aria-hidden="true"></span>
     Did you mean
     <%= link_to @spelling_suggestion,
                 search_path(search_query: @spelling_suggestion,

--- a/config/initializers/seek_testing.rb
+++ b/config/initializers/seek_testing.rb
@@ -79,6 +79,13 @@ def load_seek_testing_defaults!
       Settings.defaults[:solr_enabled] = true
       Sunspot.session = SunspotMatchers::SunspotSessionSpy.new(Sunspot.session)
 
+      # the spy has no Solr response behind it, so stub out the spellcheck block alongside the ones it already stubs
+      SunspotMatchers::SunspotSearchSpy.class_eval do
+        def solr_spellcheck
+          {}
+        end
+      end
+
       Settings.defaults[:filtering_enabled] = true
 
       Settings.defaults[:imprint_enabled]= false

--- a/solr/seek/conf/managed-schema
+++ b/solr/seek/conf/managed-schema
@@ -65,6 +65,17 @@
 
   <fieldType name="daterange" class="solr.DateRangeField" omitNorms="true"/>
 
+  <!-- Dictionary source for the spellcheck component. Deliberately plainer than
+       the "text" type - no n-gramming or word splitting, so that the terms
+       offered as suggestions are whole words as they appear in the content. -->
+  <fieldType name="spell" class="solr.TextField" positionIncrementGap="100">
+    <analyzer>
+      <tokenizer class="solr.StandardTokenizerFactory"/>
+      <filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="false"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+    </analyzer>
+  </fieldType>
+
   <!-- LatLonPointSpatialField replaces LatLonType (removed in Solr 7) -->
   <fieldType name="location" class="solr.LatLonPointSpatialField"/>
 
@@ -198,5 +209,12 @@
   <dynamicField name="*_llm" stored="false" type="location" multiValued="true" indexed="true"/>
   <dynamicField name="*_lls" stored="true" type="location" multiValued="false" indexed="true"/>
   <dynamicField name="*_llms" stored="true" type="location" multiValued="true" indexed="true"/>
+
+  <!-- Feeds the spellcheck component. Sunspot writes all full text into the
+       *_text dynamic fields, which are edge n-grammed and so unusable as a
+       spellcheck dictionary. -->
+  <field name="spellcheck_text" stored="false" type="spell" multiValued="true" indexed="true"/>
+  <copyField source="*_text" dest="spellcheck_text"/>
+  <copyField source="*_texts" dest="spellcheck_text"/>
 
 </schema>

--- a/solr/seek/conf/managed-schema
+++ b/solr/seek/conf/managed-schema
@@ -212,9 +212,10 @@
 
   <!-- Feeds the spellcheck component. Sunspot writes all full text into the
        *_text dynamic fields, which are edge n-grammed and so unusable as a
-       spellcheck dictionary. -->
-  <field name="spellcheck_text" stored="false" type="spell" multiValued="true" indexed="true"/>
-  <copyField source="*_text" dest="spellcheck_text"/>
-  <copyField source="*_texts" dest="spellcheck_text"/>
+       spellcheck dictionary. The name deliberately avoids a _text suffix so it
+       is not itself caught by the *_text copyField source glob below. -->
+  <field name="spellcheck_dictionary" stored="false" type="spell" multiValued="true" indexed="true"/>
+  <copyField source="*_text" dest="spellcheck_dictionary"/>
+  <copyField source="*_texts" dest="spellcheck_dictionary"/>
 
 </schema>

--- a/solr/seek/conf/solrconfig.xml
+++ b/solr/seek/conf/solrconfig.xml
@@ -504,8 +504,15 @@
   <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
     <lst name="spellchecker">
       <str name="name">default</str>
-      <str name="field">text</str>
-      <str name="buildOnCommit">true</str>
+      <str name="field">spellcheck_text</str>
+      <str name="classname">solr.DirectSolrSpellChecker</str>
+      <str name="distanceMeasure">internal</str>
+      <float name="accuracy">0.5</float>
+      <int name="maxEdits">2</int>
+      <int name="minPrefix">1</int>
+      <int name="maxInspections">5</int>
+      <int name="minQueryLength">4</int>
+      <float name="maxQueryFrequency">0.01</float>
     </lst>
   </searchComponent>
 

--- a/solr/seek/conf/solrconfig.xml
+++ b/solr/seek/conf/solrconfig.xml
@@ -504,7 +504,7 @@
   <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
     <lst name="spellchecker">
       <str name="name">default</str>
-      <str name="field">spellcheck_text</str>
+      <str name="field">spellcheck_dictionary</str>
       <str name="classname">solr.DirectSolrSpellChecker</str>
       <str name="distanceMeasure">internal</str>
       <float name="accuracy">0.5</float>

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -280,7 +280,7 @@ class SearchControllerTest < ActionController::TestCase
   test 'search query is passed to Solr with its original case' do
     # Solr's analysers lowercase for matching; the query must keep its case so uppercase
     # boolean operators (AND/OR/NOT) are recognised by edismax rather than downcased away.
-    FactoryBot.create_list(:public_document, 1)
+    FactoryBot.create(:public_document)
 
     received = []
     Document.stub(:solr_cache, -> (q) { received << q; Document.pluck(:id) }) do
@@ -292,7 +292,7 @@ class SearchControllerTest < ActionController::TestCase
   end
 
   test 'shows spelling suggestion when it differs from the query' do
-    FactoryBot.create_list(:public_document, 1)
+    FactoryBot.create(:public_document)
 
     with_spellcheck_collations(['collation', 'metabolomics']) do
       Document.stub(:solr_cache, -> (q) { Document.pluck(:id) }) do
@@ -307,7 +307,7 @@ class SearchControllerTest < ActionController::TestCase
   end
 
   test 'no spelling suggestion when the collation matches the query' do
-    FactoryBot.create_list(:public_document, 1)
+    FactoryBot.create(:public_document)
 
     with_spellcheck_collations(['collation', 'Metabolomics']) do
       Document.stub(:solr_cache, -> (q) { Document.pluck(:id) }) do
@@ -320,7 +320,7 @@ class SearchControllerTest < ActionController::TestCase
   end
 
   test 'no spelling suggestion when solr offers no collation' do
-    FactoryBot.create_list(:public_document, 1)
+    FactoryBot.create(:public_document)
 
     with_spellcheck_collations([]) do
       Document.stub(:solr_cache, -> (q) { Document.pluck(:id) }) do

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -277,6 +277,20 @@ class SearchControllerTest < ActionController::TestCase
     assert_select 'div#advanced-search input#include_external_search[type=checkbox][checked=checked]'
   end
 
+  test 'search query is passed to Solr with its original case' do
+    # Solr's analysers lowercase for matching; the query must keep its case so uppercase
+    # boolean operators (AND/OR/NOT) are recognised by edismax rather than downcased away.
+    FactoryBot.create_list(:public_document, 1)
+
+    received = []
+    Document.stub(:solr_cache, -> (q) { received << q; Document.pluck(:id) }) do
+      get :index, params: { q: 'cosmo OR headings' }
+    end
+
+    assert_includes received, 'cosmo OR headings'
+    refute_includes received, 'cosmo or headings'
+  end
+
   test 'shows spelling suggestion when it differs from the query' do
     FactoryBot.create_list(:public_document, 1)
 

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -276,4 +276,63 @@ class SearchControllerTest < ActionController::TestCase
     assert assigns(:include_external_search)
     assert_select 'div#advanced-search input#include_external_search[type=checkbox][checked=checked]'
   end
+
+  test 'shows spelling suggestion when it differs from the query' do
+    FactoryBot.create_list(:public_document, 1)
+
+    with_spellcheck_collations(['collation', 'metabolomics']) do
+      Document.stub(:solr_cache, -> (q) { Document.pluck(:id) }) do
+        get :index, params: { q: 'metabolomcs' }
+      end
+    end
+
+    assert_equal 'metabolomics', assigns(:spelling_suggestion)
+    assert_select 'p.spelling-suggestion' do
+      assert_select 'a[href=?]', search_path(search_query: 'metabolomics'), text: /metabolomics/
+    end
+  end
+
+  test 'no spelling suggestion when the collation matches the query' do
+    FactoryBot.create_list(:public_document, 1)
+
+    with_spellcheck_collations(['collation', 'Metabolomics']) do
+      Document.stub(:solr_cache, -> (q) { Document.pluck(:id) }) do
+        get :index, params: { q: 'Metabolomics' }
+      end
+    end
+
+    assert_nil assigns(:spelling_suggestion)
+    assert_select 'p.spelling-suggestion', count: 0
+  end
+
+  test 'no spelling suggestion when solr offers no collation' do
+    FactoryBot.create_list(:public_document, 1)
+
+    with_spellcheck_collations([]) do
+      Document.stub(:solr_cache, -> (q) { Document.pluck(:id) }) do
+        get :index, params: { q: 'metabolomics' }
+      end
+    end
+
+    assert_nil assigns(:spelling_suggestion)
+    assert_select 'p.spelling-suggestion', count: 0
+  end
+
+  private
+
+  # Stands in for the search Solr is asked to run purely for its spellcheck response
+  def with_spellcheck_collations(collations, &block)
+    search = Struct.new(:solr_spellcheck) do
+      def execute
+        self
+      end
+
+      # every other searchable type also runs through this stub, and finds nothing
+      def hits
+        []
+      end
+    end.new({ 'collations' => collations })
+
+    Sunspot.stub(:new_search, ->(*_args, &_blk) { search }, &block)
+  end
 end


### PR DESCRIPTION
Adds "did you mean …?" spelling suggestions to the search results page, and fixes two underlying search problems found along the way.

<img width="694" height="184" alt="image" src="https://github.com/user-attachments/assets/722cf463-7842-470d-a518-fabfae8c6055" />


Closes #2690.

## Spelling suggestions

The Solr spellcheck was previously non-functional: the spellchecker pointed at an empty `string` field with no `copyField` feeding it, so the dictionary was always empty. The full-text `*_text` fields could not be used directly because they are edge n-grammed.

- Added a plain `spell` field type (standard tokeniser + ASCII folding + lowercase, **no** n-gramming or word splitting) so suggestions are whole words as they appear in the content.
- Added a `spellcheck_dictionary` field fed by `copyField` from the `*_text` / `*_texts` full-text fields.
- Switched the spellchecker to `DirectSolrSpellChecker` (reads the live index, so no dictionary build / `buildOnCommit`), with `maxQueryFrequency` set so terms that actually exist in the index are not "corrected".
- The search controller runs a second, lightweight Solr query for the spellcheck response and shows the corrected collation at the top of the results **whenever it differs from what was typed** (case-insensitively), not only on zero results. Any Solr error during this lookup is logged and ignored so it can never affect the main search.
- Applies to the `/search` results page only, and is skipped for JSON responses.

## Boolean operators now work

The controller downcased the query before sending it to Solr, which turned an uppercase `OR`/`AND`/`NOT` into an ordinary lowercase word (edismax has `lowercaseOperators=false`). As a result `cosmo OR headings` was parsed as `cosmo headings` and ANDed together, returning nothing. Matching is already case-insensitive via the field analysers, so the downcase was redundant for matching and only broke the operators — it has been removed.

## Deployment note

Existing instances need the updated Solr `conf` deployed and a reindex for the dictionary to populate. `seek:upgrade` already triggers a reindex.
