### PR TITLE
Bump supercronic to v0.2.49 in the Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ ENV APP_DIR=/seek \
     BUNDLE_WITHOUT="development"
 
 # Supercronic variables
-ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.2.47/supercronic-linux-amd64 \
-    SUPERCRONIC_SHA1SUM=712d2ece75da6f6e530192a151488578153e4e96 \
+ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.2.49/supercronic-linux-amd64 \
+    SUPERCRONIC_SHA1SUM=e63c11a9726b775a6a11801e81af4f3fb926aa68 \
     SUPERCRONIC=supercronic-linux-amd64
 
 


### PR DESCRIPTION
Fixes #2657

Updates the supercronic pin in the `Dockerfile` from v0.2.47 to v0.2.49 (latest stable), along with its SHA1 checksum.

v0.2.48 and v0.2.49 are both Go toolchain and dependency updates upstream, with no functional or command line changes, so `docker/shared_functions.sh` and the `QUIET_SUPERCRONIC` handling are unaffected (`-quiet` is still supported).

The published checksum was verified against the downloaded release binary, and a locally built image was checked with a running stack: `supercronic -version` reports v0.2.49 and `supercronic -quiet /seek/seek.crontab` runs as expected in the `seek-workers` container.

The built image can be found at `fairdom/seek:supercronic` if you want to check it