### PR TITLE
External file preview does not work

### DIFF
--- a/app/views/git/_blob.html.erb
+++ b/app/views/git/_blob.html.erb
@@ -48,12 +48,16 @@
 <hr/>
 
 <% renderer = Seek::Renderers::RendererFactory.instance.renderer(@blob) %>
-<% if renderer.is_a?(Seek::Renderers::BlankRenderer) %>
-  <span class="subtle">Binary content not displayed</span>
+<% if @blob.remote? && !@blob.fetched? %>
+  <span class="alert alert-info">This file is held externally</span>
 <% else %>
-  <% if renderer.external_embed? && !cookie_consent.allow_embedding? %>
-      This embedded content is blocked due to your cookie settings
+  <% if renderer.is_a?(Seek::Renderers::BlankRenderer) %>
+    <span class="subtle">Binary content not displayed</span>
   <% else %>
-    <%= renderer.render.html_safe %>
-  <%end %>
+    <% if renderer.external_embed? && !cookie_consent.allow_embedding? %>
+        This embedded content is blocked due to your cookie settings
+    <% else %>
+      <%= renderer.render.html_safe %>
+    <%end %>
+  <% end %>
 <% end %>

--- a/app/views/git/_blob.html.erb
+++ b/app/views/git/_blob.html.erb
@@ -48,7 +48,7 @@
 <hr/>
 
 <% renderer = Seek::Renderers::RendererFactory.instance.renderer(@blob) %>
-<% if @blob.remote? && !@blob.fetched? %>
+<% if @blob.remote? && !@blob.fetched? && !renderer.external_embed? %>
   <span class="alert alert-info">This file is held externally</span>
 <% else %>
   <% if renderer.is_a?(Seek::Renderers::BlankRenderer) %>

--- a/app/views/git/_blob.html.erb
+++ b/app/views/git/_blob.html.erb
@@ -49,7 +49,7 @@
 
 <% renderer = Seek::Renderers::RendererFactory.instance.renderer(@blob) %>
 <% if @blob.remote? && !@blob.fetched? && !renderer.external_embed? %>
-  <span class="alert alert-info">This file is held externally</span>
+  <span class="alert alert-info" role="alert">This file is held externally</span>
 <% else %>
   <% if renderer.is_a?(Seek::Renderers::BlankRenderer) %>
     <span class="subtle">Binary content not displayed</span>

--- a/test/functional/git_controller_test.rb
+++ b/test/functional/git_controller_test.rb
@@ -230,6 +230,7 @@ class GitControllerTest < ActionController::TestCase
     assert_select 'a.btn[href=?]', workflow_git_remove_file_path(@workflow, version: @git_version.version, path: 'something')
     assert_select 'a.btn[href=?]', 'https://example.com/something'
     assert_select 'img.git-image-preview[src=?]', workflow_git_raw_path(@workflow, version: @git_version.version, path: 'something'), count: 0
+    assert_select 'span', 'This file is held externally'
   end
 
   test 'get raw binary file' do

--- a/test/functional/git_controller_test.rb
+++ b/test/functional/git_controller_test.rb
@@ -230,7 +230,7 @@ class GitControllerTest < ActionController::TestCase
     assert_select 'a.btn[href=?]', workflow_git_remove_file_path(@workflow, version: @git_version.version, path: 'something')
     assert_select 'a.btn[href=?]', 'https://example.com/something'
     assert_select 'img.git-image-preview[src=?]', workflow_git_raw_path(@workflow, version: @git_version.version, path: 'something'), count: 0
-    assert_select 'span', 'This file is held externally'
+    assert_select 'span.alert-info', 'This file is held externally'
   end
 
   test 'get raw binary file' do


### PR DESCRIPTION
Fixes #2708. 

This simply adds a check that the blob is remote and not fetched, and also not supposed to be embedded. If so, display a message rather than a broken link icon.