### PR TITLE
Handle non UTF-8 and very large content when rendering text previews

### DIFF
--- a/app/helpers/assets_helper.rb
+++ b/app/helpers/assets_helper.rb
@@ -47,7 +47,8 @@ module AssetsHelper
       # The renderer needs the local file content, but it is missing from the filestore
       content = ''
     else
-      content = Rails.cache.fetch("#{asset.cache_key}/#{asset.content_blob.cache_key}", expires_in: 30.days) do
+      cache_key = "#{asset.cache_key}/#{asset.content_blob.cache_key}/v#{Seek::Renderers::BlobRenderer::CACHE_VERSION}"
+      content = Rails.cache.fetch(cache_key, expires_in: 30.days) do
         our_renderer.render
       end
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -370,3 +370,6 @@ you can choose to have a %{project} linked to a site managed %{programme} instea
       general: An error occurred whilst fetching the citation
       invalid_style: Invalid citation style
       invalid_cff: "Couldn't extract the citation from the provided CFF file:"
+
+  renderers:
+    truncated_content: "Only the first %{size} of this file is shown, download the file to see the full content."

--- a/lib/seek/renderers/blob_renderer.rb
+++ b/lib/seek/renderers/blob_renderer.rb
@@ -3,6 +3,10 @@ module Seek
     class BlobRenderer
       include ActionView::Helpers
 
+      # forms part of the key for cached rendered content, and is bumped when a change to the
+      # renderers should invalidate content that has already been cached
+      CACHE_VERSION = 2
+
       attr_reader :blob, :params
 
       def initialize(git_blob_or_blob, url_options: {}, params: {})

--- a/lib/seek/renderers/text_renderer.rb
+++ b/lib/seek/renderers/text_renderer.rb
@@ -1,22 +1,27 @@
 module Seek
   module Renderers
     class TextRenderer < BlobRenderer
+      # the maximum amount of content that is rendered, anything beyond this is truncated
+      MAX_RENDERABLE_SIZE = 1.megabyte
+
       def can_render?
         blob.is_text?
       end
 
       def render_content
-        content = text_content
+        content, truncated = text_content
         if content.empty?
           '<span class="subtle">No content to display</span>'
         else
-          "<pre>#{h(content)}</pre>"
+          html = "<pre>#{h(content)}</pre>"
+          html << "<p class=\"subtle\">#{h(truncation_message)}</p>" if truncated
+          html
         end
-
       end
 
       def render_standalone
-        text_content
+        content, truncated = text_content
+        truncated ? "#{content}\n\n#{truncation_message}\n" : content
       end
 
       def format
@@ -25,10 +30,19 @@ module Seek
 
       private
 
-      # the content of the blob, with any bytes that aren't valid UTF-8 replaced, since they would
-      # otherwise break string handling and the encoding of the response
+      # the content of the blob, limited to MAX_RENDERABLE_SIZE, along with whether it was truncated.
+      # Bytes that aren't valid UTF-8 are replaced, since they would otherwise break string handling
+      # and the encoding of the response
       def text_content
-        blob.read.to_s.encode('UTF-8', invalid: :replace, undef: :replace)
+        content = blob.read(MAX_RENDERABLE_SIZE + 1).to_s.dup.force_encoding(Encoding::UTF_8)
+        truncated = content.bytesize > MAX_RENDERABLE_SIZE
+        content = content.byteslice(0, MAX_RENDERABLE_SIZE) if truncated
+        [content.encode('UTF-8', invalid: :replace, undef: :replace), truncated]
+      end
+
+      def truncation_message
+        "Only the first #{number_to_human_size(MAX_RENDERABLE_SIZE)} of this file is shown, " \
+          'download the file to see the full content.'
       end
     end
   end

--- a/lib/seek/renderers/text_renderer.rb
+++ b/lib/seek/renderers/text_renderer.rb
@@ -34,10 +34,16 @@ module Seek
       # Bytes that aren't valid UTF-8 are replaced, since they would otherwise break string handling
       # and the encoding of the response
       def text_content
+        blob.rewind
         content = blob.read(MAX_RENDERABLE_SIZE + 1).to_s.dup.force_encoding(Encoding::UTF_8)
         truncated = content.bytesize > MAX_RENDERABLE_SIZE
-        content = content.byteslice(0, MAX_RENDERABLE_SIZE) if truncated
-        [content.encode('UTF-8', invalid: :replace, undef: :replace), truncated]
+        content = content.encode('UTF-8', invalid: :replace, undef: :replace)
+        if content.bytesize > MAX_RENDERABLE_SIZE
+          # replacing invalid bytes can grow the content, and the limit may fall within a character
+          content = content.byteslice(0, MAX_RENDERABLE_SIZE).scrub('')
+          truncated = true
+        end
+        [content, truncated]
       end
 
       def truncation_message

--- a/lib/seek/renderers/text_renderer.rb
+++ b/lib/seek/renderers/text_renderer.rb
@@ -6,7 +6,7 @@ module Seek
       end
 
       def render_content
-        content = blob.read
+        content = text_content
         if content.empty?
           '<span class="subtle">No content to display</span>'
         else
@@ -16,11 +16,19 @@ module Seek
       end
 
       def render_standalone
-        blob.read
+        text_content
       end
 
       def format
         :plain
+      end
+
+      private
+
+      # the content of the blob, with any bytes that aren't valid UTF-8 replaced, since they would
+      # otherwise break string handling and the encoding of the response
+      def text_content
+        blob.read.to_s.encode('UTF-8', invalid: :replace, undef: :replace)
       end
     end
   end

--- a/lib/seek/renderers/text_renderer.rb
+++ b/lib/seek/renderers/text_renderer.rb
@@ -41,8 +41,7 @@ module Seek
       end
 
       def truncation_message
-        "Only the first #{number_to_human_size(MAX_RENDERABLE_SIZE)} of this file is shown, " \
-          'download the file to see the full content.'
+        I18n.t('renderers.truncated_content', size: number_to_human_size(MAX_RENDERABLE_SIZE))
       end
     end
   end

--- a/test/unit/cache_overflow_call_sites_test.rb
+++ b/test/unit/cache_overflow_call_sites_test.rb
@@ -13,7 +13,8 @@ class CacheOverflowCallSitesTest < ActiveSupport::TestCase
       /Rails\.cache\.fetch\("spreadsheet-workbook-.*expires_in:/,
     'lib/rightfield/rightfield.rb' =>
       [/Rails\.cache\.fetch\(".*_rf_csv", expires_in:/, /Rails\.cache\.fetch\(".*_rf_rdf", expires_in:/],
-    'app/helpers/assets_helper.rb' => /Rails\.cache\.fetch\(".*content_blob\.cache_key.*expires_in:/,
+    'app/helpers/assets_helper.rb' =>
+      [/cache_key = ".*content_blob\.cache_key.*"/, /Rails\.cache\.fetch\(cache_key, expires_in:/],
     'lib/seek/renderers/notebook_renderer.rb' => /Rails\.cache\.fetch\("notebook-.*expires_in:/,
     'lib/seek/ontologies/ontology_reader.rb' => /Rails\.cache\.fetch\(cache_key, expires_in:/,
     'lib/ebi/ols_client.rb' => [/Rails\.cache\.fetch\(key, expires_in:/,

--- a/test/unit/renderers_test.rb
+++ b/test/unit/renderers_test.rb
@@ -371,6 +371,22 @@ class RenderersTest < ActiveSupport::TestCase
     assert_equal '<span class="subtle">No content to display</span>', renderer.render
   end
 
+  test 'text renderer with content that is not valid UTF-8' do
+    blob = FactoryBot.create(:txt_content_blob, asset: @asset, data: "invalid \xFF\xFE bytes\n")
+    renderer = Seek::Renderers::TextRenderer.new(blob)
+    assert renderer.can_render?
+
+    content = renderer.render
+    assert content.valid_encoding?
+    @html = Nokogiri::HTML.parse(content)
+    assert_select 'pre', text: /invalid .+ bytes/
+
+    blob.rewind
+    standalone = renderer.render_standalone
+    assert standalone.valid_encoding?
+    assert standalone.start_with?('invalid ')
+  end
+
   test 'image renderer' do
     blob = FactoryBot.create(:image_content_blob, asset: @asset)
     renderer = Seek::Renderers::ImageRenderer.new(blob)

--- a/test/unit/renderers_test.rb
+++ b/test/unit/renderers_test.rb
@@ -387,6 +387,26 @@ class RenderersTest < ActiveSupport::TestCase
     assert standalone.start_with?('invalid ')
   end
 
+  test 'text renderer truncates large content' do
+    blob = FactoryBot.create(:large_txt_content_blob, asset: @asset)
+    assert blob.file_size > Seek::Renderers::TextRenderer::MAX_RENDERABLE_SIZE
+    renderer = Seek::Renderers::TextRenderer.new(blob)
+    assert renderer.can_render?
+
+    content = renderer.render
+    assert content.bytesize < blob.file_size
+    @html = Nokogiri::HTML.parse(content)
+    assert_select 'pre' do |elements|
+      assert elements.first.text.bytesize <= Seek::Renderers::TextRenderer::MAX_RENDERABLE_SIZE
+    end
+    assert_select 'p.subtle', text: /Only the first 1 MB of this file is shown/
+
+    blob.rewind
+    standalone = renderer.render_standalone
+    assert standalone.bytesize < blob.file_size
+    assert standalone.include?('Only the first 1 MB of this file is shown')
+  end
+
   test 'image renderer' do
     blob = FactoryBot.create(:image_content_blob, asset: @asset)
     renderer = Seek::Renderers::ImageRenderer.new(blob)

--- a/test/unit/renderers_test.rb
+++ b/test/unit/renderers_test.rb
@@ -381,10 +381,22 @@ class RenderersTest < ActiveSupport::TestCase
     @html = Nokogiri::HTML.parse(content)
     assert_select 'pre', text: /invalid .+ bytes/
 
-    blob.rewind
     standalone = renderer.render_standalone
     assert standalone.valid_encoding?
     assert standalone.start_with?('invalid ')
+  end
+
+  test 'text renderer limits the size of content that has been made valid UTF-8' do
+    max = Seek::Renderers::TextRenderer::MAX_RENDERABLE_SIZE
+    # each invalid byte is replaced by a 3 byte character, so the content grows as it is made valid
+    blob = FactoryBot.create(:txt_content_blob, asset: @asset, data: "\xFF" * max)
+    renderer = Seek::Renderers::TextRenderer.new(blob)
+
+    content = renderer.render
+    assert content.valid_encoding?
+    assert content.bytesize <= max + 1000, 'the rendered content should be limited after being made valid UTF-8'
+    @html = Nokogiri::HTML.parse(content)
+    assert_select 'p.subtle', text: /Only the first 1 MB of this file is shown/
   end
 
   test 'text renderer truncates large content' do
@@ -401,9 +413,12 @@ class RenderersTest < ActiveSupport::TestCase
     end
     assert_select 'p.subtle', text: /Only the first 1 MB of this file is shown/
 
-    blob.rewind
+    # rendering again reads the content from the start, rather than continuing where it left off
+    assert_equal content, renderer.render
+
     standalone = renderer.render_standalone
     assert standalone.bytesize < blob.file_size
+    assert standalone.start_with?(File.read(blob.filepath, 100))
     assert standalone.include?('Only the first 1 MB of this file is shown')
   end
 


### PR DESCRIPTION
Viewing an asset whose content blob is typed as text (e.g. `text/plain`, `text/xml`) but is not valid UTF-8 raised `ArgumentError: invalid byte sequence in UTF-8` from `app/helpers/assets_helper.rb`, so the show page could not be rendered at all.

Content read from a blob is tagged as UTF-8 without being validated. `CGI.escapeHTML` (used by `h`) passes invalid bytes straight through, so the invalid string escaped the renderer's own rescue and raised when the helper called `String#blank?` on it, since that runs a regexp match. `TextRenderer` now replaces invalid bytes, as `Seek::Markdown.render` already does.

Rendering a preview also read the whole file into memory, escaped it and cached the result, which is expensive for a large file and repeats for every viewer. Content is now limited to `TextRenderer::MAX_RENDERABLE_SIZE` (1MB), with a message indicating that it is truncated. The limit matches `cache_max_redis_item_size`, so a cached preview stays within a single Redis item.

Both the inline preview and the standalone view are affected.