### PR TITLE
Consistent ordering of roles on the project roles admin page

### DIFF
--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -32,10 +32,6 @@ module ProjectsHelper
     link_list_for_role(t('asset_gatekeeper'), project.asset_gatekeepers)
   end
 
-  def project_coordinators_link_list(project)
-    link_list_for_role('Project coordinator', project.project_coordinators)
-  end
-
   def programme_link(project)
     html = if project.try(:programme).nil?
              "<span class='none_text'>This #{t('project')} is not associated with a #{t('programme')}</span>"

--- a/app/views/projects/admin_member_roles.html.erb
+++ b/app/views/projects/admin_member_roles.html.erb
@@ -16,11 +16,6 @@
         </p>
         <%= form_tag(update_members_project_path(@project)) do %>
             <%= panel('Administrative Roles') do %>
-                <% if admin_logged_in? %>
-                    <label><%= "#{t('pal').pluralize}" %></label>
-                    <%= project_pals_input_box(@project) %>
-                <% end %>
-
                 <%= label_tag("#{t('project_administrator').pluralize}") %>
                 <%= project_administrators_input_box(@project) %>
 
@@ -29,6 +24,11 @@
 
                 <%= label_tag("#{t('asset_gatekeeper').pluralize}") %>
                 <%= project_asset_gatekeepers_input_box(@project) %>
+
+                <% if admin_logged_in? %>
+                    <label><%= "#{t('pal').pluralize}" %></label>
+                    <%= project_pals_input_box(@project) %>
+                <% end %>
             <% end %>
             <%= submit_tag "Confirm changes", :class => 'btn btn-primary' %>
         <% end %>

--- a/app/views/projects/admin_member_roles.html.erb
+++ b/app/views/projects/admin_member_roles.html.erb
@@ -16,19 +16,19 @@
         </p>
         <%= form_tag(update_members_project_path(@project)) do %>
             <%= panel('Administrative Roles') do %>
-                <%= label_tag("#{t('project_administrator').pluralize}") %>
-                <%= project_administrators_input_box(@project) %>
-
-                <%= label_tag("#{t('asset_gatekeeper').pluralize}") %>
-                <%= project_asset_gatekeepers_input_box(@project) %>
-
-                <%= label_tag("#{t('asset_housekeeper').pluralize}") %>
-                <%= project_asset_housekeepers_input_box(@project) %>
-
                 <% if admin_logged_in? %>
                     <label><%= "#{t('pal').pluralize}" %></label>
                     <%= project_pals_input_box(@project) %>
                 <% end %>
+
+                <%= label_tag("#{t('project_administrator').pluralize}") %>
+                <%= project_administrators_input_box(@project) %>
+
+                <%= label_tag("#{t('asset_housekeeper').pluralize}") %>
+                <%= project_asset_housekeepers_input_box(@project) %>
+
+                <%= label_tag("#{t('asset_gatekeeper').pluralize}") %>
+                <%= project_asset_gatekeepers_input_box(@project) %>
             <% end %>
             <%= submit_tag "Confirm changes", :class => 'btn btn-primary' %>
         <% end %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -49,13 +49,6 @@
           </div>
 
           <div class="col-md-6">
-            <% if @project.respond_to?(:project_coordinators) %>
-              <p class="project_coordinators">
-                <strong>Project Coordinators:</strong>
-                <%= project_coordinators_link_list @project %>
-              </p>
-            <% end%>
-
             <% if logged_in_and_registered? %>
               <p class="project_administrators">
                 <strong><%= t('project_administrator').pluralize %>:</strong>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -49,11 +49,6 @@
           </div>
 
           <div class="col-md-6">
-            <p class="pals">
-              <strong><%= Seek::Config.instance_admins_name %> <%= t('pal').pluralize %>:</strong>
-              <%= pals_link_list @project -%>
-            </p>
-
             <% if @project.respond_to?(:project_coordinators) %>
               <p class="project_coordinators">
                 <strong>Project Coordinators:</strong>
@@ -80,6 +75,11 @@
                 <%= gatekeepers_link_list @project %>
               </p>
             <% end %>
+
+            <p class="pals">
+              <strong><%= Seek::Config.instance_admins_name %> <%= t('pal').pluralize %>:</strong>
+              <%= pals_link_list @project -%>
+            </p>
             <p>
               <% if @project.start_date %>
                 <strong><%= t('project') -%> start date:</strong>


### PR DESCRIPTION
Fixes #2727

The roles on the *Administering the project roles* page were listed as Project administrators, Asset gatekeepers, Asset housekeepers, PALs — while the project overview page lists them as PALs, Project administrators, Asset housekeepers, Asset gatekeepers. Having asset gatekeepers and housekeepers swapped between the two views makes it easy to assign someone to the wrong role.

Both views now use the same order, with PALs last as the least relevant of the roles:

1. Project administrators
2. Asset housekeepers
3. Asset gatekeepers
4. PALs

Visibility of each role is unchanged — the PALs field on the admin page is still restricted to site administrators, and on the overview page the housekeepers and gatekeepers are still only shown to members and site administrators.

Also included, as a separate commit, is the removal of the unused project coordinators code that sat alongside these roles on the overview page. Project coordinators came from the `ProjectPosition` model, which was removed in #880; `Project` never defines `project_coordinators`, so the `respond_to?` guard on the show page is always false and the block never renders.
