### PR TITLE
Added a test for publications appearing in the RO-Crate meatadata

### DIFF
--- a/test/integration/workflow_ro_crate_test.rb
+++ b/test/integration/workflow_ro_crate_test.rb
@@ -31,6 +31,22 @@ class WorkflowRoCrateTest < ActionDispatch::IntegrationTest
     assert_equal 'https://spdx.org/licenses/CC-BY-4.0', crate.license, 'Should convert license to full SPDX URI'
   end
 
+  test 'Workflow RO-Crate includes publications' do
+    publication = FactoryBot.create(:publication, title: 'A Book About Stuff')
+    workflow = FactoryBot.create(:generated_galaxy_ro_crate_workflow, publications: [publication], license: 'CC-BY-4.0')
+    zip = workflow.ro_crate_zip
+
+    crate = ROCrate::WorkflowCrateReader.read_zip(zip)
+
+    refute_nil crate.main_workflow.properties['citation']
+    refute_nil crate.main_workflow.properties['citation']['@id']
+
+    included_publication = crate.get(crate.main_workflow.properties['citation']['@id'])
+    refute_nil included_publication
+    assert_equal 'ScholarlyArticle', included_publication['@type']
+    assert_equal 'A Book About Stuff', included_publication['name']
+  end
+
   test 'include remotes in generated Workflow RO-Crate' do
     mock_remote_file "#{Rails.root}/test/fixtures/files/little_file.txt", 'http://internet.internet/file'
 


### PR DESCRIPTION
#1883 was already done in code, but only had unit tests. This is adding a simple check for publications appearing in the metadata of RO-Crates.