### PR TITLE
Readme relative links

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -211,7 +211,7 @@ module ApplicationHelper
     return "<li><div class='none_text'> None specified</div></li>".html_safe if is_nil_or_empty?(list)
   end
 
-  def render_markdown(markdown, relative_root = '')
+  def render_markdown(markdown, relative_root: nil)
     Seek::Markdown.render(markdown, relative_root)
   end
 
@@ -230,7 +230,7 @@ module ApplicationHelper
       if options[:markdown]
         # Convert `&gt;` etc. back to `>` so markdown blockquotes can be used.
         # The markdown renderer will cope with rogue `>`s that are not part of quotes.
-        res = render_markdown(CGI::unescapeHTML(res), options[:markdown_relative_root])
+        res = render_markdown(CGI::unescapeHTML(res), relative_root: options[:markdown_relative_root])
       elsif options[:description] || options[:address]
         res = simple_format(res, {}, sanitize: false).html_safe
       end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -211,8 +211,8 @@ module ApplicationHelper
     return "<li><div class='none_text'> None specified</div></li>".html_safe if is_nil_or_empty?(list)
   end
 
-  def render_markdown(markdown)
-    Seek::Markdown.render(markdown)
+  def render_markdown(markdown, relative_root)
+    Seek::Markdown.render(markdown, relative_root)
   end
 
   def text_or_not_specified(text, options = {})
@@ -230,7 +230,7 @@ module ApplicationHelper
       if options[:markdown]
         # Convert `&gt;` etc. back to `>` so markdown blockquotes can be used.
         # The markdown renderer will cope with rogue `>`s that are not part of quotes.
-        res = render_markdown(CGI::unescapeHTML(res))
+        res = render_markdown(CGI::unescapeHTML(res), options[:markdown_relative_root])
       elsif options[:description] || options[:address]
         res = simple_format(res, {}, sanitize: false).html_safe
       end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -211,7 +211,7 @@ module ApplicationHelper
     return "<li><div class='none_text'> None specified</div></li>".html_safe if is_nil_or_empty?(list)
   end
 
-  def render_markdown(markdown, relative_root)
+  def render_markdown(markdown, relative_root = '')
     Seek::Markdown.render(markdown, relative_root)
   end
 

--- a/app/views/assets/_item_description.html.erb
+++ b/app/views/assets/_item_description.html.erb
@@ -7,5 +7,5 @@
     <b><%= label -%>:</b>
 <% end %>
 <div id="description" class="markdown-body seek-description">
-  <%= text_or_not_specified(description, description: true, auto_link: true, none_text: none_text, markdown: true) %>
+  <%= text_or_not_specified(description, description: true, auto_link: true, none_text: none_text, markdown: true, markdown_relative_root: '/workflows/3/git/1/raw/') %>
 </div>

--- a/app/views/assets/_item_description.html.erb
+++ b/app/views/assets/_item_description.html.erb
@@ -1,11 +1,12 @@
 <%
   label ||= ""
   none_text ||= nil
+  relative_root ||= nil
 -%>
 
 <% unless label.blank? %>
     <b><%= label -%>:</b>
 <% end %>
 <div id="description" class="markdown-body seek-description">
-  <%= text_or_not_specified(description, description: true, auto_link: true, none_text: none_text, markdown: true, markdown_relative_root: '/workflows/3/git/1/raw/') %>
+  <%= text_or_not_specified(description, description: true, auto_link: true, none_text: none_text, markdown: true, markdown_relative_root: relative_root) %>
 </div>

--- a/app/views/workflows/show.html.erb
+++ b/app/views/workflows/show.html.erb
@@ -25,7 +25,8 @@
           <% end %>
         </div>
 
-        <%= render partial: "assets/item_description", locals: { description: @display_workflow.description, relative_root: '/workflows/3/git/1/raw/'}  %>
+        <%= render partial: "assets/item_description", locals: { description: @display_workflow.description, 
+                                                                 relative_root: polymorphic_path([@workflow, :git_raw], version: @display_workflow.version, path: '/')}  %>
 
         <% begin %>
           <% if @display_workflow.diagram_exists? || @display_workflow.can_render_diagram? %>

--- a/app/views/workflows/show.html.erb
+++ b/app/views/workflows/show.html.erb
@@ -25,7 +25,7 @@
           <% end %>
         </div>
 
-        <%= item_description(@display_workflow.description) %>
+        <%= render partial: "assets/item_description", locals: { description: @display_workflow.description, relative_root: '/workflows/3/git/1/raw/'}  %>
 
         <% begin %>
           <% if @display_workflow.diagram_exists? || @display_workflow.can_render_diagram? %>

--- a/app/views/workflows/show.html.erb
+++ b/app/views/workflows/show.html.erb
@@ -26,7 +26,7 @@
         </div>
 
         <%= render partial: "assets/item_description", locals: { description: @display_workflow.description, 
-                                                                 relative_root: polymorphic_path([@workflow, :git_raw], version: @display_workflow.version)}  %>
+                                                                 relative_root: polymorphic_path([@workflow, :git_raw], version: @display_workflow.version, path: 'dummy')}  %>
 
         <% begin %>
           <% if @display_workflow.diagram_exists? || @display_workflow.can_render_diagram? %>

--- a/app/views/workflows/show.html.erb
+++ b/app/views/workflows/show.html.erb
@@ -26,7 +26,7 @@
         </div>
 
         <%= render partial: "assets/item_description", locals: { description: @display_workflow.description, 
-                                                                 relative_root: polymorphic_path([@workflow, :git_raw], version: @display_workflow.version, path: '/')}  %>
+                                                                 relative_root: polymorphic_path([@workflow, :git_raw], version: @display_workflow.version)}  %>
 
         <% begin %>
           <% if @display_workflow.diagram_exists? || @display_workflow.can_render_diagram? %>

--- a/app/views/workflows/show.html.erb
+++ b/app/views/workflows/show.html.erb
@@ -26,7 +26,7 @@
         </div>
 
         <%= render partial: "assets/item_description", locals: { description: @display_workflow.description, 
-                                                                 relative_root: polymorphic_path([@workflow, :git_raw], version: @display_workflow.version, path: 'dummy')}  %>
+                                                                 relative_root: polymorphic_path([@workflow, :git_raw], version: @display_workflow.version, trailing_slash: true)}  %>
 
         <% begin %>
           <% if @display_workflow.diagram_exists? || @display_workflow.can_render_diagram? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -130,7 +130,7 @@ SEEK::Application.routes.draw do
       scope controller: :git, path: '/git(/*version)', constraints: { path: /[^\0]+/ }, format: false do
         get 'tree(/*path)' => 'git#tree', as: :git_tree
         get 'blob/*path' => 'git#blob', as: :git_blob
-        get 'raw/*path' => 'git#raw', as: :git_raw
+        get 'raw(/*path)' => 'git#raw', as: :git_raw
         get 'download/*path' => 'git#download', as: :git_download
         get 'browse' => 'git#browse', as: :git_browse
         post 'blob(/*path)' =>'git#add_file', as: :git_add_file

--- a/lib/seek/markdown.rb
+++ b/lib/seek/markdown.rb
@@ -27,12 +27,12 @@ module Seek
       end
 
       def handle_element(img)
-        return if img['src'].nil?
+        return if img['src'].nil? || context[:relative_root].nil?
 
         src = img['src'].strip
         return if src.start_with?('http')
 
-        img['src'] = URI.join(context[:base_url], context[:workflow_root], src).to_s
+        img['src'] = Addressable::URI.join(context[:relative_root], src).to_s
       end
     end
 
@@ -57,13 +57,12 @@ module Seek
     )
 
     # Renders a markdown string to HTML
-    def self.render(markdown)
+    def self.render(markdown, relative_root = nil)
       markdown = markdown.encode('UTF-8', invalid: :replace, undef: :replace)
       return '' if markdown.blank?
 
       context = {
-        workflow_root: '/workflows/3/git/1/raw/',
-        base_url: 'http://localhost:3000'
+        relative_root: relative_root
       }
       MarkdownPipeline.call(markdown, context: context)[:output]
     end

--- a/lib/seek/markdown.rb
+++ b/lib/seek/markdown.rb
@@ -30,7 +30,8 @@ module Seek
         return if img['src'].nil? || context[:relative_root].nil?
 
         src = img['src'].strip
-        return if src.start_with?('http')
+        src_uri = URI(src)
+        return if src_uri.absolute?
 
         src = src[1..] if src.start_with?('/')
 

--- a/lib/seek/markdown.rb
+++ b/lib/seek/markdown.rb
@@ -30,12 +30,17 @@ module Seek
         return if img['src'].nil? || context[:relative_root].nil?
 
         src = img['src'].strip
-        src_uri = URI(src)
+        src_uri = Addressable::URI.parse(src)
         return if src_uri.absolute?
 
         src = src[1..] if src.start_with?('/')
 
-        img['src'] = Addressable::URI.join(context[:relative_root], src).to_s
+        new_src = Addressable::URI.join(context[:relative_root], src).to_s
+
+        # This stops anyone from attempting to show something from another record
+        return unless new_src.include? context[:relative_root]
+
+        img['src'] = new_src
       end
     end
 

--- a/lib/seek/markdown.rb
+++ b/lib/seek/markdown.rb
@@ -32,6 +32,8 @@ module Seek
         src = img['src'].strip
         return if src.start_with?('http')
 
+        src = src[1..] if src.start_with?('/')
+
         img['src'] = Addressable::URI.join(context[:relative_root], src).to_s
       end
     end

--- a/lib/seek/markdown.rb
+++ b/lib/seek/markdown.rb
@@ -19,6 +19,23 @@ module Seek
       end
     end
 
+    class RelativeLinkFilter < HTMLPipeline::NodeFilter
+      SELECTOR = Selma::Selector.new(match_element: 'img')
+
+      def selector
+        SELECTOR
+      end
+
+      def handle_element(img)
+        return if img['src'].nil?
+
+        src = img['src'].strip
+        return if src.start_with?('http')
+
+        img['src'] = URI.join('http://localhost:3000', '/workflows/3/git/1/raw/', src).to_s
+      end
+    end
+
     MarkdownPipeline = HTMLPipeline.new(
       convert_filter: HTMLPipeline::ConvertFilter::MarkdownFilter.new(context: {
         markdown: {
@@ -26,7 +43,7 @@ module Seek
           extension: { tagfilter: true, table: true, strikethrough: true, autolink: true }
         }
       }),
-      node_filters: [LinkNofollowFilter.new]
+      node_filters: [LinkNofollowFilter.new, RelativeLinkFilter.new]
     )
 
     MarkdownPlainTextPipeline = HTMLPipeline.new(

--- a/lib/seek/markdown.rb
+++ b/lib/seek/markdown.rb
@@ -32,7 +32,7 @@ module Seek
         src = img['src'].strip
         return if src.start_with?('http')
 
-        img['src'] = URI.join('http://localhost:3000', '/workflows/3/git/1/raw/', src).to_s
+        img['src'] = URI.join(context[:base_url], context[:workflow_root], src).to_s
       end
     end
 
@@ -60,7 +60,12 @@ module Seek
     def self.render(markdown)
       markdown = markdown.encode('UTF-8', invalid: :replace, undef: :replace)
       return '' if markdown.blank?
-      MarkdownPipeline.call(markdown)[:output]
+
+      context = {
+        workflow_root: '/workflows/3/git/1/raw/',
+        base_url: 'http://localhost:3000'
+      }
+      MarkdownPipeline.call(markdown, context: context)[:output]
     end
 
     # Strips markdown tags from a string and returns plain text

--- a/test/functional/workflows_controller_test.rb
+++ b/test/functional/workflows_controller_test.rb
@@ -1775,10 +1775,10 @@ class WorkflowsControllerTest < ActionController::TestCase
     assert_select '.seek-description', count: 1
     assert_select '.seek-description img', count: 3
     assert_select '.seek-description img:nth-of-type(1)' do
-      assert_select ":match('src', ?)", %r{/workflows/\d*/git/1/test1/image.png}
+      assert_select ":match('src', ?)", %r{/workflows/\d*/git/1/raw/test1/image.png}
     end
     assert_select '.seek-description img:nth-of-type(2)' do
-      assert_select ":match('src', ?)", %r{/workflows/\d*/git/1/test2/image.png}
+      assert_select ":match('src', ?)", %r{/workflows/\d*/git/1/raw/test2/image.png}
     end
     assert_select '.seek-description img:nth-of-type(3)' do
       assert_select ":match('src', ?)", 'https://example.com/test3/image.png'

--- a/test/functional/workflows_controller_test.rb
+++ b/test/functional/workflows_controller_test.rb
@@ -1765,6 +1765,26 @@ class WorkflowsControllerTest < ActionController::TestCase
     assert_select '#download-group .dropdown-toggle', count: 1
   end
 
+  test 'should have description and update src property of images if they are relative' do
+    workflow = FactoryBot.create :ro_crate_git_workflow, policy: FactoryBot.create(:public_policy)
+
+    workflow.update(description: '<img src="test1/image.png"/><img src="/test2/image.png"/><img src="https://example.com/test3/image.png"/>')
+
+    get :show, params: { id: workflow }
+
+    assert_select '.seek-description', count: 1
+    assert_select '.seek-description img', count: 3
+    assert_select '.seek-description img:nth-of-type(1)' do
+      assert_select ":match('src', ?)", %r{/workflows/\d*/git/1/test1/image.png}
+    end
+    assert_select '.seek-description img:nth-of-type(2)' do
+      assert_select ":match('src', ?)", %r{/workflows/\d*/git/1/test2/image.png}
+    end
+    assert_select '.seek-description img:nth-of-type(3)' do
+      assert_select ":match('src', ?)", 'https://example.com/test3/image.png'
+    end
+  end
+
   test 'lists doi in index in table view' do
     Workflow.delete_all
 

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -435,6 +435,25 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_equal "<p>x🍌y</p>", Seek::Markdown.render("x🍌y")
   end
 
+  test 'markdown renderer handles img tag src being relative' do
+    assert_equal '<img src="/root/path/test/image.png" />',
+                 render_markdown('<img src="test/image.png" />', relative_root: '/root/path/')
+    assert_equal '<img src="/root/path/test/image.png" />',
+                 render_markdown('<img src="/test/image.png" />', relative_root: '/root/path/')
+  end
+
+  test 'markdown renderer does not change img tag src when absolute' do
+    assert_equal '<img src="http://www.example.com/test/image.png" />',
+                 render_markdown('<img src="http://www.example.com/test/image.png" />', relative_root: '/root/path/')
+  end
+
+  test 'markdown renderer does not update img tag src when relative root is not provided' do
+    assert_equal '<img src="test/image.png" />',
+                 render_markdown('<img src="test/image.png" />')
+    assert_equal '<img src="/test/image.png" />',
+                 render_markdown('<img src="/test/image.png" />')
+  end
+
   test 'markdown stripper removes markdown tags and HTML' do
    assert_equal "Hello\nThis is some markdown Yep alert('hi');hey http://hello.com a link",
                 Seek::Markdown.strip_markdown("# Hello\n\nThis <span>is</span> some **markdown** <table><tr><td>Yep <script>alert('hi');</script>hey</td></tr></table> http://hello.com [a link](http://link.com)")

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -442,6 +442,16 @@ class ApplicationHelperTest < ActionView::TestCase
                  render_markdown('<img src="/test/image.png" />', relative_root: '/root/path/')
   end
 
+  test 'markdown renderer handles path navigation within the workflow' do
+    assert_equal '<img src="/root/path/test/image.png" />',
+                 render_markdown('<img src="test/../test/image.png" />', relative_root: '/root/path/')
+  end
+
+  test 'markdown renderer rejects path that attempts to use a different root' do
+    assert_equal '<img src="/../../another_root/path/test/image.png" />',
+                 render_markdown('<img src="/../../another_root/path/test/image.png" />', relative_root: '/root/path/')
+  end
+
   test 'markdown renderer does not change img tag src when absolute' do
     assert_equal '<img src="http://www.example.com/test/image.png" />',
                  render_markdown('<img src="http://www.example.com/test/image.png" />', relative_root: '/root/path/')


### PR DESCRIPTION
Fixes #642. This could be extended to other places that use the markdown renderer, but for now the description of workflows was the only pace that had reported theses issues.