### PR TITLE
Not adding remote files

### DIFF
--- a/app/models/concerns/workflow_extraction.rb
+++ b/app/models/concerns/workflow_extraction.rb
@@ -210,6 +210,11 @@ module WorkflowExtraction
         # TODO: Find a way to do this in populate_ro_crate (Without tmpdir disappearing when it comes to writing)
         if should_generate_crate? && is_git_versioned?
           git_version.in_temp_dir do |tmpdir|
+            crate.entities.each do |entity|
+              if !entity.nil? && entity.type == 'File' && entity.external? && !entity['localPath'].nil?
+                File.delete(File.join(tmpdir, entity['localPath']))
+              end
+            end
             crate.add_all(tmpdir, false, include_hidden: true)
             yield crate
           end

--- a/app/models/concerns/workflow_extraction.rb
+++ b/app/models/concerns/workflow_extraction.rb
@@ -211,9 +211,10 @@ module WorkflowExtraction
         if should_generate_crate? && is_git_versioned?
           git_version.in_temp_dir do |tmpdir|
             crate.entities.each do |entity|
-              if !entity.nil? && entity.type == 'File' && entity.external? && !entity['localPath'].nil?
-                File.delete(File.join(tmpdir, entity['localPath']))
-              end
+              next unless !entity.nil? && entity.type == 'File' && entity.external? && !entity['localPath'].nil?
+
+              full_path = File.join(tmpdir, entity['localPath'])
+              File.delete(full_path) if File.zero?(full_path)
             end
             crate.add_all(tmpdir, false, include_hidden: true)
             yield crate

--- a/app/models/concerns/workflow_extraction.rb
+++ b/app/models/concerns/workflow_extraction.rb
@@ -131,7 +131,7 @@ module WorkflowExtraction
       end
 
       remotes.each do |path, url|
-        crate.add_external_file(url)
+        crate.add_external_file(url, localPath: path)
       end
 
       crate['datePublished'] = git_version.commit_object&.time

--- a/test/integration/workflow_ro_crate_test.rb
+++ b/test/integration/workflow_ro_crate_test.rb
@@ -68,7 +68,7 @@ class WorkflowRoCrateTest < ActionDispatch::IntegrationTest
 
     Zip::File.open(zip) do |zipfile|
       assert zipfile.find_entry('ro-crate-metadata.json')
-      refute zipfile.find_entry('blah.txt')
+      assert zipfile.find_entry('blah.txt')
       refute zipfile.find_entry('blah2.txt')
     end
   end

--- a/test/integration/workflow_ro_crate_test.rb
+++ b/test/integration/workflow_ro_crate_test.rb
@@ -65,6 +65,12 @@ class WorkflowRoCrateTest < ActionDispatch::IntegrationTest
     remote2 = crate.get('http://internet.internet/another_file')
     assert remote2.is_a?(::ROCrate::File)
     assert_equal remote2.properties['localPath'], 'blah2.txt'
+
+    Zip::File.open(zip) do |zipfile|
+      assert zipfile.find_entry('ro-crate-metadata.json')
+      refute zipfile.find_entry('blah.txt')
+      refute zipfile.find_entry('blah2.txt')
+    end
   end
 
   test 'generate Workflow RO-Crate for repository containing symlink' do

--- a/test/integration/workflow_ro_crate_test.rb
+++ b/test/integration/workflow_ro_crate_test.rb
@@ -60,9 +60,11 @@ class WorkflowRoCrateTest < ActionDispatch::IntegrationTest
     crate = ROCrate::WorkflowCrateReader.read_zip(zip)
     remote1 = crate.get('http://internet.internet/file')
     assert remote1.is_a?(::ROCrate::File)
+    assert_equal remote1.properties['localPath'], 'blah.txt'
 
-    remote1 = crate.get('http://internet.internet/another_file')
-    assert remote1.is_a?(::ROCrate::File)
+    remote2 = crate.get('http://internet.internet/another_file')
+    assert remote2.is_a?(::ROCrate::File)
+    assert_equal remote2.properties['localPath'], 'blah2.txt'
   end
 
   test 'generate Workflow RO-Crate for repository containing symlink' do


### PR DESCRIPTION
Fixes #1829 

The directory that the crate is made from is created by a library, so we can't stop it being added in the first place. So we need to delete it from that folder before it is zipped into the RO-Crate.

This also adds the `localPath` property to remote files in downloaded crates. This is mainly because it is necessary for the deletion, but it is also allowed in the spec.