### PR TITLE
update 1.19 upgrade tasks

### DIFF
--- a/lib/tasks/seek_upgrades.rake
+++ b/lib/tasks/seek_upgrades.rake
@@ -7,17 +7,7 @@ namespace :seek do
   # these are the tasks required for this version upgrade
   task upgrade_version_tasks: %i[
     environment
-    db:seed:004_model_types
-    db:seed:005_publication_types
-    update_rdf
-    db:seed:018_discipline_vocab
-    strip_publication_abstracts
-    db:seed:015_isa_tags
-    assign_isa_tag_id_to_sample_attributes
-    assign_isa_tag_id_to_template_attributes
-    db:seed:017_minimal_starter_isa_templates
     db:seed:019_sop_type_controlled_vocab
-    db:seed:020_event_types
   ]
 
   # these are the tasks that are executes for each upgrade as standard, and rarely change
@@ -50,68 +40,6 @@ namespace :seek do
     ensure
       Seek::Config.solr_enabled = solr
     end
-  end
-
-  # if rdf repository enabled then generate jobs, otherwise just clear the cache. Only runs once
-  task(update_rdf: [:environment]) do
-    only_once('seek:update_rdf 1.18.0') do
-      if Seek::Rdf::RdfRepository.instance&.configured?
-        puts '... triggering rdf generation jobs'
-        Rake::Task['seek_rdf:generate'].invoke
-      else
-        path = Seek::Config.rdf_filestore_path
-        unless Dir.empty?(path)
-          puts "... clearing rdf cache at #{path}"
-          FileUtils.rm_rf(path, secure: true)
-        end
-      end
-    end
-  end
-
-  task(strip_publication_abstracts: [:environment]) do
-    puts 'Stripping publication abstracts...'
-    updated_count = 0
-    Publication.select(:id, :abstract).find_each do |publication|
-      if publication.abstract.present?
-        stripped = publication.abstract.strip
-        if stripped.length != publication.abstract.length
-          publication.update_column(:abstract, stripped)
-          updated_count += 1
-        end
-      end
-    end
-    puts "... updated #{updated_count} publications"
-  end
-
-  task(assign_isa_tag_id_to_sample_attributes: [:environment]) do
-    puts 'Assigning isa tags to input sample attributes...'
-    updated_count = 0
-    input_isa_tag_id = ISATag.all.detect { |tag| tag.isa_input? }.id
-    SampleAttribute.joins(:sample_type)
-                   .where(isa_tag_id: nil)
-                   .where.not(linked_sample_type_id: nil)
-                   .find_each(batch_size: 1000) do |sa|
-      next unless sa.sample_type.is_isa_json_compliant? && sa.seek_sample_multi?
-
-      sa.update_column(:isa_tag_id, input_isa_tag_id)
-      updated_count += 1
-      puts '.'
-    end
-    puts "... #{updated_count} input sample attributes were updated."
-  end
-
-  task(assign_isa_tag_id_to_template_attributes: [:environment]) do
-    puts 'Assigning isa tags to input template attributes...'
-    input_isa_tag_id = ISATag.all.detect { |tag| tag.isa_input? }.id
-    updated_count = 0
-    TemplateAttribute.where(isa_tag_id: nil).find_each(batch_size: 1000) do |ta|
-      next unless ta.seek_sample_multi?
-
-      ta.update_column(:isa_tag_id, input_isa_tag_id)
-      updated_count += 1
-      puts '.'
-    end
-    puts "... #{updated_count} input template attributes were updated."
   end
 
   private

--- a/lib/tasks/seek_upgrades.rake
+++ b/lib/tasks/seek_upgrades.rake
@@ -42,6 +42,22 @@ namespace :seek do
     end
   end
 
+  # if rdf repository enabled then generate jobs, otherwise just clear the cache. Only runs once
+  task(update_rdf: [:environment]) do
+    only_once('seek:update_rdf 1.18.0') do
+      if Seek::Rdf::RdfRepository.instance&.configured?
+        puts '... triggering rdf generation jobs'
+        Rake::Task['seek_rdf:generate'].invoke
+      else
+        path = Seek::Config.rdf_filestore_path
+        unless Dir.empty?(path)
+          puts "... clearing rdf cache at #{path}"
+          FileUtils.rm_rf(path, secure: true)
+        end
+      end
+    end
+  end
+
   private
 
   ##


### PR DESCRIPTION
cleaned up the upgrade tasks, based on what has changed since v1.18.0. No new tasks have been added for 1.19, but the sop_types seed needs keeping as the seed data changed with 1.18.1. Although unused now, kept the `update_rdf` task as it's needed quite regularly