### PR TITLE
Disable the Active Storage variant processor to fix image_processing gem warning

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,11 @@ module SEEK
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.2
     config.active_record.default_column_serializer = YAML
+
+    # Active Storage is unused, but its variant processor is resolved on boot and
+    # logs a warning unless the image_processing gem is present.
+    config.active_storage.variant_processor = :disabled
+
     # Force all environments to use the same logger level
     # Configuration for the application, engines, and railties goes here.
     # (by default production uses :info, the others :debug)


### PR DESCRIPTION
Every boot logs:

```
WARN -- : Generating image variants require the image_processing gem. Please add `gem "image_processing", "~> 1.2"` to your Gemfile or set `config.active_storage.variant_processor = :disabled`.
```

`config/application.rb` does `require 'rails/all'`, which loads Active Storage, and `config.load_defaults 7.2` sets its variant processor to `:vips`. Resolving the transformer during `after_initialize` raises `LoadError` for `image_processing` and logs the warning.

It is most visible under Docker, where the Rails log goes to stdout, but it happens everywhere — `log/development.log` here had 304 occurrences.

SEEK does not use Active Storage: there are no `has_one_attached`/`has_many_attached` declarations and no `active_storage_*` tables in the schema (avatars go through fleximage). Setting the processor to `:disabled` swaps in `ActiveStorage::Transformers::NullTransformer` and silences the warning, rather than adding an `image_processing` + libvips dependency for a feature nothing calls.