### PR TITLE
Filter out potentially invalid years from `YearFilter`

### DIFF
--- a/lib/seek/filtering/year_filter.rb
+++ b/lib/seek/filtering/year_filter.rb
@@ -13,9 +13,14 @@ module Seek
         t = collection.arel_table
         arel = years.inject(nil) do |arel, year|
           year = year.to_i
-          return collection.none if year < 1000 || year > 9999
-          dt = Time.new(year)
-          exp = t[field].gteq(dt.beginning_of_year).and(t[field].lteq(dt.end_of_year))
+          if year < 1000 || year > 9999
+            exp = Arel::Nodes::False.new # Basically a "no op". Equivalent of "1=0" in SQL, i.e.
+                                         #  it will return an empty set if it's the only condition,
+                                         #  or will do nothing if it's used in an "OR".
+          else
+            dt = Time.new(year)
+            exp = t[field].gteq(dt.beginning_of_year).and(t[field].lteq(dt.end_of_year))
+          end
           arel ? arel.or(exp) : exp
         end
 

--- a/lib/seek/filtering/year_filter.rb
+++ b/lib/seek/filtering/year_filter.rb
@@ -12,7 +12,9 @@ module Seek
 
         t = collection.arel_table
         arel = years.inject(nil) do |arel, year|
-          dt = Time.new(year.to_i)
+          year = year.to_i
+          return collection.none if year < 1000 || year > 9999
+          dt = Time.new(year)
           exp = t[field].gteq(dt.beginning_of_year).and(t[field].lteq(dt.end_of_year))
           arel ? arel.or(exp) : exp
         end

--- a/test/unit/filter_test.rb
+++ b/test/unit/filter_test.rb
@@ -144,6 +144,7 @@ class FilterTest < ActiveSupport::TestCase
     assert_empty year_filter.apply(Publication.all, ['banana']).to_a
     assert_empty year_filter.apply(Publication.all, ['999']).to_a
     assert_empty year_filter.apply(Publication.all, ['50000']).to_a
+    assert_includes_all year_filter.apply(Publication.all, ['2019', '50000']).to_a, [new_pub, newish_pub]
   end
 
   test 'get filter options' do

--- a/test/unit/filter_test.rb
+++ b/test/unit/filter_test.rb
@@ -142,6 +142,8 @@ class FilterTest < ActiveSupport::TestCase
     assert_includes_all year_filter.apply(Publication.all, ['2019', '1970']).to_a, [new_pub, newish_pub, old_pub]
     assert_empty year_filter.apply(Publication.all, ['1996']).to_a
     assert_empty year_filter.apply(Publication.all, ['banana']).to_a
+    assert_empty year_filter.apply(Publication.all, ['999']).to_a
+    assert_empty year_filter.apply(Publication.all, ['50000']).to_a
   end
 
   test 'get filter options' do


### PR DESCRIPTION
would previously trigger an `Mysql2::Error: Incorrect DATE value` error on some versions of MySQL.

Restricts the range to 1000 - 9999, which seems to be the "safest".